### PR TITLE
Fix: Re-enable final_class fixer

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -9,8 +9,8 @@ on: # yamllint disable-line rule:truthy
       - "master"
 
 env:
-  MIN_COVERED_MSI: 84
-  MIN_MSI: 53
+  MIN_COVERED_MSI: 91
+  MIN_MSI: 56
   REQUIRED_PHP_EXTENSIONS: "mbstring"
 
 jobs:

--- a/.php_cs
+++ b/.php_cs
@@ -27,7 +27,6 @@ $license = License\Type\MIT::markdown(
 $license->save();
 
 $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71($license->header()), [
-    'final_class' => false,
     'mb_str_functions' => false,
 ]);
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 * Removed `Repository` along with locking capabilities ([#15]), by [@localheinz]
 * Removed `QueryBuilder` ([#16]), by [@localheinz]
 * Used `Doctrine\ORM\EntityManagerInterface` instead of `Doctrine\ORM\EntityManager` in type and return type declarations ([#24]), by [@localheinz]
+* Marked all classes as `final` ([#33]), by [@localheinz]
 
 [fa9c564...master]: https://github.com/ergebnis/factory-bot/compare/fa9c564...master
 
@@ -32,5 +33,6 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 [#15]: https://github.com/ergebnis/factory-bot/pull/15
 [#16]: https://github.com/ergebnis/factory-bot/pull/16
 [#24]: https://github.com/ergebnis/factory-bot/pull/24
+[#33]: https://github.com/ergebnis/factory-bot/pull/33
 
 [@localheinz]: https://github.com/localheinz

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-MIN_COVERED_MSI:=84
-MIN_MSI:=53
+MIN_COVERED_MSI:=91
+MIN_MSI:=56
 
 .PHONY: it
 it: coding-standards dependency-analysis static-code-analysis doctrine tests ## Runs the coding-standards, dependency-analysis, static-code-analysis, doctrine, and tests targets

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,11 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Class Ergebnis\\\\FactoryBot\\\\EntityDef is neither abstract nor final\\.$#"
-			count: 1
-			path: src/EntityDef.php
-
-		-
 			message: "#^Property Ergebnis\\\\FactoryBot\\\\EntityDef\\:\\:\\$name has no typehint specified\\.$#"
 			count: 1
 			path: src/EntityDef.php
@@ -61,11 +56,6 @@ parameters:
 			path: src/Exception/EntityDefinitionUnavailable.php
 
 		-
-			message: "#^Class Ergebnis\\\\FactoryBot\\\\FieldDef is neither abstract nor final\\.$#"
-			count: 1
-			path: src/FieldDef.php
-
-		-
 			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
 			count: 2
 			path: src/FieldDef.php
@@ -74,11 +64,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$replace of function str_replace expects array\\|string, int given\\.$#"
 			count: 1
 			path: src/FieldDef.php
-
-		-
-			message: "#^Class Ergebnis\\\\FactoryBot\\\\FixtureFactory is neither abstract nor final\\.$#"
-			count: 1
-			path: src/FixtureFactory.php
 
 		-
 			message: "#^Method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:get\\(\\) has no return typehint specified\\.$#"

--- a/src/EntityDef.php
+++ b/src/EntityDef.php
@@ -18,7 +18,7 @@ use Doctrine\ORM;
 /**
  * An internal class that `FixtureFactory` uses to normalize and store entity definitions in.
  */
-class EntityDef
+final class EntityDef
 {
     private $name;
 

--- a/src/FieldDef.php
+++ b/src/FieldDef.php
@@ -16,7 +16,7 @@ namespace Ergebnis\FactoryBot;
 /**
  * Contains static methods to define fields as sequences, references etc.
  */
-class FieldDef
+final class FieldDef
 {
     /**
      * Defines a field to be a string based on an incrementing integer.

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -231,6 +231,14 @@ final class FixtureFactory
         return $this;
     }
 
+    /**
+     * @return EntityDef[]
+     */
+    public function definitions(): array
+    {
+        return $this->entityDefs;
+    }
+
     private function checkFieldOverrides(EntityDef $def, array $fieldOverrides): void
     {
         $extraFields = \array_diff(\array_keys($fieldOverrides), \array_keys($def->getFieldDefs()));

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -21,27 +21,27 @@ use Doctrine\ORM;
  *
  * See the README file for a tutorial.
  */
-class FixtureFactory
+final class FixtureFactory
 {
     /**
      * @var ORM\EntityManagerInterface
      */
-    protected $em;
+    private $em;
 
     /**
      * @var array<EntityDef>
      */
-    protected $entityDefs;
+    private $entityDefs;
 
     /**
      * @var array
      */
-    protected $singletons;
+    private $singletons;
 
     /**
      * @var bool
      */
-    protected $persist;
+    private $persist;
 
     public function __construct(ORM\EntityManagerInterface $em)
     {
@@ -231,7 +231,7 @@ class FixtureFactory
         return $this;
     }
 
-    protected function checkFieldOverrides(EntityDef $def, array $fieldOverrides): void
+    private function checkFieldOverrides(EntityDef $def, array $fieldOverrides): void
     {
         $extraFields = \array_diff(\array_keys($fieldOverrides), \array_keys($def->getFieldDefs()));
 
@@ -240,7 +240,7 @@ class FixtureFactory
         }
     }
 
-    protected function setField($ent, EntityDef $def, $fieldName, $fieldValue): void
+    private function setField($ent, EntityDef $def, $fieldName, $fieldValue): void
     {
         $metadata = $def->getEntityMetadata();
 
@@ -255,7 +255,7 @@ class FixtureFactory
         }
     }
 
-    protected function createCollectionFrom($array = [])
+    private function createCollectionFrom($array = [])
     {
         if (\is_array($array)) {
             return new Common\Collections\ArrayCollection($array);
@@ -264,7 +264,7 @@ class FixtureFactory
         return new Common\Collections\ArrayCollection();
     }
 
-    protected function updateCollectionSideOfAssocation($entityBeingCreated, $metadata, $fieldName, $value): void
+    private function updateCollectionSideOfAssocation($entityBeingCreated, $metadata, $fieldName, $value): void
     {
         $assoc = $metadata->getAssociationMapping($fieldName);
         $inverse = $assoc['inversedBy'];

--- a/test/Unit/Definition/DefinitionsTest.php
+++ b/test/Unit/Definition/DefinitionsTest.php
@@ -19,19 +19,21 @@ use Ergebnis\FactoryBot\Definition\FakerAwareDefinition;
 use Ergebnis\FactoryBot\Exception;
 use Ergebnis\FactoryBot\FixtureFactory;
 use Ergebnis\FactoryBot\Test\Fixture;
+use Ergebnis\FactoryBot\Test\Unit\AbstractTestCase;
 use Ergebnis\Test\Util\Helper;
 use Faker\Generator;
-use PHPUnit\Framework;
 
 /**
  * @internal
  *
  * @covers \Ergebnis\FactoryBot\Definition\Definitions
  *
+ * @uses \Ergebnis\FactoryBot\EntityDef
  * @uses \Ergebnis\FactoryBot\Exception\InvalidDefinition
  * @uses \Ergebnis\FactoryBot\Exception\InvalidDirectory
+ * @uses \Ergebnis\FactoryBot\FixtureFactory
  */
-final class DefinitionsTest extends Framework\TestCase
+final class DefinitionsTest extends AbstractTestCase
 {
     use Helper;
 
@@ -44,53 +46,47 @@ final class DefinitionsTest extends Framework\TestCase
 
     public function testInIgnoresClassesWhichDoNotImplementProviderInterface(): void
     {
-        $fixtureFactory = $this->prophesize(FixtureFactory::class);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
-        $fixtureFactory
-            ->defineEntity()
-            ->shouldNotBeCalled();
+        Definitions::in(__DIR__ . '/../../Fixture/Definition/DoesNotImplementInterface')->registerWith($fixtureFactory);
 
-        Definitions::in(__DIR__ . '/../../Fixture/Definition/DoesNotImplementInterface')->registerWith($fixtureFactory->reveal());
+        self::assertSame([], $fixtureFactory->definitions());
     }
 
     public function testInIgnoresClassesWhichAreAbstract(): void
     {
-        $fixtureFactory = $this->prophesize(FixtureFactory::class);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
-        $fixtureFactory
-            ->defineEntity()
-            ->shouldNotBeCalled();
+        Definitions::in(__DIR__ . '/../../Fixture/Definition/IsAbstract')->registerWith($fixtureFactory);
 
-        Definitions::in(__DIR__ . '/../../Fixture/Definition/IsAbstract')->registerWith($fixtureFactory->reveal());
+        self::assertSame([], $fixtureFactory->definitions());
     }
 
     public function testInIgnoresClassesWhichHavePrivateConstructors(): void
     {
-        $fixtureFactory = $this->prophesize(FixtureFactory::class);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
-        $fixtureFactory
-            ->defineEntity()
-            ->shouldNotBeCalled();
+        Definitions::in(__DIR__ . '/../../Fixture/Definition/PrivateConstructor')->registerWith($fixtureFactory);
 
-        Definitions::in(__DIR__ . '/../../Fixture/Definition/PrivateConstructor')->registerWith($fixtureFactory->reveal());
+        self::assertSame([], $fixtureFactory->definitions());
     }
 
     public function testInAcceptsClassesWhichAreAcceptable(): void
     {
-        $fixtureFactory = $this->prophesize(FixtureFactory::class);
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
-        $fixtureFactory
-            ->defineEntity(Fixture\Entity\User::class)
-            ->shouldBeCalled();
+        Definitions::in(__DIR__ . '/../../Fixture/Definition/Acceptable')->registerWith($fixtureFactory);
 
-        Definitions::in(__DIR__ . '/../../Fixture/Definition/Acceptable')->registerWith($fixtureFactory->reveal());
+        self::assertArrayHasKey(Fixture\Entity\User::class, $fixtureFactory->definitions());
     }
 
     public function testFluentInterface(): void
     {
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
+
         $definitions = Definitions::in(__DIR__ . '/../../Fixture/Definition/Acceptable');
 
-        self::assertSame($definitions, $definitions->registerWith($this->prophesize(FixtureFactory::class)->reveal()));
+        self::assertSame($definitions, $definitions->registerWith($fixtureFactory));
         self::assertSame($definitions, $definitions->provideWith($this->prophesize(Generator::class)->reveal()));
     }
 


### PR DESCRIPTION
This PR

* [x] re-enables the `final_class` fixer
* [x] runs `make coding-standards`
* [x] uses the real `FixtureFactory` in tests

Follows #1.