### PR TITLE
Fix: Remove support for callables that are not closures

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -10,7 +10,7 @@ on: # yamllint disable-line rule:truthy
 
 env:
   MIN_COVERED_MSI: 95
-  MIN_MSI: 90
+  MIN_MSI: 91
   REQUIRED_PHP_EXTENSIONS: "mbstring"
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 * Removed `Definition\FakerAwareDefinition` ([#120] and [#123]), by [@localheinz]
 * Removed `FixtureFactory::provideWith()` ([#122]), by [@localheinz]
 * Removed `FixtureFactory::getAsSingleton()`, `FixtureFactory::setSingleton()`, and `FixtureFactory::unsetSingleton()` ([#124]), by [@localheinz]
+* Removed `callable` support for field definitions ([#133]), by [@localheinz]
 
 [fa9c564...master]: https://github.com/ergebnis/factory-bot/compare/fa9c564...master
 
@@ -76,5 +77,6 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 [#126]: https://github.com/ergebnis/factory-bot/pull/126
 [#128]: https://github.com/ergebnis/factory-bot/pull/128
 [#131]: https://github.com/ergebnis/factory-bot/pull/131
+[#133]: https://github.com/ergebnis/factory-bot/pull/133
 
 [@localheinz]: https://github.com/localheinz

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 MIN_COVERED_MSI:=95
-MIN_MSI:=90
+MIN_MSI:=91
 
 .PHONY: it
 it: coding-standards static-code-analysis tests ## Runs the coding-standards, static-code-analysis, and tests targets

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,16 +21,6 @@ parameters:
 			path: src/FixtureFactory.php
 
 		-
-			message: "#^Parameter \\#1 \\$object of function method_exists expects object\\|string, callable given\\.$#"
-			count: 1
-			path: src/FixtureFactory.php
-
-		-
-			message: "#^Anonymous function should return callable\\(\\)\\: mixed but returns object\\.$#"
-			count: 1
-			path: src/FixtureFactory.php
-
-		-
 			message: "#^Method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:setField\\(\\) has parameter \\$fieldValue with no typehint specified\\.$#"
 			count: 1
 			path: src/FixtureFactory.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -15,11 +15,7 @@
     </MixedOperand>
   </file>
   <file src="src/FixtureFactory.php">
-    <InvalidArgument occurrences="1">
-      <code>$fieldDefinition</code>
-    </InvalidArgument>
-    <MissingClosureReturnType occurrences="4">
-      <code>static function () use ($fieldDefinition) {</code>
+    <MissingClosureReturnType occurrences="3">
       <code>static function () use ($fieldDefinition) {</code>
       <code>static function () {</code>
       <code>static function () use ($defaultFieldValue) {</code>
@@ -34,8 +30,7 @@
       <code>$fieldValue</code>
       <code>$inversedBy</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="2">
-      <code>$fieldDefinitions</code>
+    <MixedArgumentTypeCoercion occurrences="1">
       <code>$fieldOverrides</code>
     </MixedArgumentTypeCoercion>
     <MixedAssignment occurrences="6">
@@ -46,15 +41,6 @@
       <code>$inversedBy</code>
       <code>$collection</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>callable</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$fieldDefinition</code>
-    </MixedReturnStatement>
-    <TypeDoesNotContainType occurrences="1">
-      <code>\method_exists($fieldDefinition, '__invoke')</code>
-    </TypeDoesNotContainType>
   </file>
   <file src="test/Fixture/FixtureFactory/Entity/Organization.php">
     <PropertyNotSetInConstructor occurrences="1">

--- a/src/EntityDefinition.php
+++ b/src/EntityDefinition.php
@@ -28,7 +28,7 @@ final class EntityDefinition
 
     /**
      * @param ORM\Mapping\ClassMetadata $classMetadata
-     * @param array<string, callable>   $fieldDefinitions
+     * @param array<string, \Closure>   $fieldDefinitions
      * @param \Closure                  $afterCreate
      */
     public function __construct(ORM\Mapping\ClassMetadata $classMetadata, array $fieldDefinitions, \Closure $afterCreate)
@@ -51,7 +51,7 @@ final class EntityDefinition
     /**
      * Returns the fielde definition callbacks.
      *
-     * @return array<string, callable>
+     * @return array<string, \Closure>
      */
     public function fieldDefinitions(): array
     {

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -47,9 +47,9 @@ final class FixtureFactory
      *
      * @template T
      *
-     * @param class-string<T> $className
-     * @param array           $fieldDefinitions
-     * @param \Closure        $afterCreate
+     * @param class-string<T>               $className
+     * @param array<string, \Closure|mixed> $fieldDefinitions
+     * @param \Closure                      $afterCreate
      *
      * @throws Exception\ClassMetadataNotFound
      * @throws Exception\ClassNotFound
@@ -96,20 +96,14 @@ final class FixtureFactory
             );
         }
 
-        $fieldDefinitions = \array_map(static function ($fieldDefinition): callable {
-            if (\is_callable($fieldDefinition)) {
-                if (\method_exists($fieldDefinition, '__invoke')) {
-                    return $fieldDefinition;
-                }
-
+        $fieldDefinitions = \array_map(static function ($fieldDefinition): \Closure {
+            if (!$fieldDefinition instanceof \Closure) {
                 return static function () use ($fieldDefinition) {
-                    return \call_user_func_array($fieldDefinition, \func_get_args());
+                    return $fieldDefinition;
                 };
             }
 
-            return static function () use ($fieldDefinition) {
-                return $fieldDefinition;
-            };
+            return $fieldDefinition;
         }, $fieldDefinitions);
 
         $defaultEntity = $classMetadata->newInstance();


### PR DESCRIPTION
This PR

* [x] removes support for callables that are not closures

Follows #1.
Related to #129.