### PR TITLE
Fix: Compose meta data instead of entity manager

### DIFF
--- a/src/EntityDef.php
+++ b/src/EntityDef.php
@@ -33,11 +33,11 @@ final class EntityDef
 
     private $config;
 
-    public function __construct(ORM\EntityManagerInterface $em, $name, $type, array $fieldDefs, array $config)
+    public function __construct(ORM\Mapping\ClassMetadata $metadata, $name, $type, array $fieldDefs, array $config)
     {
         $this->name = $name;
         $this->entityType = $type;
-        $this->metadata = $em->getClassMetadata($type);
+        $this->metadata = $metadata;
         $this->fieldDefs = [];
         $this->config = $config;
 

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -225,7 +225,13 @@ final class FixtureFactory
             throw new \Exception("Unknown entity type: {$type}");
         }
 
-        $this->entityDefs[$name] = new EntityDef($this->em, $name, $type, $fieldDefs, $config);
+        $this->entityDefs[$name] = new EntityDef(
+            $metadata,
+            $name,
+            $type,
+            $fieldDefs,
+            $config
+        );
 
         return $this;
     }


### PR DESCRIPTION
This PR

* [x] composes class meta data instead of the entity manager into `EntityDef`