### PR TITLE
Fix: Use class keyword

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -459,28 +459,15 @@
     </MixedMethodCall>
   </file>
   <file src="test/Doctrine/Fixtures/ReferencesTest.php">
-    <ArgumentTypeCoercion occurrences="4">
-      <code>'Doctrine\Common\Collections\ArrayCollection'</code>
-      <code>'Doctrine\Common\Collections\ArrayCollection'</code>
-      <code>'Doctrine\Common\Collections\ArrayCollection'</code>
-      <code>'Doctrine\Common\Collections\ArrayCollection'</code>
-    </ArgumentTypeCoercion>
+    <DocblockTypeContradiction occurrences="1">
+      <code>assertEmpty</code>
+    </DocblockTypeContradiction>
     <MissingReturnType occurrences="4">
       <code>referencedObjectsShouldBeCreatedAutomatically</code>
       <code>referencedObjectsShouldBeOverrideable</code>
       <code>referencedObjectsShouldBeNullable</code>
       <code>referencedObjectsCanBeSingletons</code>
     </MissingReturnType>
-    <MixedArgument occurrences="3">
-      <code>$crew</code>
-      <code>$crew</code>
-      <code>$crew</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="3">
-      <code>$crew</code>
-      <code>$crew</code>
-      <code>$crew</code>
-    </MixedAssignment>
   </file>
   <file src="test/Doctrine/Fixtures/SequenceTest.php">
     <MissingClosureParamType occurrences="1">
@@ -617,9 +604,6 @@
     </MixedInferredReturnType>
   </file>
   <file src="test/Doctrine/ORM/RepositoryTest.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>'FactoryGirl\Tests\Provider\Doctrine\ORM\TestEntity\User'</code>
-    </ArgumentTypeCoercion>
     <MissingPropertyType occurrences="1">
       <code>$user-&gt;id</code>
     </MissingPropertyType>
@@ -637,9 +621,6 @@
     </MissingReturnType>
   </file>
   <file src="test/Doctrine/Types/StatusArrayTest.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>'\Doctrine\DBAL\Platforms\AbstractPlatform'</code>
-    </ArgumentTypeCoercion>
     <MissingParamType occurrences="5">
       <code>$stupidValue</code>
       <code>$expectedSerialization</code>

--- a/test/Doctrine/Fixtures/IncorrectUsageTest.php
+++ b/test/Doctrine/Fixtures/IncorrectUsageTest.php
@@ -30,7 +30,7 @@ class IncorrectUsageTest extends TestCase
      */
     public function throwsWhenTryingToDefineEntitiesThatAreNotEntities()
     {
-        $this->assertTrue(class_exists('FactoryGirl\Tests\Provider\Doctrine\Fixtures\TestEntity\NotAnEntity', true));
+        $this->assertTrue(class_exists(TestEntity\NotAnEntity::class, true));
 
         $this->expectException(\Exception::class);
 

--- a/test/Doctrine/Fixtures/PersistingTest.php
+++ b/test/Doctrine/Fixtures/PersistingTest.php
@@ -18,7 +18,7 @@ class PersistingTest extends TestCase
         $this->em->flush();
 
         $this->assertNotNull($ss->getId());
-        $this->assertSame($ss, $this->em->find('FactoryGirl\Tests\Provider\Doctrine\Fixtures\TestEntity\SpaceShip', $ss->getId()));
+        $this->assertSame($ss, $this->em->find(TestEntity\SpaceShip::class, $ss->getId()));
     }
 
     /**

--- a/test/Doctrine/Fixtures/ReferencesTest.php
+++ b/test/Doctrine/Fixtures/ReferencesTest.php
@@ -4,6 +4,7 @@ namespace FactoryGirl\Tests\Provider\Doctrine\Fixtures;
 
 use FactoryGirl\Provider\Doctrine\FieldDef;
 use FactoryGirl\Tests\Provider\Doctrine\Fixtures\TestEntity;
+use Doctrine\Common\Collections\ArrayCollection;
 
 class ReferencesTest extends TestCase
 {
@@ -30,8 +31,8 @@ class ReferencesTest extends TestCase
 
         $crew = $spaceShip->getCrew();
 
-        $this->assertInstanceOf('Doctrine\Common\Collections\ArrayCollection', $crew);
-        $this->assertContainsOnly('FactoryGirl\Tests\Provider\Doctrine\Fixtures\TestEntity\Person', $crew);
+        $this->assertInstanceOf(ArrayCollection::class, $crew);
+        $this->assertContainsOnly(TestEntity\Person::class, $crew);
         $this->assertCount(1, $crew);
     }
 
@@ -49,8 +50,8 @@ class ReferencesTest extends TestCase
 
         $crew = $spaceShip->getCrew();
 
-        $this->assertInstanceOf('Doctrine\Common\Collections\ArrayCollection', $crew);
-        $this->assertContainsOnly('FactoryGirl\Tests\Provider\Doctrine\Fixtures\TestEntity\Person', $crew);
+        $this->assertInstanceOf(ArrayCollection::class, $crew);
+        $this->assertContainsOnly(TestEntity\Person::class, $crew);
         $this->assertCount($count, $crew);
     }
 
@@ -66,7 +67,7 @@ class ReferencesTest extends TestCase
 
         $crew = $spaceShip->getCrew();
 
-        $this->assertInstanceOf('Doctrine\Common\Collections\ArrayCollection', $crew);
+        $this->assertInstanceOf(ArrayCollection::class, $crew);
         $this->assertEmpty($crew);
     }
 
@@ -83,7 +84,7 @@ class ReferencesTest extends TestCase
 
         $crew = $spaceShip->getCrew();
 
-        $this->assertInstanceOf('Doctrine\Common\Collections\ArrayCollection', $crew);
+        $this->assertInstanceOf(ArrayCollection::class, $crew);
         $this->assertContains($person, $crew);
         $this->assertCount(1, $crew);
     }

--- a/test/Doctrine/ORM/RepositoryTest.php
+++ b/test/Doctrine/ORM/RepositoryTest.php
@@ -25,7 +25,7 @@ class RepositoryTest extends TestCase
 
         $this->repository = new Repository(
             $this->em,
-            $this->em->getClassMetadata('FactoryGirl\Tests\Provider\Doctrine\ORM\TestEntity\User')
+            $this->em->getClassMetadata(TestEntity\User::class)
         );
     }
 
@@ -39,7 +39,7 @@ class RepositoryTest extends TestCase
         $this->em->flush();
 
         $this->assertInstanceOf(
-            'FactoryGirl\Tests\Provider\Doctrine\ORM\TestEntity\User',
+            TestEntity\User::class,
             $this->repository->getReference($user->id)
         );
     }

--- a/test/Doctrine/Types/StatusArrayTest.php
+++ b/test/Doctrine/Types/StatusArrayTest.php
@@ -5,8 +5,10 @@ namespace FactoryGirl\Tests\Provider\Doctrine\Types;
 use FactoryGirl\Tests\Provider\Doctrine\Fixtures\TestCase;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use FactoryGirl\Provider\Doctrine\DBAL\Types\StatusArrayType;
 
-Type::addType('statusarray', 'FactoryGirl\Provider\Doctrine\DBAL\Types\StatusArrayType');
+Type::addType('statusarray', StatusArrayType::class);
 
 class StatusArrayTest extends TestCase
 {
@@ -19,7 +21,7 @@ class StatusArrayTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->platform = $this->getMockForAbstractClass('\Doctrine\DBAL\Platforms\AbstractPlatform');
+        $this->platform = $this->getMockForAbstractClass(AbstractPlatform::class);
         $this->type = Type::getType('statusarray');
     }
 


### PR DESCRIPTION
This PR

* [x] uses the `class` keyword 

Follows #1.