### PR TITLE
Fix: Move exceptions into Exception namespace

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -56,9 +56,9 @@ parameters:
 			path: src/EntityDef.php
 
 		-
-			message: "#^Class \"Ergebnis\\\\FactoryBot\\\\EntityDefinitionUnavailable\" is not allowed to extend \"OutOfRangeException\"\\.$#"
+			message: "#^Class \"Ergebnis\\\\FactoryBot\\\\Exception\\\\EntityDefinitionUnavailable\" is not allowed to extend \"OutOfRangeException\"\\.$#"
 			count: 1
-			path: src/EntityDefinitionUnavailable.php
+			path: src/Exception/EntityDefinitionUnavailable.php
 
 		-
 			message: "#^Class Ergebnis\\\\FactoryBot\\\\FieldDef is neither abstract nor final\\.$#"
@@ -346,9 +346,9 @@ parameters:
 			path: test/Integration/FixtureFactoryTest.php
 
 		-
-			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'OutOfRangeException' and Ergebnis\\\\FactoryBot\\\\EntityDefinitionUnavailable will always evaluate to true\\.$#"
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'OutOfRangeException' and Ergebnis\\\\FactoryBot\\\\Exception\\\\EntityDefinitionUnavailable will always evaluate to true\\.$#"
 			count: 1
-			path: test/Unit/EntityDefinitionUnavailableTest.php
+			path: test/Unit/Exception/EntityDefinitionUnavailableTest.php
 
 		-
 			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"

--- a/src/Definition/Definitions.php
+++ b/src/Definition/Definitions.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Ergebnis\FactoryBot\Definition;
 
 use Ergebnis\Classy;
+use Ergebnis\FactoryBot\Exception;
 use Ergebnis\FactoryBot\FixtureFactory;
 use Faker\Generator;
 
@@ -33,8 +34,8 @@ final class Definitions
      *
      * @param string $directory
      *
-     * @throws Exception\InvalidDirectory
      * @throws Exception\InvalidDefinition
+     * @throws Exception\InvalidDirectory
      *
      * @return self
      */

--- a/src/Exception/EntityDefinitionUnavailable.php
+++ b/src/Exception/EntityDefinitionUnavailable.php
@@ -11,15 +11,15 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Definition\Exception;
+namespace Ergebnis\FactoryBot\Exception;
 
-final class InvalidDirectory extends \InvalidArgumentException
+final class EntityDefinitionUnavailable extends \OutOfRangeException implements Exception
 {
-    public static function notDirectory(string $directory): self
+    public static function for(string $name): self
     {
         return new self(\sprintf(
-            'Directory should be a directory, but "%s" is not.',
-            $directory
+            'An entity definition for name "%s" is not available.',
+            $name
         ));
     }
 }

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot;
+namespace Ergebnis\FactoryBot\Exception;
 
 /**
  * Marker interface for FactoryGirl\Provider\Doctrine exceptions.

--- a/src/Exception/InvalidDefinition.php
+++ b/src/Exception/InvalidDefinition.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Definition\Exception;
+namespace Ergebnis\FactoryBot\Exception;
 
 final class InvalidDefinition extends \RuntimeException
 {

--- a/src/Exception/InvalidDirectory.php
+++ b/src/Exception/InvalidDirectory.php
@@ -11,15 +11,15 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot;
+namespace Ergebnis\FactoryBot\Exception;
 
-final class EntityDefinitionUnavailable extends \OutOfRangeException implements Exception
+final class InvalidDirectory extends \InvalidArgumentException
 {
-    public static function for(string $name): self
+    public static function notDirectory(string $directory): self
     {
         return new self(\sprintf(
-            'An entity definition for name "%s" is not available.',
-            $name
+            'Directory should be a directory, but "%s" is not.',
+            $directory
         ));
     }
 }

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -65,7 +65,7 @@ class FixtureFactory
      * @param mixed $name
      * @param array $fieldOverrides
      *
-     * @throws EntityDefinitionUnavailable
+     * @throws Exception\EntityDefinitionUnavailable
      */
     public function get($name, array $fieldOverrides = [])
     {
@@ -74,7 +74,7 @@ class FixtureFactory
         }
 
         if (!\array_key_exists($name, $this->entityDefs)) {
-            throw EntityDefinitionUnavailable::for($name);
+            throw Exception\EntityDefinitionUnavailable::for($name);
         }
 
         /** @var EntityDef $def */

--- a/test/Unit/Definition/DefinitionsTest.php
+++ b/test/Unit/Definition/DefinitionsTest.php
@@ -15,8 +15,8 @@ namespace Ergebnis\FactoryBot\Test\Unit\Definition;
 
 use Ergebnis\FactoryBot\Definition\Definition;
 use Ergebnis\FactoryBot\Definition\Definitions;
-use Ergebnis\FactoryBot\Definition\Exception;
 use Ergebnis\FactoryBot\Definition\FakerAwareDefinition;
+use Ergebnis\FactoryBot\Exception;
 use Ergebnis\FactoryBot\FixtureFactory;
 use Ergebnis\FactoryBot\Test\Fixture;
 use Ergebnis\Test\Util\Helper;
@@ -28,8 +28,8 @@ use PHPUnit\Framework;
  *
  * @covers \Ergebnis\FactoryBot\Definition\Definitions
  *
- * @uses \Ergebnis\FactoryBot\Definition\Exception\InvalidDefinition
- * @uses \Ergebnis\FactoryBot\Definition\Exception\InvalidDirectory
+ * @uses \Ergebnis\FactoryBot\Exception\InvalidDefinition
+ * @uses \Ergebnis\FactoryBot\Exception\InvalidDirectory
  */
 final class DefinitionsTest extends Framework\TestCase
 {

--- a/test/Unit/Exception/EntityDefinitionUnavailableTest.php
+++ b/test/Unit/Exception/EntityDefinitionUnavailableTest.php
@@ -11,14 +11,15 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Unit;
+namespace Ergebnis\FactoryBot\Test\Unit\Exception;
 
+use Ergebnis\FactoryBot\Exception;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Ergebnis\FactoryBot\EntityDefinitionUnavailable
+ * @covers \Ergebnis\FactoryBot\Exception\EntityDefinitionUnavailable
  */
 final class EntityDefinitionUnavailableTest extends Framework\TestCase
 {
@@ -26,7 +27,7 @@ final class EntityDefinitionUnavailableTest extends Framework\TestCase
     {
         $name = 'foo';
 
-        $exception = \Ergebnis\FactoryBot\EntityDefinitionUnavailable::for($name);
+        $exception = Exception\EntityDefinitionUnavailable::for($name);
 
         self::assertInstanceOf(\OutOfRangeException::class, $exception);
 

--- a/test/Unit/Exception/InvalidDefinitionTest.php
+++ b/test/Unit/Exception/InvalidDefinitionTest.php
@@ -11,16 +11,16 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Unit\Definition\Exception;
+namespace Ergebnis\FactoryBot\Test\Unit\Exception;
 
-use Ergebnis\FactoryBot\Definition\Exception;
+use Ergebnis\FactoryBot\Exception;
 use Ergebnis\Test\Util\Helper;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Ergebnis\FactoryBot\Definition\Exception\InvalidDefinition
+ * @covers \Ergebnis\FactoryBot\Exception\InvalidDefinition
  */
 final class InvalidDefinitionTest extends Framework\TestCase
 {

--- a/test/Unit/Exception/InvalidDirectoryTest.php
+++ b/test/Unit/Exception/InvalidDirectoryTest.php
@@ -11,16 +11,16 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Unit\Definition\Exception;
+namespace Ergebnis\FactoryBot\Test\Unit\Exception;
 
-use Ergebnis\FactoryBot\Definition\Exception;
+use Ergebnis\FactoryBot\Exception;
 use Ergebnis\Test\Util\Helper;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Ergebnis\FactoryBot\Definition\Exception\InvalidDirectory
+ * @covers \Ergebnis\FactoryBot\Exception\InvalidDirectory
  */
 final class InvalidDirectoryTest extends Framework\TestCase
 {

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -15,7 +15,7 @@ namespace Ergebnis\FactoryBot\Test\Unit;
 
 use Doctrine\Common;
 use Doctrine\ORM;
-use Ergebnis\FactoryBot\EntityDefinitionUnavailable;
+use Ergebnis\FactoryBot\Exception;
 use Ergebnis\FactoryBot\FieldDef;
 use Ergebnis\FactoryBot\FixtureFactory;
 use Ergebnis\FactoryBot\Test\Fixture;
@@ -26,7 +26,7 @@ use Ergebnis\FactoryBot\Test\Fixture;
  * @covers \Ergebnis\FactoryBot\FixtureFactory
  *
  * @uses \Ergebnis\FactoryBot\EntityDef
- * @uses \Ergebnis\FactoryBot\EntityDefinitionUnavailable
+ * @uses \Ergebnis\FactoryBot\Exception\EntityDefinitionUnavailable
  * @uses \Ergebnis\FactoryBot\FieldDef
  */
 final class FixtureFactoryTest extends AbstractTestCase
@@ -37,7 +37,7 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         $fixtureFactory = new FixtureFactory($entityManager);
 
-        $this->expectException(EntityDefinitionUnavailable::class);
+        $this->expectException(Exception\EntityDefinitionUnavailable::class);
 
         $fixtureFactory->get('foo');
     }


### PR DESCRIPTION
This PR

* [x] moves exceptions into the `Exception` namespace