### PR TITLE
Fix: Remove unnecessary constructor parameter and field

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,16 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Property Ergebnis\\\\FactoryBot\\\\EntityDef\\:\\:\\$entityType has no typehint specified\\.$#"
-			count: 1
-			path: src/EntityDef.php
-
-		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\EntityDef\\:\\:__construct\\(\\) has parameter \\$type with no typehint specified\\.$#"
-			count: 1
-			path: src/EntityDef.php
-
-		-
 			message: "#^Method Ergebnis\\\\FactoryBot\\\\EntityDef\\:\\:getFieldDefs\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: src/EntityDef.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -7,13 +7,11 @@
       <code>static function () use ($def) {</code>
       <code>static function () use ($f) {</code>
     </MissingClosureReturnType>
-    <MissingParamType occurrences="3">
-      <code>$type</code>
+    <MissingParamType occurrences="2">
       <code>$def</code>
       <code>$f</code>
     </MissingParamType>
-    <MissingPropertyType occurrences="3">
-      <code>$entityType</code>
+    <MissingPropertyType occurrences="2">
       <code>$fieldDefs</code>
       <code>$config</code>
     </MissingPropertyType>
@@ -22,8 +20,7 @@
       <code>normalizeFieldDef</code>
       <code>ensureInvokable</code>
     </MissingReturnType>
-    <MixedArgument occurrences="2">
-      <code>$this-&gt;entityType</code>
+    <MixedArgument occurrences="1">
       <code>$f</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="2">
@@ -37,12 +34,10 @@
     <MixedFunctionCall occurrences="1">
       <code>\call_user_func_array($f, \func_get_args())</code>
     </MixedFunctionCall>
-    <MixedInferredReturnType occurrences="2">
-      <code>string</code>
+    <MixedInferredReturnType occurrences="1">
       <code>array</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="2">
-      <code>$this-&gt;entityType</code>
+    <MixedReturnStatement occurrences="1">
       <code>$this-&gt;config</code>
     </MixedReturnStatement>
   </file>

--- a/src/EntityDef.php
+++ b/src/EntityDef.php
@@ -25,16 +25,13 @@ final class EntityDef
      */
     private $metadata;
 
-    private $entityType;
-
     private $fieldDefs;
 
     private $config;
 
-    public function __construct(ORM\Mapping\ClassMetadata $metadata, $type, array $fieldDefs, array $config)
+    public function __construct(ORM\Mapping\ClassMetadata $metadata, array $fieldDefs, array $config)
     {
         $this->metadata = $metadata;
-        $this->entityType = $type;
         $this->fieldDefs = [];
         $this->config = $config;
 
@@ -49,7 +46,7 @@ final class EntityDef
      */
     public function getEntityType()
     {
-        return $this->entityType;
+        return $this->metadata->getName();
     }
 
     /**
@@ -86,7 +83,7 @@ final class EntityDef
             if (!$this->metadata->hasField($key) && !$this->metadata->hasAssociation($key)) {
                 throw new \Exception(\sprintf(
                     'No such field in %s: %s',
-                    $this->entityType,
+                    $this->getEntityType(),
                     $key
                 ));
             }

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -239,7 +239,6 @@ final class FixtureFactory
 
         $this->entityDefs[$name] = new EntityDef(
             $metadata,
-            $type,
             $fieldDefs,
             $config
         );


### PR DESCRIPTION
This PR

* [x] removes an unnecessary constructor parameter and field from `EntityDef`

Follows #1.