### PR TITLE
Fix: Avoid ternary statement

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -38,8 +38,9 @@
       <code>$fieldDefinitions</code>
       <code>$fieldOverrides</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment occurrences="6">
       <code>$defaultFieldValue</code>
+      <code>$fieldValues[$fieldName]</code>
       <code>$fieldValues[$fieldName]</code>
       <code>$fieldValue</code>
       <code>$inversedBy</code>

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -184,9 +184,13 @@ final class FixtureFactory
         $fieldValues = [];
 
         foreach ($entityDefinition->fieldDefinitions() as $fieldName => $fieldDefinition) {
-            $fieldValues[$fieldName] = \array_key_exists($fieldName, $fieldOverrides)
-                ? $fieldOverrides[$fieldName]
-                : $fieldDefinition($this);
+            if (\array_key_exists($fieldName, $fieldOverrides)) {
+                $fieldValues[$fieldName] = $fieldOverrides[$fieldName];
+
+                continue;
+            }
+
+            $fieldValues[$fieldName] = $fieldDefinition($this);
         }
 
         foreach ($fieldValues as $fieldName => $fieldValue) {


### PR DESCRIPTION
This PR

* [x] avoids a ternary statement

Follows #1.
Blocks #129.