### PR TITLE
Enhancement: Throw EntityDefinitionAlreadyRegistered exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 * Renamed `FieldDef` to `FieldDefinition` ([#92]), by [@localheinz]
 * Turned `$configuration` parameter of `FixtureFactory::defineEntity()` into `$afterCreate`, a `Closure` that will be invoked after object construction ([#101]), by [@localheinz]
 * Started throwing an `InvalidCount` exception instead of a generic `Exception` when an invalid number of entities are requested ([#105]), by [@localheinz]
+* Started throwing an `EntityDefinitionAlreadyRegistered` exception instead of a generic `Exception` when an entity definition for a class name has already been registered ([#106]), by [@localheinz]
 
 ### Fixed
 
@@ -51,5 +52,6 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 [#92]: https://github.com/ergebnis/factory-bot/pull/92
 [#101]: https://github.com/ergebnis/factory-bot/pull/101
 [#105]: https://github.com/ergebnis/factory-bot/pull/105
+[#106]: https://github.com/ergebnis/factory-bot/pull/106
 
 [@localheinz]: https://github.com/localheinz

--- a/src/Exception/EntityDefinitionAlreadyRegistered.php
+++ b/src/Exception/EntityDefinitionAlreadyRegistered.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/factory-bot
+ */
+
+namespace Ergebnis\FactoryBot\Exception;
+
+final class EntityDefinitionAlreadyRegistered extends \RuntimeException implements Exception
+{
+    public static function for(string $className): self
+    {
+        return new self(\sprintf(
+            'An entity definition for class name "%s" has already been registered.',
+            $className
+        ));
+    }
+}

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -54,6 +54,7 @@ final class FixtureFactory
      * @param array    $fieldDefinitions
      * @param \Closure $afterCreate
      *
+     * @throws Exception\EntityDefinitionAlreadyRegistered
      * @throws Exception\InvalidFieldNames
      * @throws \Exception
      *
@@ -62,10 +63,7 @@ final class FixtureFactory
     public function defineEntity(string $className, array $fieldDefinitions = [], ?\Closure $afterCreate = null)
     {
         if (\array_key_exists($className, $this->entityDefinitions)) {
-            throw new \Exception(\sprintf(
-                "Entity '%s' already defined in fixture factory",
-                $className
-            ));
+            throw Exception\EntityDefinitionAlreadyRegistered::for($className);
         }
 
         if (!\class_exists($className, true)) {

--- a/test/Unit/Exception/EntityDefinitionAlreadyRegisteredTest.php
+++ b/test/Unit/Exception/EntityDefinitionAlreadyRegisteredTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/factory-bot
+ */
+
+namespace Ergebnis\FactoryBot\Test\Unit\Exception;
+
+use Ergebnis\FactoryBot\Exception;
+use PHPUnit\Framework;
+
+/**
+ * @internal
+ *
+ * @covers \Ergebnis\FactoryBot\Exception\EntityDefinitionAlreadyRegistered
+ */
+final class EntityDefinitionAlreadyRegisteredTest extends Framework\TestCase
+{
+    public function testForReturnsException(): void
+    {
+        $className = self::class;
+
+        $exception = Exception\EntityDefinitionAlreadyRegistered::for($className);
+
+        $message = \sprintf(
+            'An entity definition for class name "%s" has already been registered.',
+            $className
+        );
+
+        self::assertSame($message, $exception->getMessage());
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -27,6 +27,7 @@ use Ergebnis\Test\Util\Helper;
  * @covers \Ergebnis\FactoryBot\FixtureFactory
  *
  * @uses \Ergebnis\FactoryBot\EntityDefinition
+ * @uses \Ergebnis\FactoryBot\Exception\EntityDefinitionAlreadyRegistered
  * @uses \Ergebnis\FactoryBot\Exception\EntityDefinitionUnavailable
  * @uses \Ergebnis\FactoryBot\Exception\InvalidCount
  * @uses \Ergebnis\FactoryBot\Exception\InvalidFieldNames
@@ -41,9 +42,9 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Organization::class);
 
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception\EntityDefinitionAlreadyRegistered::class);
         $this->expectExceptionMessage(\sprintf(
-            'Entity \'%s\' already defined in fixture factory',
+            'An entity definition for class name "%s" has already been registered.',
             Fixture\FixtureFactory\Entity\Organization::class
         ));
 


### PR DESCRIPTION
This PR

* [x] throws an `EntityDefinitionAlreadyRegistered` exception when an entity definition has already been registered for a class name

Follows #86.