### PR TITLE
Fix: Remove non-applicable directory exclusion

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -38,8 +38,6 @@ $config->getFinder()
         '.build/',
         '.dependabot/',
         '.github/',
-        'src/Doctrine/',
-        'test/Doctrine/',
     ])
     ->name('.php_cs');
 


### PR DESCRIPTION
This PR

* [x] removes non-applicable directory exclusions for `friendsofphp/php-cs-fixer`

Follows #17.