### PR TITLE
Enhancement: Accept closure instead of array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 * Started throwing an `InvalidFieldNames` exception instead of a generic `Exception` when fields are referenced that are not present in the corresponding entity ([#87]), by [@localheinz]
 * Renamed `EntityDef` to `EntityDefinition` ([#91]), by [@localheinz]
 * Renamed `FieldDef` to `FieldDefinition` ([#92]), by [@localheinz]
+* Turned `$configuration` parameter of `FixtureFactory::defineEntity()` into `$afterCreate`, a `Closure` that will be invoked after object construction ([#101]), by [@localheinz]
 
 ### Fixed
 
@@ -47,5 +48,6 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 [#87]: https://github.com/ergebnis/factory-bot/pull/87
 [#91]: https://github.com/ergebnis/factory-bot/pull/91
 [#92]: https://github.com/ergebnis/factory-bot/pull/92
+[#101]: https://github.com/ergebnis/factory-bot/pull/101
 
 [@localheinz]: https://github.com/localheinz

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,6 +16,16 @@ parameters:
 			path: src/FieldDefinition.php
 
 		-
+			message: "#^Method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:defineEntity\\(\\) has parameter \\$afterCreate with a nullable type declaration\\.$#"
+			count: 1
+			path: src/FixtureFactory.php
+
+		-
+			message: "#^Method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:defineEntity\\(\\) has parameter \\$afterCreate with null as default value\\.$#"
+			count: 1
+			path: src/FixtureFactory.php
+
+		-
 			message: "#^Method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:setField\\(\\) has parameter \\$fieldValue with no typehint specified\\.$#"
 			count: 1
 			path: src/FixtureFactory.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -34,9 +34,8 @@
       <code>$fieldValue</code>
       <code>$inversedBy</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="3">
+    <MixedArgumentTypeCoercion occurrences="2">
       <code>$fieldDefinitions</code>
-      <code>$configuration</code>
       <code>$fieldOverrides</code>
     </MixedArgumentTypeCoercion>
     <MixedAssignment occurrences="5">

--- a/src/EntityDefinition.php
+++ b/src/EntityDefinition.php
@@ -24,18 +24,18 @@ final class EntityDefinition
 
     private $fieldDefinitions;
 
-    private $configuration;
+    private $afterCreate;
 
     /**
      * @param ORM\Mapping\ClassMetadata $classMetadata
      * @param array<string, callable>   $fieldDefinitions
-     * @param array<string, callable>   $configuration
+     * @param \Closure                  $afterCreate
      */
-    public function __construct(ORM\Mapping\ClassMetadata $classMetadata, array $fieldDefinitions, array $configuration)
+    public function __construct(ORM\Mapping\ClassMetadata $classMetadata, array $fieldDefinitions, \Closure $afterCreate)
     {
         $this->classMetadata = $classMetadata;
         $this->fieldDefinitions = $fieldDefinitions;
-        $this->configuration = $configuration;
+        $this->afterCreate = $afterCreate;
     }
 
     /**
@@ -58,13 +58,8 @@ final class EntityDefinition
         return $this->fieldDefinitions;
     }
 
-    /**
-     * Returns the extra configuration array of the entity definition.
-     *
-     * @return array<string, callable>
-     */
-    public function configuration(): array
+    public function afterCreate(): \Closure
     {
-        return $this->configuration;
+        return $this->afterCreate;
     }
 }

--- a/test/Unit/EntityDefinitionTest.php
+++ b/test/Unit/EntityDefinitionTest.php
@@ -40,20 +40,18 @@ final class EntityDefinitionTest extends Framework\TestCase
             },
         ];
 
-        $configuration = [
-            'afterCreate' => static function ($entity, array $fieldValues): void {
-                // intentionally left blank
-            },
-        ];
+        $afterCreate = static function ($entity, array $fieldValues): void {
+            // intentionally left blank
+        };
 
         $entityDefiniton = new EntityDefinition(
             $classMetadata->reveal(),
             $fieldDefinitions,
-            $configuration
+            $afterCreate
         );
 
         self::assertSame($classMetadata->reveal(), $entityDefiniton->classMetadata());
-        self::assertSame($configuration, $entityDefiniton->configuration());
         self::assertSame($fieldDefinitions, $entityDefiniton->fieldDefinitions());
+        self::assertSame($afterCreate, $entityDefiniton->afterCreate());
     }
 }

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -627,7 +627,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         self::assertContains($repositoryTwo, $organization->repositories());
     }
 
-    public function testCanInvokeACallbackAfterObjectConstruction(): void
+    public function testDefineEntityAcceptsClosureThatWillBeInvokedAfterEntityCreation(): void
     {
         $name = self::faker()->word;
 
@@ -638,17 +638,15 @@ final class FixtureFactoryTest extends AbstractTestCase
             [
                 'name' => $name,
             ],
-            [
-                'afterCreate' => static function (Fixture\FixtureFactory\Entity\Organization $organization, array $fieldValues): void {
-                    $name = \sprintf(
-                        '%s-%s',
-                        $organization->name(),
-                        $fieldValues['name']
-                    );
+            static function (Fixture\FixtureFactory\Entity\Organization $organization, array $fieldValues): void {
+                $name = \sprintf(
+                    '%s-%s',
+                    $organization->name(),
+                    $fieldValues['name']
+                );
 
-                    $organization->renameTo($name);
-                },
-            ]
+                $organization->renameTo($name);
+            }
         );
 
         /** @var Fixture\FixtureFactory\Entity\Organization $organization */
@@ -674,14 +672,12 @@ final class FixtureFactoryTest extends AbstractTestCase
             [
                 'name' => $faker->word,
             ],
-            [
-                'afterCreate' => static function (Fixture\FixtureFactory\Entity\Organization $organization, array $fieldValues): void {
-                    $organization->__construct(\sprintf(
-                        '%s-advanced',
-                        $fieldValues['name']
-                    ));
-                },
-            ]
+            static function (Fixture\FixtureFactory\Entity\Organization $organization, array $fieldValues): void {
+                $organization->__construct(\sprintf(
+                    '%s-advanced',
+                    $fieldValues['name']
+                ));
+            }
         );
 
         $name = $faker->word;


### PR DESCRIPTION
This PR

* [x] turns the `$configuration` parameter of `FixtureFactory::defineEntity()` into `$afterCreate`, an optional closure that is invoked after object creation

Follows #1.

💁‍♂ The `$configuration` only ever handled an `afterCreate` key so far anyway.
