### PR TITLE
Fix: Define Person

### DIFF
--- a/test/Fixture/Definition/Definitions/FakerAware/PersonDefinition.php
+++ b/test/Fixture/Definition/Definitions/FakerAware/PersonDefinition.php
@@ -21,6 +21,6 @@ final class PersonDefinition implements Definition
 {
     public function accept(FixtureFactory $factory): void
     {
-        $factory->defineEntity(Fixture\FixtureFactory\Entity\Spaceship::class);
+        $factory->defineEntity(Fixture\FixtureFactory\Entity\Person::class);
     }
 }


### PR DESCRIPTION
This PR

* [x] defines a `Person` entity in the `PersonDefinition`