### PR TITLE
Fix: Populate referenced embeddables

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -10,7 +10,7 @@ on: # yamllint disable-line rule:truthy
 
 env:
   MIN_COVERED_MSI: 94
-  MIN_MSI: 86
+  MIN_MSI: 87
   REQUIRED_PHP_EXTENSIONS: "mbstring"
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 * Marked all classes as `final` ([#33]), by [@localheinz]
 * Marked `EntityDef` as internal ([#49]), by [@localheinz]
 
+### Fixed
+
+* Populated embeddables and disallowed referencing fields using dot notation ([#79]), by [@localheinz]
+
 [fa9c564...master]: https://github.com/ergebnis/factory-bot/compare/fa9c564...master
 
 [#1]: https://github.com/ergebnis/factory-bot/pull/1
@@ -36,5 +40,6 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 [#24]: https://github.com/ergebnis/factory-bot/pull/24
 [#33]: https://github.com/ergebnis/factory-bot/pull/33
 [#49]: https://github.com/ergebnis/factory-bot/pull/49
+[#79]: https://github.com/ergebnis/factory-bot/pull/79
 
 [@localheinz]: https://github.com/localheinz

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 MIN_COVERED_MSI:=94
-MIN_MSI:=86
+MIN_MSI:=87
 
 .PHONY: it
 it: coding-standards dependency-analysis static-code-analysis doctrine tests ## Runs the coding-standards, dependency-analysis, static-code-analysis, doctrine, and tests targets

--- a/src/EntityDef.php
+++ b/src/EntityDef.php
@@ -42,11 +42,16 @@ final class EntityDef
         $this->fieldDefinitions = [];
         $this->configuration = $configuration;
 
-        $fieldNames = \array_merge(
+        /** @var string[] $allFieldNames */
+        $allFieldNames = \array_merge(
             \array_keys($this->classMetadata->fieldMappings),
             \array_keys($this->classMetadata->associationMappings),
             \array_keys($this->classMetadata->embeddedClasses)
         );
+
+        $fieldNames = \array_filter($allFieldNames, static function (string $fieldName): bool {
+            return false === \strpos($fieldName, '.');
+        });
 
         $extraFieldNames = \array_diff(
             \array_keys($fieldDefinitions),

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -172,6 +172,44 @@ final class FixtureFactoryTest extends AbstractTestCase
         self::assertSame($lastName, $name->last());
     }
 
+    public function testDefineEntityThrowsExceptionWhenReferencingFieldsOfEmbeddablesUsingDotNotation(): void
+    {
+        $faker = self::faker()->unique();
+
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage(\sprintf(
+            'No such fields in %s: "name.first", "name.last"',
+            Fixture\FixtureFactory\Entity\Commander::class
+        ));
+
+        $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Commander::class, [
+            'name.first' => $faker->firstName,
+            'name.last' => $faker->lastName,
+        ]);
+    }
+
+    public function testGetEntityThrowsExceptionWhenReferencingFieldsOfEmbeddablesUsingDotNotation(): void
+    {
+        $faker = self::faker()->unique();
+
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
+
+        $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Commander::class);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Field(s) not in %s: \'name.first\', \'name.last\'',
+            Fixture\FixtureFactory\Entity\Commander::class
+        ));
+
+        $fixtureFactory->get(Fixture\FixtureFactory\Entity\Commander::class, [
+            'name.first' => $faker->firstName,
+            'name.last' => $faker->lastName,
+        ]);
+    }
+
     public function testThrowsWhenTryingToGetLessThanOneInstance(): void
     {
         $fixtureFactory = new FixtureFactory(self::createEntityManager());


### PR DESCRIPTION
This PR

* [x] asserts that referenced embeddables are populated
* [x] excludes fields using dot notation