### PR TITLE
Enhancement: Fail early when field definitions reference unavailable fields

### DIFF
--- a/src/EntityDef.php
+++ b/src/EntityDef.php
@@ -47,15 +47,20 @@ final class EntityDef
             $this->classMetadata->getAssociationNames()
         );
 
-        foreach ($fieldDefinitions as $fieldName => $fieldDefinition) {
-            if (!$this->classMetadata->hasField($fieldName) && !$this->classMetadata->hasAssociation($fieldName)) {
-                throw new \Exception(\sprintf(
-                    'No such field in %s: %s',
-                    $this->getClassName(),
-                    $fieldName
-                ));
-            }
+        $extraFieldNames = \array_diff(
+            \array_keys($fieldDefinitions),
+            $fieldNames
+        );
 
+        if ([] !== $extraFieldNames) {
+            throw new \Exception(\sprintf(
+                'No such fields in %s: "%s"',
+                $this->getClassName(),
+                \implode('", "', $extraFieldNames)
+            ));
+        }
+
+        foreach ($fieldDefinitions as $fieldName => $fieldDefinition) {
             $this->fieldDefinitions[$fieldName] = $this->normalizeFieldDefinition($fieldDefinition);
         }
 

--- a/src/EntityDef.php
+++ b/src/EntityDef.php
@@ -43,8 +43,8 @@ final class EntityDef
         $this->configuration = $configuration;
 
         $fieldNames = \array_merge(
-            $this->classMetadata->getFieldNames(),
-            $this->classMetadata->getAssociationNames(),
+            \array_keys($this->classMetadata->fieldMappings),
+            \array_keys($this->classMetadata->associationMappings),
             \array_keys($this->classMetadata->embeddedClasses)
         );
 

--- a/src/EntityDef.php
+++ b/src/EntityDef.php
@@ -42,6 +42,11 @@ final class EntityDef
         $this->fieldDefinitions = [];
         $this->configuration = $configuration;
 
+        $fieldNames = \array_merge(
+            $this->classMetadata->getFieldNames(),
+            $this->classMetadata->getAssociationNames()
+        );
+
         foreach ($fieldDefinitions as $fieldName => $fieldDefinition) {
             if (!$this->classMetadata->hasField($fieldName) && !$this->classMetadata->hasAssociation($fieldName)) {
                 throw new \Exception(\sprintf(
@@ -55,11 +60,6 @@ final class EntityDef
         }
 
         $defaultEntity = $this->classMetadata->newInstance();
-
-        $fieldNames = \array_merge(
-            $this->classMetadata->getFieldNames(),
-            $this->classMetadata->getAssociationNames()
-        );
 
         foreach ($fieldNames as $fieldName) {
             if (\array_key_exists($fieldName, $this->fieldDefinitions)) {

--- a/src/EntityDef.php
+++ b/src/EntityDef.php
@@ -54,6 +54,8 @@ final class EntityDef
         );
 
         if ([] !== $extraFieldNames) {
+            \natsort($extraFieldNames);
+
             throw new \Exception(\sprintf(
                 'No such fields in %s: "%s"',
                 $this->getClassName(),

--- a/src/EntityDef.php
+++ b/src/EntityDef.php
@@ -44,7 +44,8 @@ final class EntityDef
 
         $fieldNames = \array_merge(
             $this->classMetadata->getFieldNames(),
-            $this->classMetadata->getAssociationNames()
+            $this->classMetadata->getAssociationNames(),
+            \array_keys($this->classMetadata->embeddedClasses)
         );
 
         $extraFieldNames = \array_diff(

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -82,12 +82,15 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage(\sprintf(
-            'No such fields in %s: "diameter", "pieType"',
+            'No such fields in %s: "diameter", "foo1", "foo3", "foo20", "pieType"',
             Fixture\FixtureFactory\Entity\Commander::class
         ));
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Commander::class, [
             'diameter' => '30cm',
+            'foo1' => 'bar',
+            'foo20' => 'baz',
+            'foo3' => 'qux',
             'name' => new Fixture\FixtureFactory\Entity\Name(),
             'pieType' => 'blueberry',
         ]);

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -83,11 +83,12 @@ final class FixtureFactoryTest extends AbstractTestCase
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage(\sprintf(
             'No such fields in %s: "diameter", "pieType"',
-            Fixture\FixtureFactory\Entity\Spaceship::class
+            Fixture\FixtureFactory\Entity\Commander::class
         ));
 
-        $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Spaceship::class, [
+        $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Commander::class, [
             'diameter' => '30cm',
+            'name' => new Fixture\FixtureFactory\Entity\Name(),
             'pieType' => 'blueberry',
         ]);
     }

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -76,21 +76,19 @@ final class FixtureFactoryTest extends AbstractTestCase
         $fixtureFactory->defineEntity($className);
     }
 
-    public function testDefineEntityThrowsExceptionWhenUsingFieldNameThatDoesNotExistInEntity(): void
+    public function testDefineEntityThrowsExceptionWhenUsingFieldNamesThatDoNotExistInEntity(): void
     {
-        $fieldName = 'pieType';
-
         $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage(\sprintf(
-            'No such field in %s: %s',
-            Fixture\FixtureFactory\Entity\Spaceship::class,
-            $fieldName
+            'No such fields in %s: "diameter", "pieType"',
+            Fixture\FixtureFactory\Entity\Spaceship::class
         ));
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Spaceship::class, [
-            $fieldName => 'blueberry',
+            'diameter' => '30cm',
+            'pieType' => 'blueberry',
         ]);
     }
 


### PR DESCRIPTION
This PR

* [x] slides a statement
* [x] fails early when field definitions references field that is not available in entity