### PR TITLE
Fix: Methods can be static

### DIFF
--- a/src/EntityDefinition.php
+++ b/src/EntityDefinition.php
@@ -67,7 +67,7 @@ final class EntityDefinition
         }
 
         foreach ($fieldDefinitions as $fieldName => $fieldDefinition) {
-            $this->fieldDefinitions[$fieldName] = $this->normalizeFieldDefinition($fieldDefinition);
+            $this->fieldDefinitions[$fieldName] = self::normalizeFieldDefinition($fieldDefinition);
         }
 
         $defaultEntity = $this->classMetadata->newInstance();
@@ -138,7 +138,7 @@ final class EntityDefinition
      *
      * @return \Closure
      */
-    private function normalizeFieldDefinition($fieldDefinition): \Closure
+    private static function normalizeFieldDefinition($fieldDefinition): \Closure
     {
         if (\is_callable($fieldDefinition)) {
             if (\method_exists($fieldDefinition, '__invoke')) {

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -267,7 +267,7 @@ final class FixtureFactory
         $classMetadata = $entityDefinition->classMetadata();
 
         if ($classMetadata->isCollectionValuedAssociation($fieldName)) {
-            $classMetadata->setFieldValue($entity, $fieldName, $this->createCollectionFrom($fieldValue));
+            $classMetadata->setFieldValue($entity, $fieldName, self::createCollectionFrom($fieldValue));
         } else {
             $classMetadata->setFieldValue($entity, $fieldName, $fieldValue);
 
@@ -277,7 +277,7 @@ final class FixtureFactory
         }
     }
 
-    private function createCollectionFrom($array = []): Common\Collections\ArrayCollection
+    private static function createCollectionFrom($array = []): Common\Collections\ArrayCollection
     {
         if (\is_array($array)) {
             return new Common\Collections\ArrayCollection($array);


### PR DESCRIPTION
This PR

* [x] turns private instance methods into `static` methods where possible

Follows #1.