### PR TITLE
Fix: Rename fixture namespaces

### DIFF
--- a/test/Fixture/Definition/Definitions/DoesNotImplementDefinition/RepositoryDefinition.php
+++ b/test/Fixture/Definition/Definitions/DoesNotImplementDefinition/RepositoryDefinition.php
@@ -11,16 +11,12 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Fixture\Definition\Definitions\Acceptable;
+namespace Ergebnis\FactoryBot\Test\Fixture\Definition\Definitions\DoesNotImplementDefinition;
 
-use Ergebnis\FactoryBot\Definition\Definition;
 use Ergebnis\FactoryBot\FixtureFactory;
 use Ergebnis\FactoryBot\Test\Fixture;
 
-/**
- * Is acceptable as it implements the interface.
- */
-final class RepositoryDefinition implements Definition
+final class RepositoryDefinition
 {
     public function accept(FixtureFactory $factory): void
     {

--- a/test/Fixture/Definition/Definitions/ImplementsDefinition/RepositoryDefinition.php
+++ b/test/Fixture/Definition/Definitions/ImplementsDefinition/RepositoryDefinition.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Fixture\Definition\Definitions\FakerAware;
+namespace Ergebnis\FactoryBot\Test\Fixture\Definition\Definitions\ImplementsDefinition;
 
 use Ergebnis\FactoryBot\Definition\Definition;
 use Ergebnis\FactoryBot\FixtureFactory;

--- a/test/Fixture/Definition/Definitions/ImplementsDefinitionButHasPrivateConstructor/RepositoryDefinition.php
+++ b/test/Fixture/Definition/Definitions/ImplementsDefinitionButHasPrivateConstructor/RepositoryDefinition.php
@@ -11,18 +11,19 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Fixture\Definition\Definitions\IsAbstract;
+namespace Ergebnis\FactoryBot\Test\Fixture\Definition\Definitions\ImplementsDefinitionButHasPrivateConstructor;
 
 use Ergebnis\FactoryBot\Definition\Definition;
 use Ergebnis\FactoryBot\FixtureFactory;
 use Ergebnis\FactoryBot\Test\Fixture;
 
-/**
- * Is not acceptable as it is abstract.
- */
-abstract class RepositoryDefinition implements Definition
+final class RepositoryDefinition implements Definition
 {
-    final public function accept(FixtureFactory $factory): void
+    private function __construct()
+    {
+    }
+
+    public function accept(FixtureFactory $factory): void
     {
         $factory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class);
     }

--- a/test/Fixture/Definition/Definitions/ImplementsDefinitionButIsAbstract/RepositoryDefinition.php
+++ b/test/Fixture/Definition/Definitions/ImplementsDefinitionButIsAbstract/RepositoryDefinition.php
@@ -11,23 +11,15 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Fixture\Definition\Definitions\ThrowsExceptionDuringConstruction;
+namespace Ergebnis\FactoryBot\Test\Fixture\Definition\Definitions\ImplementsDefinitionButIsAbstract;
 
 use Ergebnis\FactoryBot\Definition\Definition;
 use Ergebnis\FactoryBot\FixtureFactory;
 use Ergebnis\FactoryBot\Test\Fixture;
 
-/**
- * Is not acceptable as it throws an exception during construction.
- */
-final class RepositoryDefinition implements Definition
+abstract class RepositoryDefinition implements Definition
 {
-    public function __construct()
-    {
-        throw new \RuntimeException();
-    }
-
-    public function accept(FixtureFactory $factory): void
+    final public function accept(FixtureFactory $factory): void
     {
         $factory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class);
     }

--- a/test/Fixture/Definition/Definitions/ImplementsDefinitionButThrowsExceptionDuringConstruction/RepositoryDefinition.php
+++ b/test/Fixture/Definition/Definitions/ImplementsDefinitionButThrowsExceptionDuringConstruction/RepositoryDefinition.php
@@ -11,19 +11,17 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Fixture\Definition\Definitions\PrivateConstructor;
+namespace Ergebnis\FactoryBot\Test\Fixture\Definition\Definitions\ImplementsDefinitionButThrowsExceptionDuringConstruction;
 
 use Ergebnis\FactoryBot\Definition\Definition;
 use Ergebnis\FactoryBot\FixtureFactory;
 use Ergebnis\FactoryBot\Test\Fixture;
 
-/**
- * Is not acceptable as it has a private constructor.
- */
 final class RepositoryDefinition implements Definition
 {
-    private function __construct()
+    public function __construct()
     {
+        throw new \RuntimeException();
     }
 
     public function accept(FixtureFactory $factory): void

--- a/test/Fixture/Definition/Definitions/ImplementsFakerAwareDefinition/OrganizationDefinition.php
+++ b/test/Fixture/Definition/Definitions/ImplementsFakerAwareDefinition/OrganizationDefinition.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Fixture\Definition\Definitions\FakerAware;
+namespace Ergebnis\FactoryBot\Test\Fixture\Definition\Definitions\ImplementsFakerAwareDefinition;
 
 use Ergebnis\FactoryBot\Definition\FakerAwareDefinition;
 use Ergebnis\FactoryBot\FixtureFactory;

--- a/test/Fixture/Definition/Definitions/ImplementsFakerAwareDefinition/RepositoryDefinition.php
+++ b/test/Fixture/Definition/Definitions/ImplementsFakerAwareDefinition/RepositoryDefinition.php
@@ -11,15 +11,13 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Fixture\Definition\Definitions\DoesNotImplementInterface;
+namespace Ergebnis\FactoryBot\Test\Fixture\Definition\Definitions\ImplementsFakerAwareDefinition;
 
+use Ergebnis\FactoryBot\Definition\Definition;
 use Ergebnis\FactoryBot\FixtureFactory;
 use Ergebnis\FactoryBot\Test\Fixture;
 
-/**
- * Is not acceptable as it does not implement the DefinitionInterface.
- */
-final class RepositoryDefinition
+final class RepositoryDefinition implements Definition
 {
     public function accept(FixtureFactory $factory): void
     {

--- a/test/Unit/Definition/DefinitionsTest.php
+++ b/test/Unit/Definition/DefinitionsTest.php
@@ -48,40 +48,47 @@ final class DefinitionsTest extends AbstractTestCase
     {
         $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
-        $definitions = Definitions::in(__DIR__ . '/../../Fixture/Definition/Definitions/DoesNotImplementInterface');
+        $definitions = Definitions::in(__DIR__ . '/../../Fixture/Definition/Definitions/DoesNotImplementDefinition');
 
         $definitions->registerWith($fixtureFactory);
 
         self::assertSame([], $fixtureFactory->definitions());
     }
 
-    public function testInIgnoresClassesWhichAreAbstract(): void
+    public function testInIgnoresDefinitionsThatAreAbstract(): void
     {
         $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
-        $definitions = Definitions::in(__DIR__ . '/../../Fixture/Definition/Definitions/IsAbstract');
+        $definitions = Definitions::in(__DIR__ . '/../../Fixture/Definition/Definitions/ImplementsDefinitionButIsAbstract');
 
         $definitions->registerWith($fixtureFactory);
 
         self::assertSame([], $fixtureFactory->definitions());
     }
 
-    public function testInIgnoresClassesWhichHavePrivateConstructors(): void
+    public function testInIgnoresDefinitionsThatHavePrivateConstructors(): void
     {
         $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
-        $definitions = Definitions::in(__DIR__ . '/../../Fixture/Definition/Definitions/PrivateConstructor');
+        $definitions = Definitions::in(__DIR__ . '/../../Fixture/Definition/Definitions/ImplementsDefinitionButHasPrivateConstructor');
 
         $definitions->registerWith($fixtureFactory);
 
         self::assertSame([], $fixtureFactory->definitions());
     }
 
-    public function testInAcceptsClassesWhichAreAcceptable(): void
+    public function testInThrowsInvalidDefinitionExceptionWhenExceptionIsThrownDuringInstantiationOfDefinition(): void
+    {
+        $this->expectException(Exception\InvalidDefinition::class);
+
+        Definitions::in(__DIR__ . '/../../Fixture/Definition/Definitions/ImplementsDefinitionButThrowsExceptionDuringConstruction');
+    }
+
+    public function testInAcceptsDefinitionsThatHaveNoIssues(): void
     {
         $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
-        $definitions = Definitions::in(__DIR__ . '/../../Fixture/Definition/Definitions/Acceptable');
+        $definitions = Definitions::in(__DIR__ . '/../../Fixture/Definition/Definitions/ImplementsDefinition');
 
         $definitions->registerWith($fixtureFactory);
 
@@ -92,17 +99,17 @@ final class DefinitionsTest extends AbstractTestCase
     {
         $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
-        $definitions = Definitions::in(__DIR__ . '/../../Fixture/Definition/Definitions/Acceptable');
+        $definitions = Definitions::in(__DIR__ . '/../../Fixture/Definition/Definitions/ImplementsDefinition');
 
         self::assertSame($definitions, $definitions->registerWith($fixtureFactory));
         self::assertSame($definitions, $definitions->provideWith($this->prophesize(Generator::class)->reveal()));
     }
 
-    public function testInAcceptsClassesWhichAreAcceptableAndFakerAwareAndProvidesThemWithFaker(): void
+    public function testInAcceptsFakerAwareDefinitionsAndProvidesThemWithFaker(): void
     {
         $faker = $this->prophesize(Generator::class);
 
-        $definitions = Definitions::in(__DIR__ . '/../../Fixture/Definition/Definitions/FakerAware');
+        $definitions = Definitions::in(__DIR__ . '/../../Fixture/Definition/Definitions/ImplementsFakerAwareDefinition');
 
         $definitions->provideWith($faker->reveal());
 
@@ -125,14 +132,7 @@ final class DefinitionsTest extends AbstractTestCase
 
         $fakerAwareDefinition = \array_shift($fakerAwareDefinitions);
 
-        self::assertInstanceOf(Fixture\Definition\Definitions\FakerAware\OrganizationDefinition::class, $fakerAwareDefinition);
+        self::assertInstanceOf(Fixture\Definition\Definitions\ImplementsFakerAwareDefinition\OrganizationDefinition::class, $fakerAwareDefinition);
         self::assertSame($faker->reveal(), $fakerAwareDefinition->faker());
-    }
-
-    public function testThrowsInvalidDefinitionExceptionIfInstantiatingDefinitionsThrowsException(): void
-    {
-        $this->expectException(Exception\InvalidDefinition::class);
-
-        Definitions::in(__DIR__ . '/../../Fixture/Definition/Definitions/ThrowsExceptionDuringConstruction');
     }
 }


### PR DESCRIPTION
This PR

* [x] renames fixture namespaces along with test methods

Follows #6.
