### PR TITLE
Fix: Remove unused accessor, constructor parameter, and field

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -10,7 +10,7 @@ on: # yamllint disable-line rule:truthy
 
 env:
   MIN_COVERED_MSI: 94
-  MIN_MSI: 85
+  MIN_MSI: 86
   REQUIRED_PHP_EXTENSIONS: "mbstring"
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 MIN_COVERED_MSI:=94
-MIN_MSI:=85
+MIN_MSI:=86
 
 .PHONY: it
 it: coding-standards dependency-analysis static-code-analysis doctrine tests ## Runs the coding-standards, dependency-analysis, static-code-analysis, doctrine, and tests targets

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,17 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Property Ergebnis\\\\FactoryBot\\\\EntityDef\\:\\:\\$name has no typehint specified\\.$#"
-			count: 1
-			path: src/EntityDef.php
-
-		-
 			message: "#^Property Ergebnis\\\\FactoryBot\\\\EntityDef\\:\\:\\$entityType has no typehint specified\\.$#"
-			count: 1
-			path: src/EntityDef.php
-
-		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\EntityDef\\:\\:__construct\\(\\) has parameter \\$name with no typehint specified\\.$#"
 			count: 1
 			path: src/EntityDef.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -7,14 +7,12 @@
       <code>static function () use ($def) {</code>
       <code>static function () use ($f) {</code>
     </MissingClosureReturnType>
-    <MissingParamType occurrences="4">
-      <code>$name</code>
+    <MissingParamType occurrences="3">
       <code>$type</code>
       <code>$def</code>
       <code>$f</code>
     </MissingParamType>
-    <MissingPropertyType occurrences="4">
-      <code>$name</code>
+    <MissingPropertyType occurrences="3">
       <code>$entityType</code>
       <code>$fieldDefs</code>
       <code>$config</code>
@@ -24,8 +22,7 @@
       <code>normalizeFieldDef</code>
       <code>ensureInvokable</code>
     </MissingReturnType>
-    <MixedArgument occurrences="2">
-      <code>$type</code>
+    <MixedArgument occurrences="1">
       <code>$f</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="2">
@@ -39,16 +36,14 @@
     <MixedFunctionCall occurrences="1">
       <code>\call_user_func_array($f, \func_get_args())</code>
     </MixedFunctionCall>
-    <MixedInferredReturnType occurrences="3">
-      <code>string</code>
+    <MixedInferredReturnType occurrences="2">
       <code>string</code>
       <code>array</code>
     </MixedInferredReturnType>
     <MixedOperand occurrences="1">
       <code>$this-&gt;entityType</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="3">
-      <code>$this-&gt;name</code>
+    <MixedReturnStatement occurrences="2">
       <code>$this-&gt;entityType</code>
       <code>$this-&gt;config</code>
     </MixedReturnStatement>

--- a/src/EntityDef.php
+++ b/src/EntityDef.php
@@ -25,34 +25,21 @@ final class EntityDef
      */
     private $metadata;
 
-    private $name;
-
     private $entityType;
 
     private $fieldDefs;
 
     private $config;
 
-    public function __construct(ORM\Mapping\ClassMetadata $metadata, $name, $type, array $fieldDefs, array $config)
+    public function __construct(ORM\Mapping\ClassMetadata $metadata, $type, array $fieldDefs, array $config)
     {
         $this->metadata = $metadata;
-        $this->name = $name;
         $this->entityType = $type;
         $this->fieldDefs = [];
         $this->config = $config;
 
         $this->readFieldDefs($fieldDefs);
         $this->defaultDefsFromMetadata();
-    }
-
-    /**
-     * Returns the name of the entity definition.
-     *
-     * @return string
-     */
-    public function getName()
-    {
-        return $this->name;
     }
 
     /**

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -227,7 +227,6 @@ final class FixtureFactory
 
         $this->entityDefs[$name] = new EntityDef(
             $metadata,
-            $name,
             $type,
             $fieldDefs,
             $config


### PR DESCRIPTION
This PR

* [x] removes an unused accessor, constructor parameter, and field from `EntityDef`