### PR TITLE
Fix: Remove useless DocBlock

### DIFF
--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace Ergebnis\FactoryBot\Exception;
 
-/**
- * Marker interface for FactoryGirl\Provider\Doctrine exceptions.
- */
 interface Exception
 {
 }


### PR DESCRIPTION
This PR

* [x] removes a useless DocBlock 