### PR TITLE
Fix: Do not return FixtureFactory from defineEntity()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 * Added `$faker` parameter to `Definition\Definition::accept()` and `Definition\Definitions::registerWith()`, providing and requiring to pass in an instance of `Faker\Generator` ([#117]), by [@localheinz]
 * Started throwing an `Exception\ClassNotFound` exception instead of a generic `Exception` when a class was not found ([#125]), by [@localheinz]
 * Added `@template` annotations to assist with static code analysis ([#128]), by [@localheinz]
+* Removed the fluent interface from `FixtureFactory::defineEntity()` ([#131]), by [@localheinz]
 
 ### Fixed
 
@@ -74,5 +75,6 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 [#125]: https://github.com/ergebnis/factory-bot/pull/125
 [#126]: https://github.com/ergebnis/factory-bot/pull/126
 [#128]: https://github.com/ergebnis/factory-bot/pull/128
+[#131]: https://github.com/ergebnis/factory-bot/pull/131
 
 [@localheinz]: https://github.com/localheinz

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -55,10 +55,8 @@ final class FixtureFactory
      * @throws Exception\ClassNotFound
      * @throws Exception\EntityDefinitionAlreadyRegistered
      * @throws Exception\InvalidFieldNames
-     *
-     * @return FixtureFactory
      */
-    public function defineEntity(string $className, array $fieldDefinitions = [], ?\Closure $afterCreate = null)
+    public function defineEntity(string $className, array $fieldDefinitions = [], ?\Closure $afterCreate = null): void
     {
         if (\array_key_exists($className, $this->entityDefinitions)) {
             throw Exception\EntityDefinitionAlreadyRegistered::for($className);
@@ -135,8 +133,6 @@ final class FixtureFactory
             $fieldDefinitions,
             $afterCreate
         );
-
-        return $this;
     }
 
     /**

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -102,15 +102,6 @@ final class FixtureFactoryTest extends AbstractTestCase
         ]);
     }
 
-    public function testDefineEntityReturnsFixtureFactory(): void
-    {
-        $entityManager = self::createEntityManager();
-
-        $fixtureFactory = new FixtureFactory($entityManager);
-
-        self::assertSame($fixtureFactory, $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class));
-    }
-
     public function testGetThrowsEntityDefinitionUnavailableWhenDefinitionIsUnavailable(): void
     {
         $className = self::class;


### PR DESCRIPTION
This PR

* [x] stops returning `FixtureFactory` from `FixtureFactory::defineEntity()`

Follows #1.