### PR TITLE
Enhancement: Sort extra fields

### DIFF
--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -253,6 +253,8 @@ final class FixtureFactory
     {
         $extraFields = \array_diff(\array_keys($fieldOverrides), \array_keys($entityDefinition->getFieldDefinitions()));
 
+        \natsort($extraFields);
+
         if (!empty($extraFields)) {
             throw new \Exception(\sprintf(
                 'Field(s) not in %s: \'%s\'',

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -205,8 +205,8 @@ final class FixtureFactoryTest extends AbstractTestCase
         ));
 
         $fixtureFactory->get(Fixture\FixtureFactory\Entity\Commander::class, [
-            'name.first' => $faker->firstName,
             'name.last' => $faker->lastName,
+            'name.first' => $faker->firstName,
         ]);
     }
 


### PR DESCRIPTION
This PR

* [x] sorts extra fields when attempting to get an instance from the fixture factory where field overrides reference fields not available in the entity