### PR TITLE
Fix: Implement Exception interface

### DIFF
--- a/src/Exception/InvalidDefinition.php
+++ b/src/Exception/InvalidDefinition.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\FactoryBot\Exception;
 
-final class InvalidDefinition extends \RuntimeException
+final class InvalidDefinition extends \RuntimeException implements Exception
 {
     public static function fromClassNameAndException(string $className, \Exception $exception): self
     {

--- a/src/Exception/InvalidDirectory.php
+++ b/src/Exception/InvalidDirectory.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\FactoryBot\Exception;
 
-final class InvalidDirectory extends \InvalidArgumentException
+final class InvalidDirectory extends \InvalidArgumentException implements Exception
 {
     public static function notDirectory(string $directory): self
     {


### PR DESCRIPTION
This PR

* [x] lets all exceptions implement the `Exception` interface