### PR TITLE
Fix: Rename methods, parameters, variables, and fields

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,7 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\EntityDef\\:\\:getFieldDefs\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Ergebnis\\\\FactoryBot\\\\EntityDef\\:\\:getFieldDefinitions\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: src/EntityDef.php
 
@@ -11,12 +11,12 @@ parameters:
 			path: src/EntityDef.php
 
 		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\EntityDef\\:\\:normalizeFieldDef\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Ergebnis\\\\FactoryBot\\\\EntityDef\\:\\:normalizeFieldDefinition\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: src/EntityDef.php
 
 		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\EntityDef\\:\\:normalizeFieldDef\\(\\) has parameter \\$def with no typehint specified\\.$#"
+			message: "#^Method Ergebnis\\\\FactoryBot\\\\EntityDef\\:\\:normalizeFieldDefinition\\(\\) has parameter \\$fieldDefinition with no typehint specified\\.$#"
 			count: 1
 			path: src/EntityDef.php
 
@@ -26,7 +26,7 @@ parameters:
 			path: src/EntityDef.php
 
 		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\EntityDef\\:\\:ensureInvokable\\(\\) has parameter \\$f with no typehint specified\\.$#"
+			message: "#^Method Ergebnis\\\\FactoryBot\\\\EntityDef\\:\\:ensureInvokable\\(\\) has parameter \\$fieldDefinition with no typehint specified\\.$#"
 			count: 1
 			path: src/EntityDef.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4,41 +4,41 @@
     <MissingClosureReturnType occurrences="4">
       <code>static function () use ($defaultFieldValue) {</code>
       <code>static function () {</code>
-      <code>static function () use ($def) {</code>
-      <code>static function () use ($f) {</code>
+      <code>static function () use ($fieldDefinition) {</code>
+      <code>static function () use ($fieldDefinition) {</code>
     </MissingClosureReturnType>
     <MissingParamType occurrences="2">
-      <code>$def</code>
-      <code>$f</code>
+      <code>$fieldDefinition</code>
+      <code>$fieldDefinition</code>
     </MissingParamType>
     <MissingPropertyType occurrences="2">
-      <code>$fieldDefs</code>
-      <code>$config</code>
+      <code>$fieldDefinitions</code>
+      <code>$configuration</code>
     </MissingPropertyType>
     <MissingReturnType occurrences="3">
-      <code>getFieldDefs</code>
-      <code>normalizeFieldDef</code>
+      <code>getFieldDefinitions</code>
+      <code>normalizeFieldDefinition</code>
       <code>ensureInvokable</code>
     </MissingReturnType>
     <MixedArgument occurrences="1">
-      <code>$f</code>
+      <code>$fieldDefinition</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="2">
-      <code>$key</code>
-      <code>$key</code>
+      <code>$fieldName</code>
+      <code>$fieldName</code>
     </MixedArgumentTypeCoercion>
     <MixedAssignment occurrences="2">
-      <code>$def</code>
+      <code>$fieldDefinition</code>
       <code>$defaultFieldValue</code>
     </MixedAssignment>
     <MixedFunctionCall occurrences="1">
-      <code>\call_user_func_array($f, \func_get_args())</code>
+      <code>\call_user_func_array($fieldDefinition, \func_get_args())</code>
     </MixedFunctionCall>
     <MixedInferredReturnType occurrences="1">
       <code>array</code>
     </MixedInferredReturnType>
     <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;config</code>
+      <code>$this-&gt;configuration</code>
     </MixedReturnStatement>
   </file>
   <file src="src/FieldDef.php">
@@ -86,7 +86,7 @@
       <code>$name</code>
       <code>$type</code>
       <code>$type</code>
-      <code>$def-&gt;getFieldDefs()</code>
+      <code>$def-&gt;getFieldDefinitions()</code>
       <code>$fieldName</code>
       <code>$ent</code>
       <code>$fieldName</code>

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -77,18 +77,18 @@ final class FixtureFactory
         /** @var EntityDef $def */
         $def = $this->entityDefs[$name];
 
-        $config = $def->getConfig();
+        $config = $def->getConfiguration();
 
         $this->checkFieldOverrides($def, $fieldOverrides);
 
         /** @var ORM\Mapping\ClassMetadata $entityMetadata */
-        $entityMetadata = $def->getEntityMetadata();
+        $entityMetadata = $def->getClassMetadata();
 
         $ent = $entityMetadata->newInstance();
 
         $fieldValues = [];
 
-        foreach ($def->getFieldDefs() as $fieldName => $fieldDef) {
+        foreach ($def->getFieldDefinitions() as $fieldName => $fieldDef) {
             $fieldValues[$fieldName] = \array_key_exists($fieldName, $fieldOverrides)
                 ? $fieldOverrides[$fieldName]
                 : $fieldDef($this);
@@ -256,12 +256,12 @@ final class FixtureFactory
 
     private function checkFieldOverrides(EntityDef $def, array $fieldOverrides): void
     {
-        $extraFields = \array_diff(\array_keys($fieldOverrides), \array_keys($def->getFieldDefs()));
+        $extraFields = \array_diff(\array_keys($fieldOverrides), \array_keys($def->getFieldDefinitions()));
 
         if (!empty($extraFields)) {
             throw new \Exception(\sprintf(
                 'Field(s) not in %s: \'%s\'',
-                $def->getEntityType(),
+                $def->getClassName(),
                 \implode("', '", $extraFields)
             ));
         }
@@ -269,7 +269,7 @@ final class FixtureFactory
 
     private function setField($ent, EntityDef $def, $fieldName, $fieldValue): void
     {
-        $metadata = $def->getEntityMetadata();
+        $metadata = $def->getClassMetadata();
 
         if ($metadata->isCollectionValuedAssociation($fieldName)) {
             $metadata->setFieldValue($ent, $fieldName, $this->createCollectionFrom($fieldValue));


### PR DESCRIPTION
This PR

* [x] renames methods, parameters, variables, and fields in `EntityDef`

Follows #1.