### PR TITLE
Fix: Rename FieldDef to FieldDefinition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 * Marked `EntityDef` as internal ([#49]), by [@localheinz]
 * Started throwing an `InvalidFieldNames` exception instead of a generic `Exception` when fields are referenced that are not present in the corresponding entity ([#87]), by [@localheinz]
 * Renamed `EntityDef` to `EntityDefinition` ([#91]), by [@localheinz]
+* Renamed `FieldDef` to `FieldDefinition` ([#92]), by [@localheinz]
 
 ### Fixed
 
@@ -45,5 +46,6 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 [#79]: https://github.com/ergebnis/factory-bot/pull/79
 [#87]: https://github.com/ergebnis/factory-bot/pull/87
 [#91]: https://github.com/ergebnis/factory-bot/pull/91
+[#92]: https://github.com/ergebnis/factory-bot/pull/92
 
 [@localheinz]: https://github.com/localheinz

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -33,12 +33,12 @@ parameters:
 		-
 			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
 			count: 2
-			path: src/FieldDef.php
+			path: src/FieldDefinition.php
 
 		-
 			message: "#^Parameter \\#2 \\$replace of function str_replace expects array\\|string, int given\\.$#"
 			count: 1
-			path: src/FieldDef.php
+			path: src/FieldDefinition.php
 
 		-
 			message: "#^Method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:get\\(\\) has no return typehint specified\\.$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -38,7 +38,7 @@
       <code>\method_exists($fieldDefinition, '__invoke')</code>
     </TypeDoesNotContainType>
   </file>
-  <file src="src/FieldDef.php">
+  <file src="src/FieldDefinition.php">
     <MissingClosureReturnType occurrences="3">
       <code>static function () use (&amp;$n, $funcOrString) {</code>
       <code>static function (FixtureFactory $factory) use ($name) {</code>

--- a/src/FieldDefinition.php
+++ b/src/FieldDefinition.php
@@ -16,7 +16,7 @@ namespace Ergebnis\FactoryBot;
 /**
  * Contains static methods to define fields as sequences, references etc.
  */
-final class FieldDef
+final class FieldDefinition
 {
     /**
      * Defines a field to be a string based on an incrementing integer.

--- a/test/AutoReview/SrcCodeTest.php
+++ b/test/AutoReview/SrcCodeTest.php
@@ -34,7 +34,7 @@ final class SrcCodeTest extends Framework\TestCase
             'Ergebnis\\FactoryBot\\Test\\Unit',
             [
                 FactoryBot\EntityDefinition::class,
-                FactoryBot\FieldDef::class,
+                FactoryBot\FieldDefinition::class,
             ]
         );
     }

--- a/test/Integration/FixtureFactoryTest.php
+++ b/test/Integration/FixtureFactoryTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\FactoryBot\Test\Integration;
 
-use Ergebnis\FactoryBot\FieldDef;
+use Ergebnis\FactoryBot\FieldDefinition;
 use Ergebnis\FactoryBot\FixtureFactory;
 use Ergebnis\FactoryBot\Test\Fixture;
 use Ergebnis\Test\Util\Helper;
@@ -82,13 +82,13 @@ final class FixtureFactoryTest extends AbstractTestCase
         $fixtureFactory = new FixtureFactory($entityManager);
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Avatar::class, [
-            'url' => FieldDef::sequence(static function () use ($faker): string {
+            'url' => FieldDefinition::sequence(static function () use ($faker): string {
                 return $faker->imageUrl();
             }),
         ]);
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\User::class, [
-            'avatar' => FieldDef::reference(Fixture\FixtureFactory\Entity\Avatar::class),
+            'avatar' => FieldDefinition::reference(Fixture\FixtureFactory\Entity\Avatar::class),
             'login' => $faker->userName,
         ]);
 

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -15,7 +15,7 @@ namespace Ergebnis\FactoryBot\Test\Unit;
 
 use Doctrine\ORM;
 use Ergebnis\FactoryBot\Exception;
-use Ergebnis\FactoryBot\FieldDef;
+use Ergebnis\FactoryBot\FieldDefinition;
 use Ergebnis\FactoryBot\FixtureFactory;
 use Ergebnis\FactoryBot\Test\Fixture;
 use Ergebnis\Test\Util\Helper;
@@ -24,7 +24,7 @@ use Ergebnis\Test\Util\Helper;
  * @internal
  *
  * @covers \Ergebnis\FactoryBot\EntityDefinition
- * @covers \Ergebnis\FactoryBot\FieldDef
+ * @covers \Ergebnis\FactoryBot\FieldDefinition
  * @covers \Ergebnis\FactoryBot\FixtureFactory
  *
  * @uses \Ergebnis\FactoryBot\Exception\EntityDefinitionUnavailable
@@ -154,7 +154,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         ]);
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\User::class, [
-            'avatar' => FieldDef::reference(Fixture\FixtureFactory\Entity\Avatar::class),
+            'avatar' => FieldDefinition::reference(Fixture\FixtureFactory\Entity\Avatar::class),
         ]);
 
         $user = $fixtureFactory->get(Fixture\FixtureFactory\Entity\User::class);
@@ -329,7 +329,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Organization::class);
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class, [
-            'organization' => FieldDef::reference(Fixture\FixtureFactory\Entity\Organization::class),
+            'organization' => FieldDefinition::reference(Fixture\FixtureFactory\Entity\Organization::class),
         ]);
 
         /** @var Fixture\FixtureFactory\Entity\Repository $repositoryOne */
@@ -388,7 +388,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Organization::class);
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class, [
-            'organization' => FieldDef::reference(Fixture\FixtureFactory\Entity\Organization::class),
+            'organization' => FieldDefinition::reference(Fixture\FixtureFactory\Entity\Organization::class),
         ]);
 
         /** @var Fixture\FixtureFactory\Entity\Repository $repository */
@@ -404,7 +404,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Project::class, [
-            'repository' => FieldDef::reference(Fixture\FixtureFactory\Entity\Repository::class),
+            'repository' => FieldDefinition::reference(Fixture\FixtureFactory\Entity\Repository::class),
         ]);
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class);
@@ -420,7 +420,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Organization::class, [
-            'repositories' => FieldDef::references(Fixture\FixtureFactory\Entity\Repository::class),
+            'repositories' => FieldDefinition::references(Fixture\FixtureFactory\Entity\Repository::class),
         ]);
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class, [
@@ -443,7 +443,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Organization::class, [
-            'repositories' => FieldDef::references(Fixture\FixtureFactory\Entity\Repository::class),
+            'repositories' => FieldDefinition::references(Fixture\FixtureFactory\Entity\Repository::class),
         ]);
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class, [
@@ -466,7 +466,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class, [
-            'template' => FieldDef::references(Fixture\FixtureFactory\Entity\Repository::class),
+            'template' => FieldDefinition::references(Fixture\FixtureFactory\Entity\Repository::class),
         ]);
 
         /** @var Fixture\FixtureFactory\Entity\Repository $repository */
@@ -585,7 +585,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Organization::class, [
-            'repositories' => FieldDef::references(Fixture\FixtureFactory\Entity\Repository::class),
+            'repositories' => FieldDefinition::references(Fixture\FixtureFactory\Entity\Repository::class),
         ]);
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class, [
@@ -611,7 +611,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Organization::class);
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class, [
-            'organization' => FieldDef::reference(Fixture\FixtureFactory\Entity\Organization::class),
+            'organization' => FieldDefinition::reference(Fixture\FixtureFactory\Entity\Organization::class),
         ]);
 
         /** @var Fixture\FixtureFactory\Entity\Organization $organization */
@@ -709,7 +709,7 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class, [
             'name' => self::faker()->word,
-            'organization' => FieldDef::reference(Fixture\FixtureFactory\Entity\Organization::class),
+            'organization' => FieldDefinition::reference(Fixture\FixtureFactory\Entity\Organization::class),
         ]);
 
         /** @var Fixture\FixtureFactory\Entity\Repository $repositoryOne */
@@ -733,11 +733,11 @@ final class FixtureFactoryTest extends AbstractTestCase
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Organization::class);
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class, [
-            'organization' => FieldDef::reference(Fixture\FixtureFactory\Entity\Organization::class),
+            'organization' => FieldDefinition::reference(Fixture\FixtureFactory\Entity\Organization::class),
         ]);
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Project::class, [
-            'repository' => FieldDef::reference(Fixture\FixtureFactory\Entity\Repository::class),
+            'repository' => FieldDefinition::reference(Fixture\FixtureFactory\Entity\Repository::class),
         ]);
 
         $project = $fixtureFactory->get(Fixture\FixtureFactory\Entity\Project::class);
@@ -761,11 +761,11 @@ final class FixtureFactoryTest extends AbstractTestCase
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Organization::class);
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class, [
-            'organization' => FieldDef::reference(Fixture\FixtureFactory\Entity\Organization::class),
+            'organization' => FieldDefinition::reference(Fixture\FixtureFactory\Entity\Organization::class),
         ]);
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Project::class, [
-            'repository' => FieldDef::reference(Fixture\FixtureFactory\Entity\Repository::class),
+            'repository' => FieldDefinition::reference(Fixture\FixtureFactory\Entity\Repository::class),
         ]);
 
         $fixtureFactory->getAsSingleton(Fixture\FixtureFactory\Entity\Organization::class);
@@ -792,7 +792,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Organization::class, [
-            'name' => FieldDef::sequence(static function (int $i): string {
+            'name' => FieldDefinition::sequence(static function (int $i): string {
                 return \sprintf(
                     'alpha-%d',
                     $i
@@ -823,7 +823,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Organization::class, [
-            'name' => FieldDef::sequence('beta-%d'),
+            'name' => FieldDefinition::sequence('beta-%d'),
         ]);
 
         /** @var Fixture\FixtureFactory\Entity\Organization $organizationOne */
@@ -849,7 +849,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Organization::class, [
-            'name' => FieldDef::sequence('gamma-'),
+            'name' => FieldDefinition::sequence('gamma-'),
         ]);
 
         /** @var Fixture\FixtureFactory\Entity\Organization $organizationOne */


### PR DESCRIPTION
This PR

* [x] renames `FieldDef` to `FieldDefinition`

Follows #1.