### PR TITLE
Fix: Move operations from EntityDefinition to FixtureFactory

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,16 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Parameter \\#1 \\$object of function method_exists expects object\\|string, callable given\\.$#"
-			count: 1
-			path: src/EntityDefinition.php
-
-		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\EntityDefinition\\:\\:normalizeFieldDefinition\\(\\) should return Closure but returns object\\.$#"
-			count: 1
-			path: src/EntityDefinition.php
-
-		-
 			message: "#^Class \"Ergebnis\\\\FactoryBot\\\\Exception\\\\EntityDefinitionUnavailable\" is not allowed to extend \"OutOfRangeException\"\\.$#"
 			count: 1
 			path: src/Exception/EntityDefinitionUnavailable.php
@@ -42,6 +32,16 @@ parameters:
 
 		-
 			message: "#^Method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:updateCollectionSideOfAssocation\\(\\) has parameter \\$fieldValue with no typehint specified\\.$#"
+			count: 1
+			path: src/FixtureFactory.php
+
+		-
+			message: "#^Parameter \\#1 \\$object of function method_exists expects object\\|string, callable given\\.$#"
+			count: 1
+			path: src/FixtureFactory.php
+
+		-
+			message: "#^Method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:normalizeFieldDefinition\\(\\) should return callable\\(\\)\\: mixed but returns object\\.$#"
 			count: 1
 			path: src/FixtureFactory.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,29 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="3.10.1@eeed5ecccc10131397f0eb7ee6da810c0be3a7fc">
-  <file src="src/EntityDefinition.php">
-    <InvalidArgument occurrences="1">
-      <code>$fieldDefinition</code>
-    </InvalidArgument>
-    <MissingClosureReturnType occurrences="4">
-      <code>static function () {</code>
-      <code>static function () use ($defaultFieldValue) {</code>
-      <code>static function () use ($fieldDefinition) {</code>
-      <code>static function () use ($fieldDefinition) {</code>
-    </MissingClosureReturnType>
-    <MixedAssignment occurrences="2">
-      <code>$fieldDefinition</code>
-      <code>$defaultFieldValue</code>
-    </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>\Closure</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$fieldDefinition</code>
-    </MixedReturnStatement>
-    <TypeDoesNotContainType occurrences="1">
-      <code>\method_exists($fieldDefinition, '__invoke')</code>
-    </TypeDoesNotContainType>
-  </file>
   <file src="src/FieldDefinition.php">
     <MissingClosureReturnType occurrences="1">
       <code>static function () use (&amp;$n, $funcOrString) {</code>
@@ -39,6 +15,15 @@
     </MixedOperand>
   </file>
   <file src="src/FixtureFactory.php">
+    <InvalidArgument occurrences="1">
+      <code>$fieldDefinition</code>
+    </InvalidArgument>
+    <MissingClosureReturnType occurrences="4">
+      <code>static function () {</code>
+      <code>static function () use ($defaultFieldValue) {</code>
+      <code>static function () use ($fieldDefinition) {</code>
+      <code>static function () use ($fieldDefinition) {</code>
+    </MissingClosureReturnType>
     <MissingParamType occurrences="3">
       <code>$fieldValue</code>
       <code>$array</code>
@@ -54,12 +39,22 @@
       <code>$configuration</code>
       <code>$fieldOverrides</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment occurrences="5">
+      <code>$defaultFieldValue</code>
       <code>$fieldValues[$fieldName]</code>
       <code>$fieldValue</code>
       <code>$inversedBy</code>
       <code>$collection</code>
     </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>callable</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$fieldDefinition</code>
+    </MixedReturnStatement>
+    <TypeDoesNotContainType occurrences="1">
+      <code>\method_exists($fieldDefinition, '__invoke')</code>
+    </TypeDoesNotContainType>
   </file>
   <file src="test/Fixture/FixtureFactory/Entity/Organization.php">
     <PropertyNotSetInConstructor occurrences="1">
@@ -86,6 +81,11 @@
     <InternalMethod occurrences="1">
       <code>addToAssertionCount</code>
     </InternalMethod>
+  </file>
+  <file src="test/Unit/EntityDefinitionTest.php">
+    <MissingClosureParamType occurrences="1">
+      <code>$entity</code>
+    </MissingClosureParamType>
   </file>
   <file src="test/Unit/FixtureFactoryTest.php">
     <MixedArgument occurrences="3">

--- a/test/AutoReview/SrcCodeTest.php
+++ b/test/AutoReview/SrcCodeTest.php
@@ -33,7 +33,6 @@ final class SrcCodeTest extends Framework\TestCase
             'Ergebnis\\FactoryBot\\',
             'Ergebnis\\FactoryBot\\Test\\Unit',
             [
-                FactoryBot\EntityDefinition::class,
                 FactoryBot\FieldDefinition::class,
             ]
         );

--- a/test/Unit/EntityDefinitionTest.php
+++ b/test/Unit/EntityDefinitionTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/factory-bot
+ */
+
+namespace Ergebnis\FactoryBot\Test\Unit;
+
+use Doctrine\ORM;
+use Ergebnis\FactoryBot\EntityDefinition;
+use Ergebnis\Test\Util\Helper;
+use PHPUnit\Framework;
+
+/**
+ * @internal
+ *
+ * @covers \Ergebnis\FactoryBot\EntityDefinition
+ */
+final class EntityDefinitionTest extends Framework\TestCase
+{
+    use Helper;
+
+    public function testConstructorSetsValues(): void
+    {
+        $className = self::faker()->word;
+
+        $classMetadata = $this->prophesize(ORM\Mapping\ClassMetadata::class);
+
+        $classMetadata
+            ->getName()
+            ->willReturn($className);
+
+        $fieldDefinitions = [
+            'foo' => static function (): string {
+                return 'bar';
+            },
+            'bar' => static function (): string {
+                return 'baz';
+            },
+        ];
+
+        $configuration = [
+            'afterCreate' => static function ($entity, array $fieldValues): void {
+                // intentionally left blank
+            },
+        ];
+
+        $entityDefiniton = new EntityDefinition(
+            $classMetadata->reveal(),
+            $fieldDefinitions,
+            $configuration
+        );
+
+        self::assertSame($classMetadata->reveal(), $entityDefiniton->classMetadata());
+        self::assertSame($configuration, $entityDefiniton->configuration());
+        self::assertSame($fieldDefinitions, $entityDefiniton->fieldDefinitions());
+        self::assertSame($className, $entityDefiniton->className());
+    }
+}

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -23,10 +23,10 @@ use Ergebnis\Test\Util\Helper;
 /**
  * @internal
  *
- * @covers \Ergebnis\FactoryBot\EntityDefinition
  * @covers \Ergebnis\FactoryBot\FieldDefinition
  * @covers \Ergebnis\FactoryBot\FixtureFactory
  *
+ * @uses \Ergebnis\FactoryBot\EntityDefinition
  * @uses \Ergebnis\FactoryBot\Exception\EntityDefinitionUnavailable
  * @uses \Ergebnis\FactoryBot\Exception\InvalidFieldNames
  */


### PR DESCRIPTION
This PR

* [x] moves operations from `EntityDefinition` to `FixtureFactory`
