### PR TITLE
Enhancement: Throw InvalidCount exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 * Renamed `EntityDef` to `EntityDefinition` ([#91]), by [@localheinz]
 * Renamed `FieldDef` to `FieldDefinition` ([#92]), by [@localheinz]
 * Turned `$configuration` parameter of `FixtureFactory::defineEntity()` into `$afterCreate`, a `Closure` that will be invoked after object construction ([#101]), by [@localheinz]
+* Started throwing an `InvalidCount` exception instead of a generic `Exception` when an invalid number of entities are requested ([#105]), by [@localheinz]
 
 ### Fixed
 
@@ -49,5 +50,6 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 [#91]: https://github.com/ergebnis/factory-bot/pull/91
 [#92]: https://github.com/ergebnis/factory-bot/pull/92
 [#101]: https://github.com/ergebnis/factory-bot/pull/101
+[#105]: https://github.com/ergebnis/factory-bot/pull/105
 
 [@localheinz]: https://github.com/localheinz

--- a/src/Exception/InvalidCount.php
+++ b/src/Exception/InvalidCount.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/factory-bot
+ */
+
+namespace Ergebnis\FactoryBot\Exception;
+
+final class InvalidCount extends \InvalidArgumentException implements Exception
+{
+    public static function notGreaterThanorEqualTo(int $minimumCount, int $count): self
+    {
+        return new self(\sprintf(
+            'Count needs to be greater than or equal to %d, but %d is not.',
+            $minimumCount,
+            $count
+        ));
+    }
+}

--- a/src/FieldDefinition.php
+++ b/src/FieldDefinition.php
@@ -89,23 +89,28 @@ final class FieldDefinition
      * entity. If a singleton has been defined, a collection with a single instance will be returned.
      *
      * @param string $className
-     * @param int    $numberOfInstances
+     * @param int    $count
      *
-     * @throws \InvalidArgumentException
+     * @throws Exception\InvalidCount
      *
      * @return \Closure
      */
-    public static function references(string $className, int $numberOfInstances = 1): \Closure
+    public static function references(string $className, int $count = 1): \Closure
     {
-        if (1 > $numberOfInstances) {
-            throw new \InvalidArgumentException('Can only get >= 1 instances');
+        $minimumCount = 1;
+
+        if ($minimumCount > $count) {
+            throw Exception\InvalidCount::notGreaterThanorEqualTo(
+                $minimumCount,
+                $count
+            );
         }
 
-        return static function (FixtureFactory $factory) use ($className, $numberOfInstances): array {
+        return static function (FixtureFactory $factory) use ($className, $count): array {
             return $factory->getList(
                 $className,
                 [],
-                $numberOfInstances
+                $count
             );
         };
     }

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -230,25 +230,30 @@ final class FixtureFactory
      *
      * @param string $className
      * @param array  $fieldOverrides
-     * @param int    $numberOfInstances
+     * @param int    $count
      *
-     * @throws \InvalidArgumentException
+     * @throws Exception\InvalidCount
      *
      * @return object[]
      */
-    public function getList(string $className, array $fieldOverrides = [], int $numberOfInstances = 1): array
+    public function getList(string $className, array $fieldOverrides = [], int $count = 1): array
     {
-        if (1 > $numberOfInstances) {
-            throw new \InvalidArgumentException('Can only get >= 1 instances');
+        $minimumCount = 1;
+
+        if ($minimumCount > $count) {
+            throw Exception\InvalidCount::notGreaterThanorEqualTo(
+                $minimumCount,
+                $count
+            );
         }
 
-        if (1 < $numberOfInstances && \array_key_exists($className, $this->singletons)) {
-            $numberOfInstances = 1;
+        if (1 < $count && \array_key_exists($className, $this->singletons)) {
+            $count = 1;
         }
 
         $instances = [];
 
-        for ($i = 0; $i < $numberOfInstances; ++$i) {
+        for ($i = 0; $i < $count; ++$i) {
             $instances[] = $this->get($className, $fieldOverrides);
         }
 

--- a/test/DataProvider/NumberProvider.php
+++ b/test/DataProvider/NumberProvider.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/factory-bot
+ */
+
+namespace Ergebnis\FactoryBot\Test\DataProvider;
+
+use Ergebnis\Test\Util\Helper;
+
+final class NumberProvider
+{
+    use Helper;
+
+    /**
+     * @return \Generator<string, array<int>>
+     */
+    public function intLessThanOne(): \Generator
+    {
+        $values = [
+            'int-zero' => 0,
+            'int-minus-one' => -1,
+            'int-less-than-minus-one' => -1 * self::faker()->numberBetween(2),
+        ];
+
+        foreach ($values as $key => $value) {
+            yield $key => [
+                $value,
+            ];
+        }
+    }
+
+    /**
+     * @return \Generator<string, array<int>>
+     */
+    public function intBetweenOneAndFive(): \Generator
+    {
+        foreach (\range(1, 5) as $value) {
+            yield (string) $value => [
+                $value,
+            ];
+        }
+    }
+}

--- a/test/Unit/Exception/InvalidCountTest.php
+++ b/test/Unit/Exception/InvalidCountTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/factory-bot
+ */
+
+namespace Ergebnis\FactoryBot\Test\Unit\Exception;
+
+use Ergebnis\FactoryBot\Exception;
+use Ergebnis\Test\Util\Helper;
+use PHPUnit\Framework;
+
+/**
+ * @internal
+ *
+ * @covers \Ergebnis\FactoryBot\Exception\InvalidCount
+ */
+final class InvalidCountTest extends Framework\TestCase
+{
+    use Helper;
+
+    public function testNotGreaterThanOrEqualToReturnsException(): void
+    {
+        $faker = self::faker();
+
+        $minimumCount = $faker->numberBetween(1, 1000);
+        $count = $minimumCount - $faker->numberBetween(1);
+
+        $exception = Exception\InvalidCount::notGreaterThanorEqualTo(
+            $minimumCount,
+            $count
+        );
+
+        $message = \sprintf(
+            'Count needs to be greater than or equal to %d, but %d is not.',
+            $minimumCount,
+            $count
+        );
+
+        self::assertSame($message, $exception->getMessage());
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/test/Unit/FieldDefinitionTest.php
+++ b/test/Unit/FieldDefinitionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/factory-bot
+ */
+
+namespace Ergebnis\FactoryBot\Test\Unit;
+
+use Ergebnis\FactoryBot\Exception;
+use Ergebnis\FactoryBot\FieldDefinition;
+use Ergebnis\Test\Util\Helper;
+use PHPUnit\Framework;
+
+/**
+ * @internal
+ *
+ * @covers \Ergebnis\FactoryBot\FieldDefinition
+ *
+ * @uses \Ergebnis\FactoryBot\Exception\InvalidCount
+ */
+final class FieldDefinitionTest extends Framework\TestCase
+{
+    use Helper;
+
+    /**
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intLessThanOne()
+     *
+     * @param int $count
+     */
+    public function testReferencesThrowsInvalidCountExceptionWhenCountIsLessThanOne(int $count): void
+    {
+        $className = self::class;
+
+        $this->expectException(Exception\InvalidCount::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Count needs to be greater than or equal to 1, but %d is not.',
+            $count
+        ));
+
+        FieldDefinition::references(
+            $className,
+            $count
+        );
+    }
+}


### PR DESCRIPTION
This PR

* [x] throws an `InvalidCount` exception when an invalid number of entities is requested

Follows #87.