### PR TITLE
Fix: Rename methods

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,7 +6,7 @@ parameters:
 			path: src/EntityDef.php
 
 		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\EntityDef\\:\\:getFieldDefinitions\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Ergebnis\\\\FactoryBot\\\\EntityDef\\:\\:fieldDefinitions\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: src/EntityDef.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -18,7 +18,7 @@
       <code>$configuration</code>
     </MissingPropertyType>
     <MissingReturnType occurrences="2">
-      <code>getFieldDefinitions</code>
+      <code>fieldDefinitions</code>
       <code>normalizeFieldDefinition</code>
     </MissingReturnType>
     <MixedArgumentTypeCoercion occurrences="1">
@@ -79,7 +79,7 @@
       <code>$name</code>
       <code>$name</code>
       <code>$name</code>
-      <code>$entityDefinition-&gt;getFieldDefinitions()</code>
+      <code>$entityDefinition-&gt;fieldDefinitions()</code>
       <code>$fieldName</code>
       <code>$name</code>
       <code>$name</code>

--- a/src/EntityDef.php
+++ b/src/EntityDef.php
@@ -98,7 +98,7 @@ final class EntityDef
      *
      * @return string
      */
-    public function getClassName()
+    public function className()
     {
         return $this->classMetadata->getName();
     }
@@ -106,7 +106,7 @@ final class EntityDef
     /**
      * Returns the fielde definition callbacks.
      */
-    public function getFieldDefinitions()
+    public function fieldDefinitions()
     {
         return $this->fieldDefinitions;
     }
@@ -116,7 +116,7 @@ final class EntityDef
      *
      * @return ORM\Mapping\ClassMetadata
      */
-    public function getClassMetadata()
+    public function classMetadata()
     {
         return $this->classMetadata;
     }
@@ -126,7 +126,7 @@ final class EntityDef
      *
      * @return array
      */
-    public function getConfiguration()
+    public function configuration()
     {
         return $this->configuration;
     }

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -120,28 +120,28 @@ final class FixtureFactory
         /** @var EntityDef $entityDefinition */
         $entityDefinition = $this->entityDefinitions[$name];
 
-        $configuration = $entityDefinition->getConfiguration();
+        $configuration = $entityDefinition->configuration();
 
         $extraFieldNames = \array_diff(
             \array_keys($fieldOverrides),
-            \array_keys($entityDefinition->getFieldDefinitions())
+            \array_keys($entityDefinition->fieldDefinitions())
         );
 
         if ([] !== $extraFieldNames) {
             throw Exception\InvalidFieldNames::notFoundIn(
-                $entityDefinition->getClassName(),
+                $entityDefinition->className(),
                 ...$extraFieldNames
             );
         }
 
         /** @var ORM\Mapping\ClassMetadata $classMetadata */
-        $classMetadata = $entityDefinition->getClassMetadata();
+        $classMetadata = $entityDefinition->classMetadata();
 
         $entity = $classMetadata->newInstance();
 
         $fieldValues = [];
 
-        foreach ($entityDefinition->getFieldDefinitions() as $fieldName => $fieldDefinition) {
+        foreach ($entityDefinition->fieldDefinitions() as $fieldName => $fieldDefinition) {
             $fieldValues[$fieldName] = \array_key_exists($fieldName, $fieldOverrides)
                 ? $fieldOverrides[$fieldName]
                 : $fieldDefinition($this);
@@ -262,7 +262,7 @@ final class FixtureFactory
 
     private function setField($entity, EntityDef $entityDefinition, $fieldName, $fieldValue): void
     {
-        $classMetadata = $entityDefinition->getClassMetadata();
+        $classMetadata = $entityDefinition->classMetadata();
 
         if ($classMetadata->isCollectionValuedAssociation($fieldName)) {
             $classMetadata->setFieldValue($entity, $fieldName, $this->createCollectionFrom($fieldValue));


### PR DESCRIPTION
This PR

* [x] renames methods in `EntityDef`

Follows #1.