### PR TITLE
Fix: Extend RuntimeException

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,11 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Class \"Ergebnis\\\\FactoryBot\\\\Exception\\\\EntityDefinitionUnavailable\" is not allowed to extend \"OutOfRangeException\"\\.$#"
-			count: 1
-			path: src/Exception/EntityDefinitionUnavailable.php
-
-		-
 			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
 			count: 2
 			path: src/FieldDefinition.php
@@ -99,11 +94,6 @@ parameters:
 			message: "#^Method Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\User\\:\\:id\\(\\) has a nullable return type declaration\\.$#"
 			count: 1
 			path: test/Fixture/FixtureFactory/Entity/User.php
-
-		-
-			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'OutOfRangeException' and Ergebnis\\\\FactoryBot\\\\Exception\\\\EntityDefinitionUnavailable will always evaluate to true\\.$#"
-			count: 1
-			path: test/Unit/Exception/EntityDefinitionUnavailableTest.php
 
 		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot…' and Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\Repository will always evaluate to true\\.$#"

--- a/src/Exception/EntityDefinitionUnavailable.php
+++ b/src/Exception/EntityDefinitionUnavailable.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\FactoryBot\Exception;
 
-final class EntityDefinitionUnavailable extends \OutOfRangeException implements Exception
+final class EntityDefinitionUnavailable extends \RuntimeException implements Exception
 {
     public static function for(string $className): self
     {

--- a/test/Unit/Exception/EntityDefinitionUnavailableTest.php
+++ b/test/Unit/Exception/EntityDefinitionUnavailableTest.php
@@ -29,8 +29,6 @@ final class EntityDefinitionUnavailableTest extends Framework\TestCase
 
         $exception = Exception\EntityDefinitionUnavailable::for($className);
 
-        self::assertInstanceOf(\OutOfRangeException::class, $exception);
-
         $message = \sprintf(
             'An entity definition for class name "%s" is not available.',
             $className


### PR DESCRIPTION
This PR

* [x] lets `EntityDefinitionUnavailable` extend from `RuntimeException`

Follows #6.