### PR TITLE
Fix: Use interface in type and return type declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 * Removed `FieldDef::past()`, `FieldDef::future()`, and `DateIntervalHelper` ([#14]), by [@localheinz]
 * Removed `Repository` along with locking capabilities ([#15]), by [@localheinz]
 * Removed `QueryBuilder` ([#16]), by [@localheinz]
+* Used `Doctrine\ORM\EntityManagerInterface` instead of `Doctrine\ORM\EntityManager` in type and return type declarations ([#24]), by [@localheinz]
 
 [fa9c564...master]: https://github.com/ergebnis/factory-bot/compare/fa9c564...master
 
@@ -30,5 +31,6 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 [#14]: https://github.com/ergebnis/factory-bot/pull/14
 [#15]: https://github.com/ergebnis/factory-bot/pull/15
 [#16]: https://github.com/ergebnis/factory-bot/pull/16
+[#24]: https://github.com/ergebnis/factory-bot/pull/24
 
 [@localheinz]: https://github.com/localheinz

--- a/src/EntityDef.php
+++ b/src/EntityDef.php
@@ -33,7 +33,7 @@ class EntityDef
 
     private $config;
 
-    public function __construct(ORM\EntityManager $em, $name, $type, array $fieldDefs, array $config)
+    public function __construct(ORM\EntityManagerInterface $em, $name, $type, array $fieldDefs, array $config)
     {
         $this->name = $name;
         $this->entityType = $type;

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -24,7 +24,7 @@ use Doctrine\ORM;
 class FixtureFactory
 {
     /**
-     * @var ORM\EntityManager
+     * @var ORM\EntityManagerInterface
      */
     protected $em;
 
@@ -43,7 +43,7 @@ class FixtureFactory
      */
     protected $persist;
 
-    public function __construct(ORM\EntityManager $em)
+    public function __construct(ORM\EntityManagerInterface $em)
     {
         $this->em = $em;
 

--- a/test/Integration/AbstractTestCase.php
+++ b/test/Integration/AbstractTestCase.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework;
  */
 abstract class AbstractTestCase extends Framework\TestCase
 {
-    final protected static function createEntityManager(): ORM\EntityManager
+    final protected static function createEntityManager(): ORM\EntityManagerInterface
     {
         $configuration = ORM\Tools\Setup::createAnnotationMetadataConfiguration(
             [

--- a/test/Unit/AbstractTestCase.php
+++ b/test/Unit/AbstractTestCase.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework;
  */
 abstract class AbstractTestCase extends Framework\TestCase
 {
-    final protected static function createEntityManager(): ORM\EntityManager
+    final protected static function createEntityManager(): ORM\EntityManagerInterface
     {
         $configuration = ORM\Tools\Setup::createAnnotationMetadataConfiguration(
             [

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -29,7 +29,7 @@ final class FixtureFactoryTest extends Framework\TestCase
 {
     public function testGetThrowsEntityDefinitionUnavailableWhenDefinitionIsUnavailable(): void
     {
-        $entityManager = $this->prophesize(ORM\EntityManager::class)->reveal();
+        $entityManager = $this->prophesize(ORM\EntityManagerInterface::class)->reveal();
 
         $fixtureFactory = new FixtureFactory($entityManager);
 


### PR DESCRIPTION
This PR

* [x] uses `Doctrine\ORM\EntityManagerInterface` instead of `Doctrine\ORM\EntityManager` in type and return type declarations