### PR TITLE
Fix: Rename EntityDef to EntityDefinition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 * Marked all classes as `final` ([#33]), by [@localheinz]
 * Marked `EntityDef` as internal ([#49]), by [@localheinz]
 * Started throwing an `InvalidFieldNames` exception instead of a generic `Exception` when fields are referenced that are not present in the corresponding entity ([#87]), by [@localheinz]
+* Renamed `EntityDef` to `EntityDefinition` ([#91]), by [@localheinz]
 
 ### Fixed
 
@@ -43,5 +44,6 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 [#49]: https://github.com/ergebnis/factory-bot/pull/49
 [#79]: https://github.com/ergebnis/factory-bot/pull/79
 [#87]: https://github.com/ergebnis/factory-bot/pull/87
+[#91]: https://github.com/ergebnis/factory-bot/pull/91
 
 [@localheinz]: https://github.com/localheinz

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3,27 +3,27 @@ parameters:
 		-
 			message: "#^Parameter \\#2 \\.\\.\\.\\$fieldNames of static method Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidFieldNames\\:\\:notFoundIn\\(\\) expects array\\<int, string\\>, array\\<int, \\(int\\|string\\)\\> given\\.$#"
 			count: 1
-			path: src/EntityDef.php
+			path: src/EntityDefinition.php
 
 		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\EntityDef\\:\\:fieldDefinitions\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Ergebnis\\\\FactoryBot\\\\EntityDefinition\\:\\:fieldDefinitions\\(\\) has no return typehint specified\\.$#"
 			count: 1
-			path: src/EntityDef.php
+			path: src/EntityDefinition.php
 
 		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\EntityDef\\:\\:normalizeFieldDefinition\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method Ergebnis\\\\FactoryBot\\\\EntityDefinition\\:\\:normalizeFieldDefinition\\(\\) has no return typehint specified\\.$#"
 			count: 1
-			path: src/EntityDef.php
+			path: src/EntityDefinition.php
 
 		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\EntityDef\\:\\:normalizeFieldDefinition\\(\\) has parameter \\$fieldDefinition with no typehint specified\\.$#"
+			message: "#^Method Ergebnis\\\\FactoryBot\\\\EntityDefinition\\:\\:normalizeFieldDefinition\\(\\) has parameter \\$fieldDefinition with no typehint specified\\.$#"
 			count: 1
-			path: src/EntityDef.php
+			path: src/EntityDefinition.php
 
 		-
 			message: "#^Parameter \\#1 \\$object of function method_exists expects object\\|string, callable given\\.$#"
 			count: 1
-			path: src/EntityDef.php
+			path: src/EntityDefinition.php
 
 		-
 			message: "#^Class \"Ergebnis\\\\FactoryBot\\\\Exception\\\\EntityDefinitionUnavailable\" is not allowed to extend \"OutOfRangeException\"\\.$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="3.10.1@eeed5ecccc10131397f0eb7ee6da810c0be3a7fc">
-  <file src="src/EntityDef.php">
+  <file src="src/EntityDefinition.php">
     <InvalidArgument occurrences="1">
       <code>$fieldDefinition</code>
     </InvalidArgument>

--- a/src/EntityDefinition.php
+++ b/src/EntityDefinition.php
@@ -18,7 +18,7 @@ use Doctrine\ORM;
 /**
  * @internal
  */
-final class EntityDef
+final class EntityDefinition
 {
     /**
      * @var ORM\Mapping\ClassMetadata

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -26,7 +26,7 @@ final class FixtureFactory
     private $entityManager;
 
     /**
-     * @var array<string, EntityDef>
+     * @var array<string, EntityDefinition>
      */
     private $entityDefinitions = [];
 
@@ -84,7 +84,7 @@ final class FixtureFactory
             ));
         }
 
-        $this->entityDefinitions[$name] = new EntityDef(
+        $this->entityDefinitions[$name] = new EntityDefinition(
             $classMetadata,
             $fieldDefinitions,
             $configuration
@@ -117,7 +117,7 @@ final class FixtureFactory
             throw Exception\EntityDefinitionUnavailable::for($name);
         }
 
-        /** @var EntityDef $entityDefinition */
+        /** @var EntityDefinition $entityDefinition */
         $entityDefinition = $this->entityDefinitions[$name];
 
         $configuration = $entityDefinition->configuration();
@@ -253,14 +253,14 @@ final class FixtureFactory
     }
 
     /**
-     * @return EntityDef[]
+     * @return EntityDefinition[]
      */
     public function definitions(): array
     {
         return $this->entityDefinitions;
     }
 
-    private function setField($entity, EntityDef $entityDefinition, $fieldName, $fieldValue): void
+    private function setField($entity, EntityDefinition $entityDefinition, $fieldName, $fieldValue): void
     {
         $classMetadata = $entityDefinition->classMetadata();
 

--- a/test/AutoReview/SrcCodeTest.php
+++ b/test/AutoReview/SrcCodeTest.php
@@ -33,7 +33,7 @@ final class SrcCodeTest extends Framework\TestCase
             'Ergebnis\\FactoryBot\\',
             'Ergebnis\\FactoryBot\\Test\\Unit',
             [
-                FactoryBot\EntityDef::class,
+                FactoryBot\EntityDefinition::class,
                 FactoryBot\FieldDef::class,
             ]
         );

--- a/test/Unit/Definition/DefinitionsTest.php
+++ b/test/Unit/Definition/DefinitionsTest.php
@@ -28,7 +28,7 @@ use Faker\Generator;
  *
  * @covers \Ergebnis\FactoryBot\Definition\Definitions
  *
- * @uses \Ergebnis\FactoryBot\EntityDef
+ * @uses \Ergebnis\FactoryBot\EntityDefinition
  * @uses \Ergebnis\FactoryBot\Exception\InvalidDefinition
  * @uses \Ergebnis\FactoryBot\Exception\InvalidDirectory
  * @uses \Ergebnis\FactoryBot\FixtureFactory

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -23,7 +23,7 @@ use Ergebnis\Test\Util\Helper;
 /**
  * @internal
  *
- * @covers \Ergebnis\FactoryBot\EntityDef
+ * @covers \Ergebnis\FactoryBot\EntityDefinition
  * @covers \Ergebnis\FactoryBot\FieldDef
  * @covers \Ergebnis\FactoryBot\FixtureFactory
  *


### PR DESCRIPTION
This PR

* [x] renames `EntityDef` to `EntityDefinition`

Follows #1.