### PR TITLE
Fix: Remove possibility to specify entity namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,13 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 
 * Imported [`breerly/factory-girl-php@0e6f1b6`](https://github.com/unhashable/factory-girl-php/tree/0e6f1b6724d39108a2e7cef68a74668b7a77b856), ([#1]), by [@localheinz]
 
+### Changed
+
+* Removed possibility to set the entity namespace on the `FixtureFactory` ([#3]), by [@localheinz]
+
 [fa9c564...master]: https://github.com/ergebnis/factory-bot/compare/fa9c564...master
 
 [#1]: https://github.com/ergebnis/factory-bot/pull/1
+[#3]: https://github.com/ergebnis/factory-bot/pull/3
 
 [@localheinz]: https://github.com/localheinz

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -166,21 +166,6 @@ parameters:
 			path: src/Doctrine/FixtureFactory.php
 
 		-
-			message: "#^Method FactoryGirl\\\\Provider\\\\Doctrine\\\\FixtureFactory\\:\\:setEntityNamespace\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: src/Doctrine/FixtureFactory.php
-
-		-
-			message: "#^Method FactoryGirl\\\\Provider\\\\Doctrine\\\\FixtureFactory\\:\\:setEntityNamespace\\(\\) has parameter \\$namespace with no typehint specified\\.$#"
-			count: 1
-			path: src/Doctrine/FixtureFactory.php
-
-		-
-			message: "#^Method FactoryGirl\\\\Provider\\\\Doctrine\\\\FixtureFactory\\:\\:getEntityNamespace\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: src/Doctrine/FixtureFactory.php
-
-		-
 			message: "#^Method FactoryGirl\\\\Provider\\\\Doctrine\\\\FixtureFactory\\:\\:get\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: src/Doctrine/FixtureFactory.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -125,8 +125,7 @@
     <DocblockTypeContradiction occurrences="1">
       <code>isset($metadata)</code>
     </DocblockTypeContradiction>
-    <MissingParamType occurrences="18">
-      <code>$namespace</code>
+    <MissingParamType occurrences="17">
       <code>$name</code>
       <code>$name</code>
       <code>$numberOfInstances</code>
@@ -145,9 +144,7 @@
       <code>$fieldName</code>
       <code>$value</code>
     </MissingParamType>
-    <MissingReturnType occurrences="12">
-      <code>setEntityNamespace</code>
-      <code>getEntityNamespace</code>
+    <MissingReturnType occurrences="10">
       <code>get</code>
       <code>getList</code>
       <code>checkFieldOverrides</code>
@@ -159,8 +156,7 @@
       <code>unsetSingleton</code>
       <code>updateCollectionSideOfAssocation</code>
     </MissingReturnType>
-    <MixedArgument occurrences="16">
-      <code>$namespace</code>
+    <MixedArgument occurrences="15">
       <code>$name</code>
       <code>$name</code>
       <code>$fieldName</code>
@@ -172,7 +168,7 @@
       <code>$ent</code>
       <code>$fieldName</code>
       <code>$fieldName</code>
-      <code>$name</code>
+      <code>$type</code>
       <code>$value</code>
       <code>$value</code>
       <code>$inverse</code>
@@ -193,12 +189,13 @@
       <code>$this-&gt;entityDefs[$name]</code>
       <code>$this-&gt;entityDefs[$name]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="8">
+    <MixedAssignment occurrences="9">
       <code>$fieldDef</code>
       <code>$fieldValues[$fieldName]</code>
       <code>$fieldValue</code>
       <code>$instances[]</code>
       <code>$this-&gt;persist</code>
+      <code>$type</code>
       <code>$assoc</code>
       <code>$inverse</code>
       <code>$collection</code>
@@ -330,11 +327,6 @@
     </UndefinedMethod>
   </file>
   <file src="test/Doctrine/Fixtures/BasicUsageTest.php">
-    <ArgumentTypeCoercion occurrences="3">
-      <code>'FactoryGirl\Tests\Provider\Doctrine\Fixtures\TestEntity\SpaceShip'</code>
-      <code>'FactoryGirl\Tests\Provider\Doctrine\Fixtures\TestEntity\Person\User'</code>
-      <code>'FactoryGirl\Tests\Provider\Doctrine\Fixtures\TestAnotherEntity\Artist'</code>
-    </ArgumentTypeCoercion>
     <MissingReturnType occurrences="12">
       <code>acceptsConstantValuesInEntityDefinitions</code>
       <code>acceptsGeneratorFunctionsInEntityDefinitions</code>
@@ -350,8 +342,8 @@
       <code>canSpecifyNumberOfReturnedInstances</code>
     </MissingReturnType>
     <MixedArgument occurrences="2">
-      <code>$this-&gt;factory-&gt;getList('SpaceShip')</code>
-      <code>$this-&gt;factory-&gt;getList('SpaceShip', [], 5)</code>
+      <code>$this-&gt;factory-&gt;getList(TestEntity\SpaceShip::class)</code>
+      <code>$this-&gt;factory-&gt;getList(TestEntity\SpaceShip::class, [], 5)</code>
     </MixedArgument>
     <MixedAssignment occurrences="8">
       <code>$ss</code>

--- a/src/Doctrine/FixtureFactory.php
+++ b/src/Doctrine/FixtureFactory.php
@@ -20,11 +20,6 @@ class FixtureFactory
     protected $em;
 
     /**
-     * @var string
-     */
-    protected $entityNamespace;
-
-    /**
      * @var array<EntityDef>
      */
     protected $entityDefs;
@@ -43,26 +38,11 @@ class FixtureFactory
     {
         $this->em = $em;
 
-        $this->entityNamespace = '';
-
         $this->entityDefs = [];
 
         $this->singletons = [];
 
         $this->persist = false;
-    }
-
-    /**
-     * Sets the namespace to be prefixed to all entity names passed to this class.
-     */
-    public function setEntityNamespace($namespace)
-    {
-        $this->entityNamespace = trim($namespace, '\\');
-    }
-
-    public function getEntityNamespace()
-    {
-        return $this->entityNamespace;
     }
 
     /**
@@ -233,7 +213,7 @@ class FixtureFactory
             throw new Exception("Entity '$name' already defined in fixture factory");
         }
 
-        $type = $this->addNamespace($name);
+        $type = $name;
         if (!class_exists($type, true)) {
             throw new Exception("Not a class: $type");
         }
@@ -246,21 +226,6 @@ class FixtureFactory
         $this->entityDefs[$name] = new EntityDef($this->em, $name, $type, $fieldDefs, $config);
 
         return $this;
-    }
-
-    /**
-     * @param  string $name
-     * @return string
-     */
-    protected function addNamespace($name)
-    {
-        $name = rtrim($name, '\\');
-
-        if ($name[0] === '\\') {
-            return $name;
-        }
-
-        return $this->entityNamespace . '\\' . $name;
     }
 
     protected function updateCollectionSideOfAssocation($entityBeingCreated, $metadata, $fieldName, $value)

--- a/test/Doctrine/Fixtures/BasicUsageTest.php
+++ b/test/Doctrine/Fixtures/BasicUsageTest.php
@@ -12,10 +12,10 @@ class BasicUsageTest extends TestCase
     public function acceptsConstantValuesInEntityDefinitions()
     {
         $ss = $this->factory
-            ->defineEntity('SpaceShip', [
+            ->defineEntity(TestEntity\SpaceShip::class, [
                 'name' => 'My BattleCruiser'
             ])
-            ->get('SpaceShip');
+            ->get(TestEntity\SpaceShip::class);
 
         $this->assertSame('My BattleCruiser', $ss->getName());
     }
@@ -26,15 +26,15 @@ class BasicUsageTest extends TestCase
     public function acceptsGeneratorFunctionsInEntityDefinitions()
     {
         $name = "Star";
-        $this->factory->defineEntity('SpaceShip', [
+        $this->factory->defineEntity(TestEntity\SpaceShip::class, [
             'name' => function () use (&$name) {
                 return "M/S $name";
             }
         ]);
 
-        $this->assertSame('M/S Star', $this->factory->get('SpaceShip')->getName());
+        $this->assertSame('M/S Star', $this->factory->get(TestEntity\SpaceShip::class)->getName());
         $name = "Superstar";
-        $this->assertSame('M/S Superstar', $this->factory->get('SpaceShip')->getName());
+        $this->assertSame('M/S Superstar', $this->factory->get(TestEntity\SpaceShip::class)->getName());
     }
 
     /**
@@ -43,10 +43,10 @@ class BasicUsageTest extends TestCase
     public function valuesCanBeOverriddenAtCreationTime()
     {
         $ss = $this->factory
-            ->defineEntity('SpaceShip', [
+            ->defineEntity(TestEntity\SpaceShip::class, [
                 'name' => 'My BattleCruiser'
             ])
-            ->get('SpaceShip', ['name' => 'My CattleBruiser']);
+            ->get(TestEntity\SpaceShip::class, ['name' => 'My CattleBruiser']);
         $this->assertSame('My CattleBruiser', $ss->getName());
     }
 
@@ -56,8 +56,8 @@ class BasicUsageTest extends TestCase
     public function preservesDefaultValuesOfEntity()
     {
         $ss = $this->factory
-            ->defineEntity('SpaceStation')
-            ->get('SpaceStation');
+            ->defineEntity(TestEntity\SpaceStation::class)
+            ->get(TestEntity\SpaceStation::class);
         $this->assertSame('Babylon5', $ss->getName());
     }
 
@@ -67,8 +67,8 @@ class BasicUsageTest extends TestCase
     public function doesNotCallTheConstructorOfTheEntity()
     {
         $ss = $this->factory
-            ->defineEntity('SpaceShip', [])
-            ->get('SpaceShip');
+            ->defineEntity(TestEntity\SpaceShip::class, [])
+            ->get(TestEntity\SpaceShip::class);
         $this->assertFalse($ss->constructorWasCalled());
     }
 
@@ -78,10 +78,10 @@ class BasicUsageTest extends TestCase
     public function instantiatesCollectionAssociationsToBeEmptyCollectionsWhenUnspecified()
     {
         $ss = $this->factory
-            ->defineEntity('SpaceShip', [
+            ->defineEntity(TestEntity\SpaceShip::class, [
                 'name' => 'Battlestar Galaxy'
             ])
-            ->get('SpaceShip');
+            ->get(TestEntity\SpaceShip::class);
 
         $this->assertInstanceOf(ArrayCollection::class, $ss->getCrew());
         $this->assertEmpty($ss->getCrew());
@@ -92,15 +92,15 @@ class BasicUsageTest extends TestCase
      */
     public function arrayElementsAreMappedToCollectionAsscociationFields()
     {
-        $this->factory->defineEntity('SpaceShip');
-        $this->factory->defineEntity('Person', [
-            'spaceShip' => FieldDef::reference('SpaceShip')
+        $this->factory->defineEntity(TestEntity\SpaceShip::class);
+        $this->factory->defineEntity(TestEntity\Person::class, [
+            'spaceShip' => FieldDef::reference(TestEntity\SpaceShip::class)
         ]);
 
-        $p1 = $this->factory->get('Person');
-        $p2 = $this->factory->get('Person');
+        $p1 = $this->factory->get(TestEntity\Person::class);
+        $p2 = $this->factory->get(TestEntity\Person::class);
 
-        $ship = $this->factory->get('SpaceShip', [
+        $ship = $this->factory->get(TestEntity\SpaceShip::class, [
             'name' => 'Battlestar Galaxy',
             'crew' => [$p1, $p2]
         ]);
@@ -115,8 +115,8 @@ class BasicUsageTest extends TestCase
      */
     public function unspecifiedFieldsAreLeftNull()
     {
-        $this->factory->defineEntity('SpaceShip');
-        $this->assertNull($this->factory->get('SpaceShip')->getName());
+        $this->factory->defineEntity(TestEntity\SpaceShip::class);
+        $this->assertNull($this->factory->get(TestEntity\SpaceShip::class)->getName());
     }
 
     /**
@@ -124,17 +124,17 @@ class BasicUsageTest extends TestCase
      */
     public function entityIsDefinedToDefaultNamespace()
     {
-        $this->factory->defineEntity('SpaceShip');
-        $this->factory->defineEntity('Person\User');
+        $this->factory->defineEntity(TestEntity\SpaceShip::class);
+        $this->factory->defineEntity(TestEntity\Person\User::class);
 
         $this->assertInstanceOf(
-            'FactoryGirl\Tests\Provider\Doctrine\Fixtures\TestEntity\SpaceShip',
-            $this->factory->get('SpaceShip')
+            TestEntity\SpaceShip::class,
+            $this->factory->get(TestEntity\SpaceShip::class)
         );
 
         $this->assertInstanceOf(
-            'FactoryGirl\Tests\Provider\Doctrine\Fixtures\TestEntity\Person\User',
-            $this->factory->get('Person\User')
+            TestEntity\Person\User::class,
+            $this->factory->get(TestEntity\Person\User::class)
         );
     }
 
@@ -144,13 +144,13 @@ class BasicUsageTest extends TestCase
     public function entityCanBeDefinedToAnotherNamespace()
     {
         $this->factory->defineEntity(
-            '\FactoryGirl\Tests\Provider\Doctrine\Fixtures\TestAnotherEntity\Artist'
+            TestAnotherEntity\Artist::class
         );
 
         $this->assertInstanceOf(
-            'FactoryGirl\Tests\Provider\Doctrine\Fixtures\TestAnotherEntity\Artist',
+            TestAnotherEntity\Artist::class,
             $this->factory->get(
-                '\FactoryGirl\Tests\Provider\Doctrine\Fixtures\TestAnotherEntity\Artist'
+                TestAnotherEntity\Artist::class
             )
         );
     }
@@ -160,9 +160,9 @@ class BasicUsageTest extends TestCase
      */
     public function returnsListOfEntities()
     {
-        $this->factory->defineEntity('SpaceShip');
+        $this->factory->defineEntity(TestEntity\SpaceShip::class);
 
-        $this->assertCount(1, $this->factory->getList('SpaceShip'));
+        $this->assertCount(1, $this->factory->getList(TestEntity\SpaceShip::class));
     }
 
     /**
@@ -170,8 +170,8 @@ class BasicUsageTest extends TestCase
      */
     public function canSpecifyNumberOfReturnedInstances()
     {
-        $this->factory->defineEntity('SpaceShip');
+        $this->factory->defineEntity(TestEntity\SpaceShip::class);
 
-        $this->assertCount(5, $this->factory->getList('SpaceShip', [], 5));
+        $this->assertCount(5, $this->factory->getList(TestEntity\SpaceShip::class, [], 5));
     }
 }

--- a/test/Doctrine/Fixtures/BidirectionalReferencesTest.php
+++ b/test/Doctrine/Fixtures/BidirectionalReferencesTest.php
@@ -10,12 +10,12 @@ class BidirectionalReferencesTest extends TestCase
      */
     public function bidirectionalOntToManyReferencesAreAssignedBothWays()
     {
-        $this->factory->defineEntity('SpaceShip');
-        $this->factory->defineEntity('Person', [
-            'spaceShip' => FieldDef::reference('SpaceShip')
+        $this->factory->defineEntity(TestEntity\SpaceShip::class);
+        $this->factory->defineEntity(TestEntity\Person::class, [
+            'spaceShip' => FieldDef::reference(TestEntity\SpaceShip::class)
         ]);
 
-        $person = $this->factory->get('Person');
+        $person = $this->factory->get(TestEntity\Person::class);
         $ship = $person->getSpaceShip();
 
         $this->assertContains($person, $ship->getCrew());
@@ -26,12 +26,12 @@ class BidirectionalReferencesTest extends TestCase
      */
     public function unidirectionalReferencesWorkAsUsual()
     {
-        $this->factory->defineEntity('Badge', [
-            'owner' => FieldDef::reference('Person')
+        $this->factory->defineEntity(TestEntity\Badge::class, [
+            'owner' => FieldDef::reference(TestEntity\Person::class)
         ]);
-        $this->factory->defineEntity('Person');
+        $this->factory->defineEntity(TestEntity\Person::class);
 
-        $this->assertInstanceOf(TestEntity\Person::class, $this->factory->get('Badge')->getOwner());
+        $this->assertInstanceOf(TestEntity\Person::class, $this->factory->get(TestEntity\Badge::class)->getOwner());
     }
 
     /**
@@ -39,14 +39,14 @@ class BidirectionalReferencesTest extends TestCase
      */
     public function whenTheOneSideIsASingletonItMayGetSeveralChildObjects()
     {
-        $this->factory->defineEntity('SpaceShip');
-        $this->factory->defineEntity('Person', [
-            'spaceShip' => FieldDef::reference('SpaceShip')
+        $this->factory->defineEntity(TestEntity\SpaceShip::class);
+        $this->factory->defineEntity(TestEntity\Person::class, [
+            'spaceShip' => FieldDef::reference(TestEntity\SpaceShip::class)
         ]);
 
-        $ship = $this->factory->getAsSingleton('SpaceShip');
-        $p1 = $this->factory->get('Person');
-        $p2 = $this->factory->get('Person');
+        $ship = $this->factory->getAsSingleton(TestEntity\SpaceShip::class);
+        $p1 = $this->factory->get(TestEntity\Person::class);
+        $p2 = $this->factory->get(TestEntity\Person::class);
 
         $this->assertContains($p1, $ship->getCrew());
         $this->assertContains($p2, $ship->getCrew());

--- a/test/Doctrine/Fixtures/ExtraConfigurationTest.php
+++ b/test/Doctrine/Fixtures/ExtraConfigurationTest.php
@@ -8,14 +8,14 @@ class ExtraConfigurationTest extends TestCase
      */
     public function canInvokeACallbackAfterObjectConstruction()
     {
-        $this->factory->defineEntity('SpaceShip', [
+        $this->factory->defineEntity(TestEntity\SpaceShip::class, [
             'name' => 'Foo'
         ], [
             'afterCreate' => function (TestEntity\SpaceShip $ss, array $fieldValues) {
                 $ss->setName($ss->getName() . '-' . $fieldValues['name']);
             }
         ]);
-        $ss = $this->factory->get('SpaceShip');
+        $ss = $this->factory->get(TestEntity\SpaceShip::class);
 
         $this->assertSame("Foo-Foo", $ss->getName());
     }
@@ -25,14 +25,14 @@ class ExtraConfigurationTest extends TestCase
      */
     public function theAfterCreateCallbackCanBeUsedToCallTheConstructor()
     {
-        $this->factory->defineEntity('SpaceShip', [
+        $this->factory->defineEntity(TestEntity\SpaceShip::class, [
             'name' => 'Foo'
         ], [
             'afterCreate' => function (TestEntity\SpaceShip $ss, array $fieldValues) {
                 $ss->__construct($fieldValues['name'] . 'Master');
             }
         ]);
-        $ss = $this->factory->get('SpaceShip', ['name' => 'Xoo']);
+        $ss = $this->factory->get(TestEntity\SpaceShip::class, ['name' => 'Xoo']);
 
         $this->assertTrue($ss->constructorWasCalled());
         $this->assertSame('XooMaster', $ss->getName());

--- a/test/Doctrine/Fixtures/IncorrectUsageTest.php
+++ b/test/Doctrine/Fixtures/IncorrectUsageTest.php
@@ -8,11 +8,11 @@ class IncorrectUsageTest extends TestCase
      */
     public function throwsWhenTryingToDefineTheSameEntityTwice()
     {
-        $factory = $this->factory->defineEntity('SpaceShip');
+        $factory = $this->factory->defineEntity(TestEntity\SpaceShip::class);
 
         $this->expectException(\Exception::class);
 
-        $factory->defineEntity('SpaceShip');
+        $factory->defineEntity(TestEntity\SpaceShip::class);
     }
 
     /**
@@ -34,7 +34,7 @@ class IncorrectUsageTest extends TestCase
 
         $this->expectException(\Exception::class);
 
-        $this->factory->defineEntity('NotAnEntity');
+        $this->factory->defineEntity(TestEntity\NotAnEntity::class);
     }
 
     /**
@@ -44,7 +44,7 @@ class IncorrectUsageTest extends TestCase
     {
         $this->expectException(\Exception::class);
 
-        $this->factory->defineEntity('SpaceShip', [
+        $this->factory->defineEntity(TestEntity\SpaceShip::class, [
             'pieType' => 'blueberry'
         ]);
     }
@@ -54,11 +54,11 @@ class IncorrectUsageTest extends TestCase
      */
     public function throwsWhenTryingToGiveNonexistentFieldsWhileConstructing()
     {
-        $this->factory->defineEntity('SpaceShip', ['name' => 'Alpha']);
+        $this->factory->defineEntity(TestEntity\SpaceShip::class, ['name' => 'Alpha']);
 
         $this->expectException(\Exception::class);
 
-        $this->factory->get('SpaceShip', [
+        $this->factory->get(TestEntity\SpaceShip::class, [
             'pieType' => 'blueberry'
         ]);
     }
@@ -68,10 +68,10 @@ class IncorrectUsageTest extends TestCase
      */
     public function throwsWhenTryingToGetLessThanOneInstance()
     {
-        $this->factory->defineEntity('SpaceShip');
+        $this->factory->defineEntity(TestEntity\SpaceShip::class);
 
         $this->expectException(\Exception::class);
 
-        $this->factory->getList('SpaceShip', [], 0);
+        $this->factory->getList(TestEntity\SpaceShip::class, [], 0);
     }
 }

--- a/test/Doctrine/Fixtures/PersistingTest.php
+++ b/test/Doctrine/Fixtures/PersistingTest.php
@@ -11,10 +11,10 @@ class PersistingTest extends TestCase
      */
     public function automaticPersistCanBeTurnedOn()
     {
-        $this->factory->defineEntity('SpaceShip', ['name' => 'Zeta']);
+        $this->factory->defineEntity(TestEntity\SpaceShip::class, ['name' => 'Zeta']);
 
         $this->factory->persistOnGet();
-        $ss = $this->factory->get('SpaceShip');
+        $ss = $this->factory->get(TestEntity\SpaceShip::class);
         $this->em->flush();
 
         $this->assertNotNull($ss->getId());
@@ -26,8 +26,8 @@ class PersistingTest extends TestCase
      */
     public function doesNotPersistByDefault()
     {
-        $this->factory->defineEntity('SpaceShip', ['name' => 'Zeta']);
-        $ss = $this->factory->get('SpaceShip');
+        $this->factory->defineEntity(TestEntity\SpaceShip::class, ['name' => 'Zeta']);
+        $ss = $this->factory->get(TestEntity\SpaceShip::class);
         $this->em->flush();
 
         $this->assertNull($ss->getId());
@@ -55,7 +55,7 @@ class PersistingTest extends TestCase
             }
         }
 
-        $this->factory->defineEntity('Name', [
+        $this->factory->defineEntity(TestEntity\Name::class, [
             'first' => FieldDef::sequence(static function () {
                 $values = [
                     null,
@@ -76,14 +76,14 @@ class PersistingTest extends TestCase
             }),
         ]);
 
-        $this->factory->defineEntity('Commander', [
-            'name' => FieldDef::reference('Name'),
+        $this->factory->defineEntity(TestEntity\Commander::class, [
+            'name' => FieldDef::reference(TestEntity\Name::class),
         ]);
 
         $this->factory->persistOnGet();
 
         /** @var TestEntity\Commander $commander */
-        $commander = $this->factory->get('Commander');
+        $commander = $this->factory->get(TestEntity\Commander::class);
 
         $this->assertInstanceOf(TestEntity\Commander::class, $commander);
         $this->assertInstanceOf(TestEntity\Name::class, $commander->name());

--- a/test/Doctrine/Fixtures/ReferenceTest.php
+++ b/test/Doctrine/Fixtures/ReferenceTest.php
@@ -9,10 +9,10 @@ class ReferenceTest extends TestCase
     {
         parent::setUp();
 
-        $this->factory->defineEntity('SpaceShip');
-        $this->factory->defineEntity('Person', [
+        $this->factory->defineEntity(TestEntity\SpaceShip::class);
+        $this->factory->defineEntity(TestEntity\Person::class, [
             'name' => 'Eve',
-            'spaceShip' => FieldDef::reference('SpaceShip')
+            'spaceShip' => FieldDef::reference(TestEntity\SpaceShip::class)
         ]);
     }
 
@@ -21,8 +21,8 @@ class ReferenceTest extends TestCase
      */
     public function referencedObjectShouldBeCreatedAutomatically()
     {
-        $ss1 = $this->factory->get('Person')->getSpaceShip();
-        $ss2 = $this->factory->get('Person')->getSpaceShip();
+        $ss1 = $this->factory->get(TestEntity\Person::class)->getSpaceShip();
+        $ss2 = $this->factory->get(TestEntity\Person::class)->getSpaceShip();
 
         $this->assertNotNull($ss1);
         $this->assertNotNull($ss2);
@@ -34,7 +34,7 @@ class ReferenceTest extends TestCase
      */
     public function referencedObjectsShouldBeNullable()
     {
-        $person = $this->factory->get('Person', ['spaceShip' => null]);
+        $person = $this->factory->get(TestEntity\Person::class, ['spaceShip' => null]);
 
         $this->assertNull($person->getSpaceShip());
     }

--- a/test/Doctrine/Fixtures/ReferencesTest.php
+++ b/test/Doctrine/Fixtures/ReferencesTest.php
@@ -11,11 +11,11 @@ class ReferencesTest extends TestCase
     {
         parent::setUp();
 
-        $this->factory->defineEntity('SpaceShip', [
-            'crew' => FieldDef::references('Person')
+        $this->factory->defineEntity(TestEntity\SpaceShip::class, [
+            'crew' => FieldDef::references(TestEntity\Person::class)
         ]);
 
-        $this->factory->defineEntity('Person', [
+        $this->factory->defineEntity(TestEntity\Person::class, [
             'name' => 'Eve',
         ]);
     }
@@ -26,7 +26,7 @@ class ReferencesTest extends TestCase
     public function referencedObjectsShouldBeCreatedAutomatically()
     {
         /** @var TestEntity\SpaceShip $spaceShip */
-        $spaceShip = $this->factory->get('SpaceShip');
+        $spaceShip = $this->factory->get(TestEntity\SpaceShip::class);
 
         $crew = $spaceShip->getCrew();
 
@@ -43,8 +43,8 @@ class ReferencesTest extends TestCase
         $count = 5;
 
         /** @var TestEntity\SpaceShip $spaceShip */
-        $spaceShip = $this->factory->get('SpaceShip', [
-            'crew' => $this->factory->getList('Person', [], $count),
+        $spaceShip = $this->factory->get(TestEntity\SpaceShip::class, [
+            'crew' => $this->factory->getList(TestEntity\Person::class, [], $count),
         ]);
 
         $crew = $spaceShip->getCrew();
@@ -60,7 +60,7 @@ class ReferencesTest extends TestCase
     public function referencedObjectsShouldBeNullable()
     {
         /** @var TestEntity\SpaceShip $spaceShip */
-        $spaceShip = $this->factory->get('SpaceShip', [
+        $spaceShip = $this->factory->get(TestEntity\SpaceShip::class, [
             'crew' => null,
         ]);
 
@@ -76,10 +76,10 @@ class ReferencesTest extends TestCase
     public function referencedObjectsCanBeSingletons()
     {
         /** @var TestEntity\Person $person*/
-        $person = $this->factory->getAsSingleton('Person');
+        $person = $this->factory->getAsSingleton(TestEntity\Person::class);
 
         /** @var TestEntity\SpaceShip $spaceShip */
-        $spaceShip = $this->factory->get('SpaceShip');
+        $spaceShip = $this->factory->get(TestEntity\SpaceShip::class);
 
         $crew = $spaceShip->getCrew();
 

--- a/test/Doctrine/Fixtures/SequenceTest.php
+++ b/test/Doctrine/Fixtures/SequenceTest.php
@@ -11,15 +11,15 @@ class SequenceTest extends TestCase
      */
     public function sequenceGeneratorCallsAFunctionWithAnIncrementingArgument()
     {
-        $this->factory->defineEntity('SpaceShip', [
+        $this->factory->defineEntity(TestEntity\SpaceShip::class, [
             'name' => FieldDef::sequence(function ($n) {
                 return "Alpha $n";
             })
         ]);
-        $this->assertSame('Alpha 1', $this->factory->get('SpaceShip')->getName());
-        $this->assertSame('Alpha 2', $this->factory->get('SpaceShip')->getName());
-        $this->assertSame('Alpha 3', $this->factory->get('SpaceShip')->getName());
-        $this->assertSame('Alpha 4', $this->factory->get('SpaceShip')->getName());
+        $this->assertSame('Alpha 1', $this->factory->get(TestEntity\SpaceShip::class)->getName());
+        $this->assertSame('Alpha 2', $this->factory->get(TestEntity\SpaceShip::class)->getName());
+        $this->assertSame('Alpha 3', $this->factory->get(TestEntity\SpaceShip::class)->getName());
+        $this->assertSame('Alpha 4', $this->factory->get(TestEntity\SpaceShip::class)->getName());
     }
 
     /**
@@ -27,13 +27,13 @@ class SequenceTest extends TestCase
      */
     public function sequenceGeneratorCanTakeAPlaceholderString()
     {
-        $this->factory->defineEntity('SpaceShip', [
+        $this->factory->defineEntity(TestEntity\SpaceShip::class, [
             'name' => FieldDef::sequence("Beta %d")
         ]);
-        $this->assertSame('Beta 1', $this->factory->get('SpaceShip')->getName());
-        $this->assertSame('Beta 2', $this->factory->get('SpaceShip')->getName());
-        $this->assertSame('Beta 3', $this->factory->get('SpaceShip')->getName());
-        $this->assertSame('Beta 4', $this->factory->get('SpaceShip')->getName());
+        $this->assertSame('Beta 1', $this->factory->get(TestEntity\SpaceShip::class)->getName());
+        $this->assertSame('Beta 2', $this->factory->get(TestEntity\SpaceShip::class)->getName());
+        $this->assertSame('Beta 3', $this->factory->get(TestEntity\SpaceShip::class)->getName());
+        $this->assertSame('Beta 4', $this->factory->get(TestEntity\SpaceShip::class)->getName());
     }
 
     /**
@@ -41,12 +41,12 @@ class SequenceTest extends TestCase
      */
     public function sequenceGeneratorCanTakeAStringToAppendTo()
     {
-        $this->factory->defineEntity('SpaceShip', [
+        $this->factory->defineEntity(TestEntity\SpaceShip::class, [
             'name' => FieldDef::sequence("Gamma ")
         ]);
-        $this->assertSame('Gamma 1', $this->factory->get('SpaceShip')->getName());
-        $this->assertSame('Gamma 2', $this->factory->get('SpaceShip')->getName());
-        $this->assertSame('Gamma 3', $this->factory->get('SpaceShip')->getName());
-        $this->assertSame('Gamma 4', $this->factory->get('SpaceShip')->getName());
+        $this->assertSame('Gamma 1', $this->factory->get(TestEntity\SpaceShip::class)->getName());
+        $this->assertSame('Gamma 2', $this->factory->get(TestEntity\SpaceShip::class)->getName());
+        $this->assertSame('Gamma 3', $this->factory->get(TestEntity\SpaceShip::class)->getName());
+        $this->assertSame('Gamma 4', $this->factory->get(TestEntity\SpaceShip::class)->getName());
     }
 }

--- a/test/Doctrine/Fixtures/SingletonTest.php
+++ b/test/Doctrine/Fixtures/SingletonTest.php
@@ -8,12 +8,12 @@ class SingletonTest extends TestCase
      */
     public function afterGettingAnEntityAsASingletonGettingTheEntityAgainReturnsTheSameObject()
     {
-        $this->factory->defineEntity('SpaceShip');
+        $this->factory->defineEntity(TestEntity\SpaceShip::class);
 
-        $ss = $this->factory->getAsSingleton('SpaceShip');
+        $ss = $this->factory->getAsSingleton(TestEntity\SpaceShip::class);
 
-        $this->assertSame($ss, $this->factory->get('SpaceShip'));
-        $this->assertSame($ss, $this->factory->get('SpaceShip'));
+        $this->assertSame($ss, $this->factory->get(TestEntity\SpaceShip::class));
+        $this->assertSame($ss, $this->factory->get(TestEntity\SpaceShip::class));
     }
 
     /**
@@ -21,11 +21,11 @@ class SingletonTest extends TestCase
      */
     public function getAsSingletonMethodAcceptsFieldOverridesLikeGet()
     {
-        $this->factory->defineEntity('SpaceShip');
+        $this->factory->defineEntity(TestEntity\SpaceShip::class);
 
-        $ss = $this->factory->getAsSingleton('SpaceShip', ['name' => 'Beta']);
+        $ss = $this->factory->getAsSingleton(TestEntity\SpaceShip::class, ['name' => 'Beta']);
         $this->assertSame('Beta', $ss->getName());
-        $this->assertSame('Beta', $this->factory->get('SpaceShip')->getName());
+        $this->assertSame('Beta', $this->factory->get(TestEntity\SpaceShip::class)->getName());
     }
 
     /**
@@ -33,12 +33,12 @@ class SingletonTest extends TestCase
      */
     public function throwsAnErrorWhenCallingGetSingletonTwiceOnTheSameEntity()
     {
-        $this->factory->defineEntity('SpaceShip', ['name' => 'Alpha']);
-        $this->factory->getAsSingleton('SpaceShip');
+        $this->factory->defineEntity(TestEntity\SpaceShip::class, ['name' => 'Alpha']);
+        $this->factory->getAsSingleton(TestEntity\SpaceShip::class);
 
         $this->expectException(\Exception::class);
 
-        $this->factory->getAsSingleton('SpaceShip');
+        $this->factory->getAsSingleton(TestEntity\SpaceShip::class);
     }
 
     //TODO: should it be an error to get() a singleton with overrides?
@@ -48,12 +48,12 @@ class SingletonTest extends TestCase
      */
     public function allowsSettingSingletons()
     {
-        $this->factory->defineEntity('SpaceShip');
+        $this->factory->defineEntity(TestEntity\SpaceShip::class);
         $ss = new TestEntity\SpaceShip("The mothership");
 
-        $this->factory->setSingleton('SpaceShip', $ss);
+        $this->factory->setSingleton(TestEntity\SpaceShip::class, $ss);
 
-        $this->assertSame($ss, $this->factory->get('SpaceShip'));
+        $this->assertSame($ss, $this->factory->get(TestEntity\SpaceShip::class));
     }
 
     /**
@@ -61,13 +61,13 @@ class SingletonTest extends TestCase
      */
     public function allowsUnsettingSingletons()
     {
-        $this->factory->defineEntity('SpaceShip');
+        $this->factory->defineEntity(TestEntity\SpaceShip::class);
         $ss = new TestEntity\SpaceShip("The mothership");
 
-        $this->factory->setSingleton('SpaceShip', $ss);
-        $this->factory->unsetSingleton('SpaceShip');
+        $this->factory->setSingleton(TestEntity\SpaceShip::class, $ss);
+        $this->factory->unsetSingleton(TestEntity\SpaceShip::class);
 
-        $this->assertNotSame($ss, $this->factory->get('SpaceShip'));
+        $this->assertNotSame($ss, $this->factory->get(TestEntity\SpaceShip::class));
     }
 
     /**
@@ -75,13 +75,13 @@ class SingletonTest extends TestCase
      */
     public function allowsOverwritingExistingSingletons()
     {
-        $this->factory->defineEntity('SpaceShip');
+        $this->factory->defineEntity(TestEntity\SpaceShip::class);
         $ss1 = new TestEntity\SpaceShip("The mothership");
         $ss2 = new TestEntity\SpaceShip("The battlecruiser");
 
-        $this->factory->setSingleton('SpaceShip', $ss1);
-        $this->factory->setSingleton('SpaceShip', $ss2);
+        $this->factory->setSingleton(TestEntity\SpaceShip::class, $ss1);
+        $this->factory->setSingleton(TestEntity\SpaceShip::class, $ss2);
 
-        $this->assertSame($ss2, $this->factory->get('SpaceShip'));
+        $this->assertSame($ss2, $this->factory->get(TestEntity\SpaceShip::class));
     }
 }

--- a/test/Doctrine/Fixtures/TestCase.php
+++ b/test/Doctrine/Fixtures/TestCase.php
@@ -42,6 +42,5 @@ abstract class TestCase extends Framework\TestCase
         $this->em = $this->testDb->createEntityManager();
 
         $this->factory = new FixtureFactory($this->em);
-        $this->factory->setEntityNamespace('FactoryGirl\Tests\Provider\Doctrine\Fixtures\TestEntity');
     }
 }

--- a/test/Doctrine/Fixtures/TransitiveReferencesTest.php
+++ b/test/Doctrine/Fixtures/TransitiveReferencesTest.php
@@ -8,13 +8,13 @@ class TransitiveReferencesTest extends TestCase
 {
     private function simpleSetup()
     {
-        $this->factory->defineEntity('Person', [
-            'spaceShip' => FieldDef::reference('SpaceShip'),
+        $this->factory->defineEntity(TestEntity\Person::class, [
+            'spaceShip' => FieldDef::reference(TestEntity\SpaceShip::class),
         ]);
-        $this->factory->defineEntity('Badge', [
-            'owner' => FieldDef::reference('Person')
+        $this->factory->defineEntity(TestEntity\Badge::class, [
+            'owner' => FieldDef::reference(TestEntity\Person::class)
         ]);
-        $this->factory->defineEntity('SpaceShip');
+        $this->factory->defineEntity(TestEntity\SpaceShip::class);
     }
 
     /**
@@ -24,7 +24,7 @@ class TransitiveReferencesTest extends TestCase
     {
         $this->simpleSetup();
 
-        $badge = $this->factory->get('Badge');
+        $badge = $this->factory->get(TestEntity\Badge::class);
 
         $this->assertNotNull($badge->getOwner()->getSpaceShip());
     }
@@ -36,9 +36,9 @@ class TransitiveReferencesTest extends TestCase
     {
         $this->simpleSetup();
 
-        $this->factory->getAsSingleton('SpaceShip');
-        $badge1 = $this->factory->get('Badge');
-        $badge2 = $this->factory->get('Badge');
+        $this->factory->getAsSingleton(TestEntity\SpaceShip::class);
+        $badge1 = $this->factory->get(TestEntity\Badge::class);
+        $badge2 = $this->factory->get(TestEntity\Badge::class);
 
         $this->assertNotSame($badge1->getOwner(), $badge2->getOwner());
         $this->assertSame($badge1->getOwner()->getSpaceShip(), $badge2->getOwner()->getSpaceShip());


### PR DESCRIPTION
This PR

* [x] removes the possibility to set an entity namespace on the `FixtureFactory`

💁‍♂ This should not be necessary since PHP 5.5 and the introduction of the `class` keyword, see https://www.php.net/manual/en/language.oop5.basic.php#language.oop5.basic.class.class.