### PR TITLE
Fix: Rename parameter

### DIFF
--- a/src/FieldDefinition.php
+++ b/src/FieldDefinition.php
@@ -75,8 +75,8 @@ final class FieldDefinition
      */
     public static function reference(string $className): \Closure
     {
-        return static function (FixtureFactory $factory) use ($className): object {
-            return $factory->get($className);
+        return static function (FixtureFactory $fixtureFactory) use ($className): object {
+            return $fixtureFactory->get($className);
         };
     }
 
@@ -106,8 +106,8 @@ final class FieldDefinition
             );
         }
 
-        return static function (FixtureFactory $factory) use ($className, $count): array {
-            return $factory->getList(
+        return static function (FixtureFactory $fixtureFactory) use ($className, $count): array {
+            return $fixtureFactory->getList(
                 $className,
                 [],
                 $count

--- a/test/Fixture/Definition/Definitions/DoesNotImplementDefinition/RepositoryDefinition.php
+++ b/test/Fixture/Definition/Definitions/DoesNotImplementDefinition/RepositoryDefinition.php
@@ -18,8 +18,8 @@ use Ergebnis\FactoryBot\Test\Fixture;
 
 final class RepositoryDefinition
 {
-    public function accept(FixtureFactory $factory): void
+    public function accept(FixtureFactory $fixtureFactory): void
     {
-        $factory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class);
+        $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class);
     }
 }

--- a/test/Fixture/Definition/Definitions/ImplementsDefinition/RepositoryDefinition.php
+++ b/test/Fixture/Definition/Definitions/ImplementsDefinition/RepositoryDefinition.php
@@ -20,8 +20,8 @@ use Faker\Generator;
 
 final class RepositoryDefinition implements Definition
 {
-    public function accept(FixtureFactory $factory, Generator $faker): void
+    public function accept(FixtureFactory $fixtureFactory, Generator $faker): void
     {
-        $factory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class);
+        $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class);
     }
 }

--- a/test/Fixture/Definition/Definitions/ImplementsDefinitionButHasPrivateConstructor/RepositoryDefinition.php
+++ b/test/Fixture/Definition/Definitions/ImplementsDefinitionButHasPrivateConstructor/RepositoryDefinition.php
@@ -24,8 +24,8 @@ final class RepositoryDefinition implements Definition
     {
     }
 
-    public function accept(FixtureFactory $factory, Generator $faker): void
+    public function accept(FixtureFactory $fixtureFactory, Generator $faker): void
     {
-        $factory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class);
+        $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class);
     }
 }

--- a/test/Fixture/Definition/Definitions/ImplementsDefinitionButIsAbstract/RepositoryDefinition.php
+++ b/test/Fixture/Definition/Definitions/ImplementsDefinitionButIsAbstract/RepositoryDefinition.php
@@ -20,8 +20,8 @@ use Faker\Generator;
 
 abstract class RepositoryDefinition implements Definition
 {
-    final public function accept(FixtureFactory $factory, Generator $faker): void
+    final public function accept(FixtureFactory $fixtureFactory, Generator $faker): void
     {
-        $factory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class);
+        $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class);
     }
 }

--- a/test/Fixture/Definition/Definitions/ImplementsDefinitionButThrowsExceptionDuringConstruction/RepositoryDefinition.php
+++ b/test/Fixture/Definition/Definitions/ImplementsDefinitionButThrowsExceptionDuringConstruction/RepositoryDefinition.php
@@ -25,8 +25,8 @@ final class RepositoryDefinition implements Definition
         throw new \RuntimeException();
     }
 
-    public function accept(FixtureFactory $factory, Generator $faker): void
+    public function accept(FixtureFactory $fixtureFactory, Generator $faker): void
     {
-        $factory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class);
+        $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class);
     }
 }

--- a/test/Fixture/Definition/Definitions/ImplementsFakerAwareDefinition/OrganizationDefinition.php
+++ b/test/Fixture/Definition/Definitions/ImplementsFakerAwareDefinition/OrganizationDefinition.php
@@ -25,9 +25,9 @@ final class OrganizationDefinition implements FakerAwareDefinition
      */
     private $faker;
 
-    public function accept(FixtureFactory $factory, Generator $faker): void
+    public function accept(FixtureFactory $fixtureFactory, Generator $faker): void
     {
-        $factory->defineEntity(Fixture\FixtureFactory\Entity\Organization::class);
+        $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Organization::class);
     }
 
     public function provideWith(Generator $faker): void

--- a/test/Fixture/Definition/Definitions/ImplementsFakerAwareDefinition/RepositoryDefinition.php
+++ b/test/Fixture/Definition/Definitions/ImplementsFakerAwareDefinition/RepositoryDefinition.php
@@ -20,8 +20,8 @@ use Faker\Generator;
 
 final class RepositoryDefinition implements Definition
 {
-    public function accept(FixtureFactory $factory, Generator $faker): void
+    public function accept(FixtureFactory $fixtureFactory, Generator $faker): void
     {
-        $factory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class);
+        $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class);
     }
 }


### PR DESCRIPTION
This PR

* [x] renames the `$factory` parameter to `$fixtureFactory`

Follows #1 and #6.