### PR TITLE
Enhancement: Turn FieldDefinition into object

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,11 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Method Ergebnis\\\\FactoryBot\\\\FieldDefinition\\:\\:__invoke\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/FieldDefinition.php
+
+		-
 			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
 			count: 2
 			path: src/FieldDefinition.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -15,9 +15,8 @@
     </MixedOperand>
   </file>
   <file src="src/FixtureFactory.php">
-    <MissingClosureReturnType occurrences="3">
+    <MissingClosureReturnType occurrences="2">
       <code>static function () use ($fieldDefinition) {</code>
-      <code>static function () {</code>
       <code>static function () use ($defaultFieldValue) {</code>
     </MissingClosureReturnType>
     <MissingParamType occurrences="3">

--- a/src/EntityDefinition.php
+++ b/src/EntityDefinition.php
@@ -27,9 +27,9 @@ final class EntityDefinition
     private $afterCreate;
 
     /**
-     * @param ORM\Mapping\ClassMetadata $classMetadata
-     * @param array<string, \Closure>   $fieldDefinitions
-     * @param \Closure                  $afterCreate
+     * @param ORM\Mapping\ClassMetadata      $classMetadata
+     * @param array<string, FieldDefinition> $fieldDefinitions
+     * @param \Closure                       $afterCreate
      */
     public function __construct(ORM\Mapping\ClassMetadata $classMetadata, array $fieldDefinitions, \Closure $afterCreate)
     {
@@ -51,7 +51,7 @@ final class EntityDefinition
     /**
      * Returns the fielde definition callbacks.
      *
-     * @return array<string, \Closure>
+     * @return array<string, FieldDefinition>
      */
     public function fieldDefinitions(): array
     {

--- a/test/Unit/Definition/DefinitionsTest.php
+++ b/test/Unit/Definition/DefinitionsTest.php
@@ -28,6 +28,7 @@ use Ergebnis\Test\Util\Helper;
  * @uses \Ergebnis\FactoryBot\EntityDefinition
  * @uses \Ergebnis\FactoryBot\Exception\InvalidDefinition
  * @uses \Ergebnis\FactoryBot\Exception\InvalidDirectory
+ * @uses \Ergebnis\FactoryBot\FieldDefinition
  * @uses \Ergebnis\FactoryBot\FixtureFactory
  */
 final class DefinitionsTest extends AbstractTestCase

--- a/test/Unit/EntityDefinitionTest.php
+++ b/test/Unit/EntityDefinitionTest.php
@@ -15,6 +15,7 @@ namespace Ergebnis\FactoryBot\Test\Unit;
 
 use Doctrine\ORM;
 use Ergebnis\FactoryBot\EntityDefinition;
+use Ergebnis\FactoryBot\FieldDefinition;
 use Ergebnis\Test\Util\Helper;
 use PHPUnit\Framework;
 
@@ -22,6 +23,8 @@ use PHPUnit\Framework;
  * @internal
  *
  * @covers \Ergebnis\FactoryBot\EntityDefinition
+ *
+ * @uses \Ergebnis\FactoryBot\FieldDefinition
  */
 final class EntityDefinitionTest extends Framework\TestCase
 {
@@ -32,12 +35,12 @@ final class EntityDefinitionTest extends Framework\TestCase
         $classMetadata = $this->prophesize(ORM\Mapping\ClassMetadata::class);
 
         $fieldDefinitions = [
-            'foo' => static function (): string {
+            'foo' => FieldDefinition::sequence(static function (): string {
                 return 'bar';
-            },
-            'bar' => static function (): string {
+            }),
+            'bar' => FieldDefinition::sequence(static function (): string {
                 return 'baz';
-            },
+            }),
         ];
 
         $afterCreate = static function ($entity, array $fieldValues): void {


### PR DESCRIPTION
This PR

* [x] turns `FieldDefinition` into an object that can be passed around