### PR TITLE
Fix: Do not create entity manager in setUp()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -786,11 +786,6 @@ parameters:
 			path: test/Doctrine/Fixtures/TestCase.php
 
 		-
-			message: "#^Method FactoryGirl\\\\Tests\\\\Provider\\\\Doctrine\\\\Fixtures\\\\TestCase\\:\\:setUp\\(\\) is not final, but since the containing class is abstract, it should be\\.$#"
-			count: 1
-			path: test/Doctrine/Fixtures/TestCase.php
-
-		-
 			message: "#^Parameter \\#1 \\$paths of method Doctrine\\\\ORM\\\\Configuration\\:\\:newDefaultAnnotationDriver\\(\\) expects array, string given\\.$#"
 			count: 1
 			path: test/Doctrine/Fixtures/TestCase.php

--- a/test/Doctrine/Fixtures/BasicUsageTest.php
+++ b/test/Doctrine/Fixtures/BasicUsageTest.php
@@ -13,7 +13,7 @@ class BasicUsageTest extends TestCase
      */
     public function acceptsConstantValuesInEntityDefinitions()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $ss = $fixtureFactory
             ->defineEntity(Entity\SpaceShip::class, [
@@ -31,7 +31,7 @@ class BasicUsageTest extends TestCase
     {
         $name = "Star";
 
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class, [
             'name' => function () use (&$name) {
@@ -49,7 +49,7 @@ class BasicUsageTest extends TestCase
      */
     public function valuesCanBeOverriddenAtCreationTime()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $ss = $fixtureFactory
             ->defineEntity(Entity\SpaceShip::class, [
@@ -64,7 +64,7 @@ class BasicUsageTest extends TestCase
      */
     public function preservesDefaultValuesOfEntity()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $ss = $fixtureFactory
             ->defineEntity(Entity\SpaceStation::class)
@@ -77,7 +77,7 @@ class BasicUsageTest extends TestCase
      */
     public function doesNotCallTheConstructorOfTheEntity()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $ss = $fixtureFactory
             ->defineEntity(Entity\SpaceShip::class, [])
@@ -90,7 +90,7 @@ class BasicUsageTest extends TestCase
      */
     public function instantiatesCollectionAssociationsToBeEmptyCollectionsWhenUnspecified()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $ss = $fixtureFactory
             ->defineEntity(Entity\SpaceShip::class, [
@@ -107,7 +107,7 @@ class BasicUsageTest extends TestCase
      */
     public function arrayElementsAreMappedToCollectionAsscociationFields()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class);
         $fixtureFactory->defineEntity(Entity\Person::class, [
@@ -132,7 +132,7 @@ class BasicUsageTest extends TestCase
      */
     public function unspecifiedFieldsAreLeftNull()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class);
         $this->assertNull($fixtureFactory->get(Entity\SpaceShip::class)->getName());
@@ -143,7 +143,7 @@ class BasicUsageTest extends TestCase
      */
     public function entityIsDefinedToDefaultNamespace()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class);
         $fixtureFactory->defineEntity(Entity\Person\User::class);
@@ -164,7 +164,7 @@ class BasicUsageTest extends TestCase
      */
     public function entityCanBeDefinedToAnotherNamespace()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(
             Entity\Artist::class
@@ -183,7 +183,7 @@ class BasicUsageTest extends TestCase
      */
     public function returnsListOfEntities()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class);
 
@@ -195,7 +195,7 @@ class BasicUsageTest extends TestCase
      */
     public function canSpecifyNumberOfReturnedInstances()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class);
 

--- a/test/Doctrine/Fixtures/BidirectionalReferencesTest.php
+++ b/test/Doctrine/Fixtures/BidirectionalReferencesTest.php
@@ -12,7 +12,7 @@ class BidirectionalReferencesTest extends TestCase
      */
     public function bidirectionalOntToManyReferencesAreAssignedBothWays()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class);
         $fixtureFactory->defineEntity(Entity\Person::class, [
@@ -30,7 +30,7 @@ class BidirectionalReferencesTest extends TestCase
      */
     public function unidirectionalReferencesWorkAsUsual()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\Badge::class, [
             'owner' => FieldDef::reference(Entity\Person::class)
@@ -45,7 +45,7 @@ class BidirectionalReferencesTest extends TestCase
      */
     public function whenTheOneSideIsASingletonItMayGetSeveralChildObjects()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class);
         $fixtureFactory->defineEntity(Entity\Person::class, [

--- a/test/Doctrine/Fixtures/ExtraConfigurationTest.php
+++ b/test/Doctrine/Fixtures/ExtraConfigurationTest.php
@@ -11,7 +11,7 @@ class ExtraConfigurationTest extends TestCase
      */
     public function canInvokeACallbackAfterObjectConstruction()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class, [
             'name' => 'Foo'
@@ -30,7 +30,7 @@ class ExtraConfigurationTest extends TestCase
      */
     public function theAfterCreateCallbackCanBeUsedToCallTheConstructor()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class, [
             'name' => 'Foo'

--- a/test/Doctrine/Fixtures/IncorrectUsageTest.php
+++ b/test/Doctrine/Fixtures/IncorrectUsageTest.php
@@ -11,7 +11,7 @@ class IncorrectUsageTest extends TestCase
      */
     public function throwsWhenTryingToDefineTheSameEntityTwice()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class);
 
@@ -25,7 +25,7 @@ class IncorrectUsageTest extends TestCase
      */
     public function throwsWhenTryingToDefineEntitiesThatAreNotEvenClasses()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $this->expectException(\Exception::class);
 
@@ -37,7 +37,7 @@ class IncorrectUsageTest extends TestCase
      */
     public function throwsWhenTryingToDefineEntitiesThatAreNotEntities()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $this->assertTrue(class_exists(Entity\NotAnEntity::class, true));
 
@@ -51,7 +51,7 @@ class IncorrectUsageTest extends TestCase
      */
     public function throwsWhenTryingToDefineNonexistentFields()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $this->expectException(\Exception::class);
 
@@ -65,7 +65,7 @@ class IncorrectUsageTest extends TestCase
      */
     public function throwsWhenTryingToGiveNonexistentFieldsWhileConstructing()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class, ['name' => 'Alpha']);
 
@@ -81,7 +81,7 @@ class IncorrectUsageTest extends TestCase
      */
     public function throwsWhenTryingToGetLessThanOneInstance()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class);
 

--- a/test/Doctrine/Fixtures/PersistingTest.php
+++ b/test/Doctrine/Fixtures/PersistingTest.php
@@ -13,17 +13,19 @@ class PersistingTest extends TestCase
      */
     public function automaticPersistCanBeTurnedOn()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $entityManager = self::createEntityManager();
+
+        $fixtureFactory = new FixtureFactory($entityManager);
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class, ['name' => 'Zeta']);
 
         $fixtureFactory->persistOnGet();
 
         $ss = $fixtureFactory->get(Entity\SpaceShip::class);
-        $this->em->flush();
+        $entityManager->flush();
 
         $this->assertNotNull($ss->getId());
-        $this->assertSame($ss, $this->em->find(Entity\SpaceShip::class, $ss->getId()));
+        $this->assertSame($ss, $entityManager->find(Entity\SpaceShip::class, $ss->getId()));
     }
 
     /**
@@ -31,16 +33,18 @@ class PersistingTest extends TestCase
      */
     public function doesNotPersistByDefault()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $entityManager = self::createEntityManager();
+
+        $fixtureFactory = new FixtureFactory($entityManager);
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class, ['name' => 'Zeta']);
 
         $ss = $fixtureFactory->get(Entity\SpaceShip::class);
 
-        $this->em->flush();
+        $entityManager->flush();
 
         $this->assertNull($ss->getId());
-        $q = $this->em
+        $q = $entityManager
             ->createQueryBuilder()
             ->select('ss')
             ->from(Entity\SpaceShip::class, 'ss')
@@ -64,7 +68,9 @@ class PersistingTest extends TestCase
             }
         }
 
-        $fixtureFactory = new FixtureFactory($this->em);
+        $entityManager = self::createEntityManager();
+
+        $fixtureFactory = new FixtureFactory($entityManager);
 
         $fixtureFactory->defineEntity(Entity\Name::class, [
             'first' => FieldDef::sequence(static function () {
@@ -99,6 +105,6 @@ class PersistingTest extends TestCase
         $this->assertInstanceOf(Entity\Commander::class, $commander);
         $this->assertInstanceOf(Entity\Name::class, $commander->name());
 
-        $this->em->flush();
+        $entityManager->flush();
     }
 }

--- a/test/Doctrine/Fixtures/ReferenceTest.php
+++ b/test/Doctrine/Fixtures/ReferenceTest.php
@@ -12,7 +12,7 @@ class ReferenceTest extends TestCase
      */
     public function referencedObjectShouldBeCreatedAutomatically()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class);
         $fixtureFactory->defineEntity(Entity\Person::class, [
@@ -33,7 +33,7 @@ class ReferenceTest extends TestCase
      */
     public function referencedObjectsShouldBeNullable()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class);
         $fixtureFactory->defineEntity(Entity\Person::class, [

--- a/test/Doctrine/Fixtures/ReferencesTest.php
+++ b/test/Doctrine/Fixtures/ReferencesTest.php
@@ -15,7 +15,7 @@ class ReferencesTest extends TestCase
      */
     public function referencedObjectsShouldBeCreatedAutomatically()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class, [
             'crew' => FieldDef::references(Entity\Person::class)
@@ -42,7 +42,7 @@ class ReferencesTest extends TestCase
     {
         $count = 5;
 
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class, [
             'crew' => FieldDef::references(Entity\Person::class)
@@ -69,7 +69,7 @@ class ReferencesTest extends TestCase
      */
     public function referencedObjectsShouldBeNullable()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class, [
             'crew' => FieldDef::references(Entity\Person::class)
@@ -95,7 +95,7 @@ class ReferencesTest extends TestCase
      */
     public function referencedObjectsCanBeSingletons()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class, [
             'crew' => FieldDef::references(Entity\Person::class)

--- a/test/Doctrine/Fixtures/SequenceTest.php
+++ b/test/Doctrine/Fixtures/SequenceTest.php
@@ -13,7 +13,7 @@ class SequenceTest extends TestCase
      */
     public function sequenceGeneratorCallsAFunctionWithAnIncrementingArgument()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class, [
             'name' => FieldDef::sequence(function ($n) {
@@ -31,7 +31,7 @@ class SequenceTest extends TestCase
      */
     public function sequenceGeneratorCanTakeAPlaceholderString()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class, [
             'name' => FieldDef::sequence("Beta %d")
@@ -47,7 +47,7 @@ class SequenceTest extends TestCase
      */
     public function sequenceGeneratorCanTakeAStringToAppendTo()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class, [
             'name' => FieldDef::sequence("Gamma ")

--- a/test/Doctrine/Fixtures/SingletonTest.php
+++ b/test/Doctrine/Fixtures/SingletonTest.php
@@ -11,7 +11,7 @@ class SingletonTest extends TestCase
      */
     public function afterGettingAnEntityAsASingletonGettingTheEntityAgainReturnsTheSameObject()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class);
 
@@ -26,7 +26,7 @@ class SingletonTest extends TestCase
      */
     public function getAsSingletonMethodAcceptsFieldOverridesLikeGet()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class);
 
@@ -40,7 +40,7 @@ class SingletonTest extends TestCase
      */
     public function throwsAnErrorWhenCallingGetSingletonTwiceOnTheSameEntity()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class, ['name' => 'Alpha']);
         $fixtureFactory->getAsSingleton(Entity\SpaceShip::class);
@@ -57,7 +57,7 @@ class SingletonTest extends TestCase
      */
     public function allowsSettingSingletons()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class);
         $ss = new Entity\SpaceShip("The mothership");
@@ -72,7 +72,7 @@ class SingletonTest extends TestCase
      */
     public function allowsUnsettingSingletons()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class);
         $ss = new Entity\SpaceShip("The mothership");
@@ -88,7 +88,7 @@ class SingletonTest extends TestCase
      */
     public function allowsOverwritingExistingSingletons()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\SpaceShip::class);
         $ss1 = new Entity\SpaceShip("The mothership");

--- a/test/Doctrine/Fixtures/TestCase.php
+++ b/test/Doctrine/Fixtures/TestCase.php
@@ -12,18 +12,6 @@ use Exception;
 
 abstract class TestCase extends Framework\TestCase
 {
-    /**
-     * @var EntityManager
-     */
-    protected $em;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->em = self::createEntityManager();
-    }
-
     final protected static function createEntityManager(): EntityManager
     {
         $annotationPath = __DIR__ . '/../../Fixture/Entity';

--- a/test/Doctrine/Fixtures/TransitiveReferencesTest.php
+++ b/test/Doctrine/Fixtures/TransitiveReferencesTest.php
@@ -13,7 +13,7 @@ class TransitiveReferencesTest extends TestCase
      */
     public function referencesGetInstantiatedTransitively()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\Person::class, [
             'spaceShip' => FieldDef::reference(Entity\SpaceShip::class),
@@ -35,7 +35,7 @@ class TransitiveReferencesTest extends TestCase
      */
     public function transitiveReferencesWorkWithSingletons()
     {
-        $fixtureFactory = new FixtureFactory($this->em);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Entity\Person::class, [
             'spaceShip' => FieldDef::reference(Entity\SpaceShip::class),


### PR DESCRIPTION
This PR

* [x] stops creating the `EntityManager` in `setUp()`