### PR TITLE
Enhancement: Pass in Faker\Generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 * Turned `$configuration` parameter of `FixtureFactory::defineEntity()` into `$afterCreate`, a `Closure` that will be invoked after object construction ([#101]), by [@localheinz]
 * Started throwing an `Exception\InvalidCount` exception instead of a generic `Exception` when an invalid number of entities are requested ([#105]), by [@localheinz]
 * Started throwing an `Exception\EntityDefinitionAlreadyRegistered` exception instead of a generic `Exception` when an entity definition for a class name has already been registered ([#106]), by [@localheinz]
+* Added `$faker` parameter to `Definition\Definition::accept()` and `Definition\Definitions::registerWith()`, providing and requiring to pass in an instance of `Faker\Generator` ([#117]), by [@localheinz]
 
 ### Fixed
 
@@ -59,5 +60,6 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 [#106]: https://github.com/ergebnis/factory-bot/pull/106
 [#114]: https://github.com/ergebnis/factory-bot/pull/114
 [#116]: https://github.com/ergebnis/factory-bot/pull/116
+[#117]: https://github.com/ergebnis/factory-bot/pull/117
 
 [@localheinz]: https://github.com/localheinz

--- a/src/Definition/Definition.php
+++ b/src/Definition/Definition.php
@@ -14,8 +14,9 @@ declare(strict_types=1);
 namespace Ergebnis\FactoryBot\Definition;
 
 use Ergebnis\FactoryBot\FixtureFactory;
+use Faker\Generator;
 
 interface Definition
 {
-    public function accept(FixtureFactory $fixtureFactory): void;
+    public function accept(FixtureFactory $fixturefactory, Generator $faker): void;
 }

--- a/src/Definition/Definitions.php
+++ b/src/Definition/Definitions.php
@@ -83,13 +83,17 @@ final class Definitions
      * Registers all found definitions with the specified fixture factory.
      *
      * @param FixtureFactory $fixtureFactory
+     * @param Generator      $faker
      *
      * @return self
      */
-    public function registerWith(FixtureFactory $fixtureFactory): self
+    public function registerWith(FixtureFactory $fixtureFactory, Generator $faker): self
     {
         foreach ($this->definitions as $definition) {
-            $definition->accept($fixtureFactory);
+            $definition->accept(
+                $fixtureFactory,
+                $faker
+            );
         }
 
         return $this;

--- a/test/Fixture/Definition/Definitions/ImplementsDefinition/RepositoryDefinition.php
+++ b/test/Fixture/Definition/Definitions/ImplementsDefinition/RepositoryDefinition.php
@@ -16,10 +16,11 @@ namespace Ergebnis\FactoryBot\Test\Fixture\Definition\Definitions\ImplementsDefi
 use Ergebnis\FactoryBot\Definition\Definition;
 use Ergebnis\FactoryBot\FixtureFactory;
 use Ergebnis\FactoryBot\Test\Fixture;
+use Faker\Generator;
 
 final class RepositoryDefinition implements Definition
 {
-    public function accept(FixtureFactory $factory): void
+    public function accept(FixtureFactory $factory, Generator $faker): void
     {
         $factory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class);
     }

--- a/test/Fixture/Definition/Definitions/ImplementsDefinitionButHasPrivateConstructor/RepositoryDefinition.php
+++ b/test/Fixture/Definition/Definitions/ImplementsDefinitionButHasPrivateConstructor/RepositoryDefinition.php
@@ -16,6 +16,7 @@ namespace Ergebnis\FactoryBot\Test\Fixture\Definition\Definitions\ImplementsDefi
 use Ergebnis\FactoryBot\Definition\Definition;
 use Ergebnis\FactoryBot\FixtureFactory;
 use Ergebnis\FactoryBot\Test\Fixture;
+use Faker\Generator;
 
 final class RepositoryDefinition implements Definition
 {
@@ -23,7 +24,7 @@ final class RepositoryDefinition implements Definition
     {
     }
 
-    public function accept(FixtureFactory $factory): void
+    public function accept(FixtureFactory $factory, Generator $faker): void
     {
         $factory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class);
     }

--- a/test/Fixture/Definition/Definitions/ImplementsDefinitionButIsAbstract/RepositoryDefinition.php
+++ b/test/Fixture/Definition/Definitions/ImplementsDefinitionButIsAbstract/RepositoryDefinition.php
@@ -16,10 +16,11 @@ namespace Ergebnis\FactoryBot\Test\Fixture\Definition\Definitions\ImplementsDefi
 use Ergebnis\FactoryBot\Definition\Definition;
 use Ergebnis\FactoryBot\FixtureFactory;
 use Ergebnis\FactoryBot\Test\Fixture;
+use Faker\Generator;
 
 abstract class RepositoryDefinition implements Definition
 {
-    final public function accept(FixtureFactory $factory): void
+    final public function accept(FixtureFactory $factory, Generator $faker): void
     {
         $factory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class);
     }

--- a/test/Fixture/Definition/Definitions/ImplementsDefinitionButThrowsExceptionDuringConstruction/RepositoryDefinition.php
+++ b/test/Fixture/Definition/Definitions/ImplementsDefinitionButThrowsExceptionDuringConstruction/RepositoryDefinition.php
@@ -16,6 +16,7 @@ namespace Ergebnis\FactoryBot\Test\Fixture\Definition\Definitions\ImplementsDefi
 use Ergebnis\FactoryBot\Definition\Definition;
 use Ergebnis\FactoryBot\FixtureFactory;
 use Ergebnis\FactoryBot\Test\Fixture;
+use Faker\Generator;
 
 final class RepositoryDefinition implements Definition
 {
@@ -24,7 +25,7 @@ final class RepositoryDefinition implements Definition
         throw new \RuntimeException();
     }
 
-    public function accept(FixtureFactory $factory): void
+    public function accept(FixtureFactory $factory, Generator $faker): void
     {
         $factory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class);
     }

--- a/test/Fixture/Definition/Definitions/ImplementsFakerAwareDefinition/OrganizationDefinition.php
+++ b/test/Fixture/Definition/Definitions/ImplementsFakerAwareDefinition/OrganizationDefinition.php
@@ -25,7 +25,7 @@ final class OrganizationDefinition implements FakerAwareDefinition
      */
     private $faker;
 
-    public function accept(FixtureFactory $factory): void
+    public function accept(FixtureFactory $factory, Generator $faker): void
     {
         $factory->defineEntity(Fixture\FixtureFactory\Entity\Organization::class);
     }

--- a/test/Fixture/Definition/Definitions/ImplementsFakerAwareDefinition/RepositoryDefinition.php
+++ b/test/Fixture/Definition/Definitions/ImplementsFakerAwareDefinition/RepositoryDefinition.php
@@ -16,10 +16,11 @@ namespace Ergebnis\FactoryBot\Test\Fixture\Definition\Definitions\ImplementsFake
 use Ergebnis\FactoryBot\Definition\Definition;
 use Ergebnis\FactoryBot\FixtureFactory;
 use Ergebnis\FactoryBot\Test\Fixture;
+use Faker\Generator;
 
 final class RepositoryDefinition implements Definition
 {
-    public function accept(FixtureFactory $factory): void
+    public function accept(FixtureFactory $factory, Generator $faker): void
     {
         $factory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class);
     }

--- a/test/Unit/Definition/DefinitionsTest.php
+++ b/test/Unit/Definition/DefinitionsTest.php
@@ -46,33 +46,48 @@ final class DefinitionsTest extends AbstractTestCase
 
     public function testInIgnoresClassesWhichDoNotImplementProviderInterface(): void
     {
+        $faker = self::faker();
+
         $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $definitions = Definitions::in(__DIR__ . '/../../Fixture/Definition/Definitions/DoesNotImplementDefinition');
 
-        $definitions->registerWith($fixtureFactory);
+        $definitions->registerWith(
+            $fixtureFactory,
+            $faker
+        );
 
         self::assertSame([], $fixtureFactory->definitions());
     }
 
     public function testInIgnoresDefinitionsThatAreAbstract(): void
     {
+        $faker = self::faker();
+
         $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $definitions = Definitions::in(__DIR__ . '/../../Fixture/Definition/Definitions/ImplementsDefinitionButIsAbstract');
 
-        $definitions->registerWith($fixtureFactory);
+        $definitions->registerWith(
+            $fixtureFactory,
+            $faker
+        );
 
         self::assertSame([], $fixtureFactory->definitions());
     }
 
     public function testInIgnoresDefinitionsThatHavePrivateConstructors(): void
     {
+        $faker = self::faker();
+
         $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $definitions = Definitions::in(__DIR__ . '/../../Fixture/Definition/Definitions/ImplementsDefinitionButHasPrivateConstructor');
 
-        $definitions->registerWith($fixtureFactory);
+        $definitions->registerWith(
+            $fixtureFactory,
+            $faker
+        );
 
         self::assertSame([], $fixtureFactory->definitions());
     }
@@ -86,22 +101,29 @@ final class DefinitionsTest extends AbstractTestCase
 
     public function testInAcceptsDefinitionsThatHaveNoIssues(): void
     {
+        $faker = self::faker();
+
         $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $definitions = Definitions::in(__DIR__ . '/../../Fixture/Definition/Definitions/ImplementsDefinition');
 
-        $definitions->registerWith($fixtureFactory);
+        $definitions->registerWith(
+            $fixtureFactory,
+            $faker
+        );
 
         self::assertArrayHasKey(Fixture\FixtureFactory\Entity\Repository::class, $fixtureFactory->definitions());
     }
 
     public function testFluentInterface(): void
     {
+        $faker = self::faker();
+
         $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
         $definitions = Definitions::in(__DIR__ . '/../../Fixture/Definition/Definitions/ImplementsDefinition');
 
-        self::assertSame($definitions, $definitions->registerWith($fixtureFactory));
+        self::assertSame($definitions, $definitions->registerWith($fixtureFactory, $faker));
         self::assertSame($definitions, $definitions->provideWith($this->prophesize(Generator::class)->reveal()));
     }
 
@@ -130,6 +152,7 @@ final class DefinitionsTest extends AbstractTestCase
         self::assertCount(1, $fakerAwareDefinitions);
         self::assertContainsOnlyInstancesOf(FakerAwareDefinition::class, $fakerAwareDefinitions);
 
+        /** @var FakerAwareDefinition $fakerAwareDefinition */
         $fakerAwareDefinition = \array_shift($fakerAwareDefinitions);
 
         self::assertInstanceOf(Fixture\Definition\Definitions\ImplementsFakerAwareDefinition\OrganizationDefinition::class, $fakerAwareDefinition);


### PR DESCRIPTION
This PR

* [x] passes in an instance of `Faker\Generator` into `Definition\Definitions::registerWith()` and `Definition\Definition::accept()`

Follows #6.
