### PR TITLE
Fix: Avoid use of empty()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -41,16 +41,6 @@ parameters:
 			path: src/FixtureFactory.php
 
 		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 1
-			path: src/FixtureFactory.php
-
-		-
-			message: "#^Language construct empty\\(\\) should not be used\\.$#"
-			count: 1
-			path: src/FixtureFactory.php
-
-		-
 			message: "#^Method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:getList\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: src/FixtureFactory.php

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -125,7 +125,7 @@ final class FixtureFactory
 
         \natsort($extraFields);
 
-        if (!empty($extraFields)) {
+        if ([] !== $extraFields) {
             throw new \Exception(\sprintf(
                 'Field(s) not in %s: \'%s\'',
                 $entityDefinition->getClassName(),


### PR DESCRIPTION
This PR

* [x] avoids use of `empty()`

Follows #1.