### PR TITLE
Fix: Configure mapping for classes used as entities

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -261,11 +261,6 @@ parameters:
 			path: test/Fixture/Entity/Person.php
 
 		-
-			message: "#^Property Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\Entity\\\\Person\\\\User\\:\\:\\$id has no typehint specified\\.$#"
-			count: 1
-			path: test/Fixture/Entity/Person/User.php
-
-		-
 			message: "#^Property Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\Entity\\\\SpaceShip\\:\\:\\$id has no typehint specified\\.$#"
 			count: 1
 			path: test/Fixture/Entity/SpaceShip.php

--- a/test/Fixture/Entity/Artist.php
+++ b/test/Fixture/Entity/Artist.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
+ * @ORM\Table(name="artist")
  */
 class Artist
 {

--- a/test/Fixture/Entity/Badge.php
+++ b/test/Fixture/Entity/Badge.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
+ * @ORM\Table(name="badge")
  */
 class Badge
 {

--- a/test/Fixture/Entity/Commander.php
+++ b/test/Fixture/Entity/Commander.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
+ * @ORM\Table(name="commander")
  */
 class Commander
 {

--- a/test/Fixture/Entity/Group.php
+++ b/test/Fixture/Entity/Group.php
@@ -13,6 +13,24 @@ declare(strict_types=1);
 
 namespace Ergebnis\FactoryBot\Test\Fixture\Entity;
 
-final class Group
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="group")
+ */
+class Group
 {
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="string")
+     *
+     * @var string
+     */
+    private $id;
+
+    public function __construct(string $id)
+    {
+        $this->id = $id;
+    }
 }

--- a/test/Fixture/Entity/Person.php
+++ b/test/Fixture/Entity/Person.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
+ * @ORM\Table(name="person")
  */
 class Person
 {

--- a/test/Fixture/Entity/Person/User.php
+++ b/test/Fixture/Entity/Person/User.php
@@ -17,13 +17,20 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
+ * @ORM\Table(name="person_user")
  */
 class User
 {
     /**
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
-     * @ORM\Column(type="integer")
+     * @ORM\Column(type="string")
+     *
+     * @var string
      */
     protected $id;
+
+    public function __construct(string $id)
+    {
+        $this->id = $id;
+    }
 }

--- a/test/Fixture/Entity/SpaceShip.php
+++ b/test/Fixture/Entity/SpaceShip.php
@@ -18,6 +18,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
+ * @ORM\Table(name="space_ship")
  */
 class SpaceShip
 {

--- a/test/Fixture/Entity/SpaceStation.php
+++ b/test/Fixture/Entity/SpaceStation.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
+ * @ORM\Table(name="space_station")
  */
 class SpaceStation
 {

--- a/test/Fixture/Entity/User.php
+++ b/test/Fixture/Entity/User.php
@@ -13,6 +13,24 @@ declare(strict_types=1);
 
 namespace Ergebnis\FactoryBot\Test\Fixture\Entity;
 
-final class User
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="user")
+ */
+class User
 {
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="string")
+     *
+     * @var string
+     */
+    private $id;
+
+    public function __construct(string $id)
+    {
+        $this->id = $id;
+    }
 }


### PR DESCRIPTION
This PR

* [x] configures the mapping for classes used as entities

Blocks #33.