### PR TITLE
Fix: Extend Throwable interface

### DIFF
--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -13,6 +13,6 @@ declare(strict_types=1);
 
 namespace Ergebnis\FactoryBot\Exception;
 
-interface Exception
+interface Exception extends \Throwable
 {
 }


### PR DESCRIPTION
This PR

* [x] lets the `Exception` interface extend the `Throwable` interface


💁‍♂ This will allow using `Exception` in `catch` statements.