### PR TITLE
Fix: Throw ClassMetadataNotFound exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 ### Fixed
 
 * Populated embeddables and disallowed referencing fields using dot notation ([#79]), by [@localheinz]
+* Started throwing an `Exception\ClassMetadataNotFound` exception instead of bubbling up `Doctrine\ORM\Mapping\MappingException` when a class is not an entity ([#126]), by [@localheinz]
 
 ### Removed
 
@@ -70,5 +71,6 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 [#123]: https://github.com/ergebnis/factory-bot/pull/123
 [#124]: https://github.com/ergebnis/factory-bot/pull/124
 [#125]: https://github.com/ergebnis/factory-bot/pull/125
+[#126]: https://github.com/ergebnis/factory-bot/pull/126
 
 [@localheinz]: https://github.com/localheinz

--- a/src/Exception/ClassMetadataNotFound.php
+++ b/src/Exception/ClassMetadataNotFound.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/factory-bot
+ */
+
+namespace Ergebnis\FactoryBot\Exception;
+
+final class ClassMetadataNotFound extends \RuntimeException implements Exception
+{
+    public static function for(string $className): self
+    {
+        return new self(\sprintf(
+            'Class metadata for a class with the name "%s" could not be found.',
+            $className
+        ));
+    }
+}

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -49,10 +49,10 @@ final class FixtureFactory
      * @param array    $fieldDefinitions
      * @param \Closure $afterCreate
      *
+     * @throws Exception\ClassMetadataNotFound
      * @throws Exception\ClassNotFound
      * @throws Exception\EntityDefinitionAlreadyRegistered
      * @throws Exception\InvalidFieldNames
-     * @throws \Exception
      *
      * @return FixtureFactory
      */
@@ -66,14 +66,10 @@ final class FixtureFactory
             throw Exception\ClassNotFound::name($className);
         }
 
-        /** @var null|ORM\Mapping\ClassMetadata $classMetadata */
-        $classMetadata = $this->entityManager->getClassMetadata($className);
-
-        if (null === $classMetadata) {
-            throw new \Exception(\sprintf(
-                'Unknown entity type: %s',
-                $className
-            ));
+        try {
+            $classMetadata = $this->entityManager->getClassMetadata($className);
+        } catch (ORM\Mapping\MappingException $exception) {
+            throw Exception\ClassMetadataNotFound::for($className);
         }
 
         /** @var string[] $allFieldNames */

--- a/test/Unit/Exception/ClassMetadataNotFoundTest.php
+++ b/test/Unit/Exception/ClassMetadataNotFoundTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/factory-bot
+ */
+
+namespace Ergebnis\FactoryBot\Test\Unit\Exception;
+
+use Ergebnis\FactoryBot\Exception;
+use PHPUnit\Framework;
+
+/**
+ * @internal
+ *
+ * @covers \Ergebnis\FactoryBot\Exception\ClassMetadataNotFound
+ */
+final class ClassMetadataNotFoundTest extends Framework\TestCase
+{
+    public function testNameReturnsException(): void
+    {
+        $className = 'foo';
+
+        $exception = Exception\ClassMetadataNotFound::for($className);
+
+        $message = \sprintf(
+            'Class metadata for a class with the name "%s" could not be found.',
+            $className
+        );
+
+        self::assertSame($message, $exception->getMessage());
+    }
+}

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -67,15 +67,15 @@ final class FixtureFactoryTest extends AbstractTestCase
         $fixtureFactory->defineEntity($className);
     }
 
-    public function testDefineEntityThrowsExceptionWhenClassNameDoesNotReferenceAnEntity(): void
+    public function testDefineEntityThrowsClassMetadataNotFoundExceptionWhenClassNameDoesNotReferenceAnEntity(): void
     {
         $className = Fixture\FixtureFactory\NotAnEntity\User::class;
 
         $fixtureFactory = new FixtureFactory(self::createEntityManager());
 
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception\ClassMetadataNotFound::class);
         $this->expectExceptionMessage(\sprintf(
-            'Class "%s" is not a valid entity or mapped super class.',
+            'Class metadata for a class with the name "%s" could not be found.',
             $className
         ));
 


### PR DESCRIPTION
This PR

* [x] throws a `ClassMetadataNotFound` exception when class metadata could not be found for a referenced class name

Follows #1.