### PR TITLE
Fix: Use class-map autoloading for imported classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,15 +51,19 @@
   },
   "autoload": {
     "psr-4": {
-      "Ergebnis\\FactoryBot\\": "src/",
-      "FactoryGirl\\Provider\\Doctrine\\": "src/Doctrine/"
-    }
+      "Ergebnis\\FactoryBot\\": "src/"
+    },
+    "classmap": [
+      "src/Doctrine/"
+    ]
   },
   "autoload-dev": {
     "psr-4": {
-      "Ergebnis\\FactoryBot\\Test\\": "test/",
-      "FactoryGirl\\Tests\\Provider\\Doctrine\\": "test/Doctrine/"
-    }
+      "Ergebnis\\FactoryBot\\Test\\": "test/"
+    },
+    "classmap": [
+      "test/Doctrine/"
+    ]
   },
   "support": {
     "issues": "https://github.com/ergebnis/factory-bot/issues",


### PR DESCRIPTION
This PR

* [x] uses class-map autoloading for previously imported classes

Follows #1.