### PR TITLE
Enhancement: Throw InvalidFieldNames exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 * Used `Doctrine\ORM\EntityManagerInterface` instead of `Doctrine\ORM\EntityManager` in type and return type declarations ([#24]), by [@localheinz]
 * Marked all classes as `final` ([#33]), by [@localheinz]
 * Marked `EntityDef` as internal ([#49]), by [@localheinz]
+* Started throwing an `InvalidFieldNames` exception instead of a generic `Exception` when fields are referenced that are not present in the corresponding entity ([#87]), by [@localheinz]
 
 ### Fixed
 
@@ -41,5 +42,6 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 [#33]: https://github.com/ergebnis/factory-bot/pull/33
 [#49]: https://github.com/ergebnis/factory-bot/pull/49
 [#79]: https://github.com/ergebnis/factory-bot/pull/79
+[#87]: https://github.com/ergebnis/factory-bot/pull/87
 
 [@localheinz]: https://github.com/localheinz

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,11 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$fieldNames of static method Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidFieldNames\\:\\:notFoundIn\\(\\) expects array\\<int, string\\>, array\\<int, \\(int\\|string\\)\\> given\\.$#"
+			count: 1
+			path: src/EntityDef.php
+
+		-
 			message: "#^Method Ergebnis\\\\FactoryBot\\\\EntityDef\\:\\:getFieldDefinitions\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: src/EntityDef.php
@@ -37,6 +42,11 @@ parameters:
 
 		-
 			message: "#^Method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:get\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/FixtureFactory.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$fieldNames of static method Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidFieldNames\\:\\:notFoundIn\\(\\) expects array\\<int, string\\>, array\\<int, \\(int\\|string\\)\\> given\\.$#"
 			count: 1
 			path: src/FixtureFactory.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -21,6 +21,9 @@
       <code>getFieldDefinitions</code>
       <code>normalizeFieldDefinition</code>
     </MissingReturnType>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$extraFieldNames</code>
+    </MixedArgumentTypeCoercion>
     <MixedAssignment occurrences="2">
       <code>$fieldDefinition</code>
       <code>$defaultFieldValue</code>
@@ -91,6 +94,9 @@
       <code>$fieldValue</code>
       <code>$inversedBy</code>
     </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$extraFieldNames</code>
+    </MixedArgumentTypeCoercion>
     <MixedArrayAccess occurrences="1">
       <code>$association['inversedBy']</code>
     </MixedArrayAccess>

--- a/src/EntityDef.php
+++ b/src/EntityDef.php
@@ -34,6 +34,7 @@ final class EntityDef
      * @param array                     $fieldDefinitions
      * @param array                     $configuration
      *
+     * @throws Exception\InvalidFieldNames
      * @throws \Exception
      */
     public function __construct(ORM\Mapping\ClassMetadata $classMetadata, array $fieldDefinitions, array $configuration)
@@ -59,13 +60,10 @@ final class EntityDef
         );
 
         if ([] !== $extraFieldNames) {
-            \natsort($extraFieldNames);
-
-            throw new \Exception(\sprintf(
-                'No such fields in %s: "%s"',
-                $this->getClassName(),
-                \implode('", "', $extraFieldNames)
-            ));
+            throw Exception\InvalidFieldNames::notFoundIn(
+                $classMetadata->getName(),
+                ...$extraFieldNames
+            );
         }
 
         foreach ($fieldDefinitions as $fieldName => $fieldDefinition) {

--- a/src/Exception/InvalidFieldNames.php
+++ b/src/Exception/InvalidFieldNames.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/factory-bot
+ */
+
+namespace Ergebnis\FactoryBot\Exception;
+
+final class InvalidFieldNames extends \InvalidArgumentException implements Exception
+{
+    public static function notFoundIn(string $className, string ...$fieldNames): self
+    {
+        \natsort($fieldNames);
+
+        $template = 'Entity "%s" does not have fields with the names "%s".';
+
+        if (1 === \count($fieldNames)) {
+            $template = 'Entity "%s" does not have a field with the name "%s".';
+        }
+
+        return new self(\sprintf(
+            $template,
+            $className,
+            \implode('", "', $fieldNames)
+        ));
+    }
+}

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -105,6 +105,7 @@ final class FixtureFactory
      * @param array $fieldOverrides
      *
      * @throws Exception\EntityDefinitionUnavailable
+     * @throws Exception\InvalidFieldNames
      */
     public function get($name, array $fieldOverrides = [])
     {
@@ -121,16 +122,16 @@ final class FixtureFactory
 
         $configuration = $entityDefinition->getConfiguration();
 
-        $extraFields = \array_diff(\array_keys($fieldOverrides), \array_keys($entityDefinition->getFieldDefinitions()));
+        $extraFieldNames = \array_diff(
+            \array_keys($fieldOverrides),
+            \array_keys($entityDefinition->getFieldDefinitions())
+        );
 
-        \natsort($extraFields);
-
-        if ([] !== $extraFields) {
-            throw new \Exception(\sprintf(
-                'Field(s) not in %s: \'%s\'',
+        if ([] !== $extraFieldNames) {
+            throw Exception\InvalidFieldNames::notFoundIn(
                 $entityDefinition->getClassName(),
-                \implode("', '", $extraFields)
-            ));
+                ...$extraFieldNames
+            );
         }
 
         /** @var ORM\Mapping\ClassMetadata $classMetadata */

--- a/test/Unit/Exception/InvalidFieldNamesTest.php
+++ b/test/Unit/Exception/InvalidFieldNamesTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/factory-bot
+ */
+
+namespace Ergebnis\FactoryBot\Test\Unit\Exception;
+
+use Ergebnis\FactoryBot\Exception;
+use Ergebnis\Test\Util\Helper;
+use PHPUnit\Framework;
+
+/**
+ * @internal
+ *
+ * @covers \Ergebnis\FactoryBot\Exception\InvalidFieldNames
+ */
+final class InvalidFieldNamesTest extends Framework\TestCase
+{
+    use Helper;
+
+    public function testNotFoundInReturnsExceptionWhenOnlyOneFieldNameIsProvided(): void
+    {
+        $faker = self::faker();
+
+        $className = $faker->word;
+        $fieldName = $faker->word;
+
+        $exception = Exception\InvalidFieldNames::notFoundIn(
+            $className,
+            $fieldName
+        );
+
+        $message = \sprintf(
+            'Entity "%s" does not have a field with the name "%s".',
+            $className,
+            $fieldName
+        );
+
+        self::assertSame($message, $exception->getMessage());
+        self::assertSame(0, $exception->getCode());
+    }
+
+    public function testNotFoundInReturnsExceptionWhenMoreThanOneFieldNameIsProvided(): void
+    {
+        $faker = self::faker();
+
+        $className = $faker->word;
+
+        /** @var string[] $fieldNames */
+        $fieldNames = $faker->words(10);
+
+        $exception = Exception\InvalidFieldNames::notFoundIn(
+            $className,
+            ...$fieldNames
+        );
+
+        $sortedFieldNames = $fieldNames;
+
+        \natsort($sortedFieldNames);
+
+        $message = \sprintf(
+            'Entity "%s" does not have fields with the names "%s".',
+            $className,
+            \implode('", "', $sortedFieldNames)
+        );
+
+        self::assertSame($message, $exception->getMessage());
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -28,6 +28,7 @@ use Ergebnis\Test\Util\Helper;
  * @covers \Ergebnis\FactoryBot\FixtureFactory
  *
  * @uses \Ergebnis\FactoryBot\Exception\EntityDefinitionUnavailable
+ * @uses \Ergebnis\FactoryBot\Exception\InvalidFieldNames
  */
 final class FixtureFactoryTest extends AbstractTestCase
 {
@@ -84,9 +85,9 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception\InvalidFieldNames::class);
         $this->expectExceptionMessage(\sprintf(
-            'No such fields in %s: "email", "phone"',
+            'Entity "%s" does not have fields with the names "email", "phone".',
             Fixture\FixtureFactory\Entity\User::class
         ));
 
@@ -120,17 +121,19 @@ final class FixtureFactoryTest extends AbstractTestCase
 
     public function testThrowsWhenTryingToGiveNonexistentFieldsWhileConstructing(): void
     {
-        $fieldName = 'pieType';
+        $faker = self::faker()->unique();
+
+        $fieldName = $faker->word;
 
         $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Organization::class, [
-            'name' => self::faker()->word,
+            'name' => $faker->word,
         ]);
 
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception\InvalidFieldNames::class);
         $this->expectExceptionMessage(\sprintf(
-            'Field(s) not in %s: \'%s\'',
+            'Entity "%s" does not have a field with the name "%s".',
             Fixture\FixtureFactory\Entity\Organization::class,
             $fieldName
         ));
@@ -170,11 +173,7 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage(\sprintf(
-            'No such fields in %s: "avatar.height", "avatar.url", "avatar.width',
-            Fixture\FixtureFactory\Entity\User::class
-        ));
+        $this->expectException(Exception\InvalidFieldNames::class);
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\User::class, [
             'login' => $faker->userName,
@@ -192,9 +191,9 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\User::class);
 
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception\InvalidFieldNames::class);
         $this->expectExceptionMessage(\sprintf(
-            'Field(s) not in %s: \'avatar.height\', \'avatar.url\', \'avatar.width\'',
+            'Entity "%s" does not have fields with the names "avatar.height", "avatar.url", "avatar.width".',
             Fixture\FixtureFactory\Entity\User::class
         ));
 


### PR DESCRIPTION
This PR

* [x] throws a `FieldsNotFound` exception instead of a generic `Exception` when fields are referenced that are not found in the corresponding entity