### PR TITLE
Fix: Add tests for FieldDefinition

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -9,8 +9,8 @@ on: # yamllint disable-line rule:truthy
       - "master"
 
 env:
-  MIN_COVERED_MSI: 98
-  MIN_MSI: 96
+  MIN_COVERED_MSI: 99
+  MIN_MSI: 97
   REQUIRED_PHP_EXTENSIONS: "mbstring"
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-MIN_COVERED_MSI:=98
-MIN_MSI:=96
+MIN_COVERED_MSI:=99
+MIN_MSI:=97
 
 .PHONY: it
 it: coding-standards static-code-analysis tests ## Runs the coding-standards, static-code-analysis, and tests targets

--- a/test/Unit/FieldDefinitionTest.php
+++ b/test/Unit/FieldDefinitionTest.php
@@ -15,19 +15,35 @@ namespace Ergebnis\FactoryBot\Test\Unit;
 
 use Ergebnis\FactoryBot\Exception;
 use Ergebnis\FactoryBot\FieldDefinition;
+use Ergebnis\FactoryBot\FixtureFactory;
+use Ergebnis\FactoryBot\Test\Fixture;
 use Ergebnis\Test\Util\Helper;
-use PHPUnit\Framework;
 
 /**
  * @internal
  *
  * @covers \Ergebnis\FactoryBot\FieldDefinition
  *
+ * @uses \Ergebnis\FactoryBot\EntityDefinition
  * @uses \Ergebnis\FactoryBot\Exception\InvalidCount
+ * @uses \Ergebnis\FactoryBot\FixtureFactory
  */
-final class FieldDefinitionTest extends Framework\TestCase
+final class FieldDefinitionTest extends AbstractTestCase
 {
     use Helper;
+
+    public function testReferenceResolvesToInstanceOfReferencedClass(): void
+    {
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
+
+        $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\User::class);
+
+        $fieldDefinition = FieldDefinition::reference(Fixture\FixtureFactory\Entity\User::class);
+
+        $resolved = $fieldDefinition($fixtureFactory);
+
+        self::assertInstanceOf(Fixture\FixtureFactory\Entity\User::class, $resolved);
+    }
 
     /**
      * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intLessThanOne()
@@ -44,5 +60,119 @@ final class FieldDefinitionTest extends Framework\TestCase
             $className,
             $count
         );
+    }
+
+    public function testReferencesResolvesToAnArrayOfOneInstancesOfReferencedClassWhenCountIsNotSpecified(): void
+    {
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
+
+        $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\User::class);
+
+        $fieldDefinition = FieldDefinition::references(Fixture\FixtureFactory\Entity\User::class);
+
+        $resolved = $fieldDefinition($fixtureFactory);
+
+        self::assertIsArray($resolved);
+        self::assertCount(1, $resolved);
+        self::assertContainsOnly(Fixture\FixtureFactory\Entity\User::class, $resolved);
+    }
+
+    /**
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intBetweenOneAndFive()
+     *
+     * @param int $count
+     */
+    public function testReferencesResolvesToAnArrayOfCountInstancesOfReferencedClassWhenCountIsSpecified(int $count): void
+    {
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
+
+        $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\User::class);
+
+        $fieldDefinition = FieldDefinition::references(
+            Fixture\FixtureFactory\Entity\User::class,
+            $count
+        );
+
+        $resolved = $fieldDefinition($fixtureFactory);
+
+        self::assertIsArray($resolved);
+        self::assertCount($count, $resolved);
+        self::assertContainsOnly(Fixture\FixtureFactory\Entity\User::class, $resolved);
+    }
+
+    public function testSequenceResolvesToReturnValueOfCallableInvokedWithSequentialNumberWhenSequenceIsCallable(): void
+    {
+        $callable = [
+            self::class,
+            'exampleCallable',
+        ];
+
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
+
+        $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\User::class);
+
+        $fieldDefinition = FieldDefinition::sequence($callable);
+
+        self::assertSame('number-1-is-an-integer', $fieldDefinition($fixtureFactory));
+        self::assertSame('number-2-is-an-integer', $fieldDefinition($fixtureFactory));
+        self::assertSame('number-3-is-an-integer', $fieldDefinition($fixtureFactory));
+    }
+
+    public static function exampleCallable(int $number): string
+    {
+        return \sprintf(
+            'number-%d-is-an-integer',
+            $number
+        );
+    }
+
+    public function testSequenceResolvesToTheReturnValueOfClosureInvokedWithSequentialNumberWhenSequenceIsClosure(): void
+    {
+        $closure = static function (int $number): string {
+            return \sprintf(
+                'number-%d-is-ok',
+                $number
+            );
+        };
+
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
+
+        $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\User::class);
+
+        $fieldDefinition = FieldDefinition::sequence($closure);
+
+        self::assertSame('number-1-is-ok', $fieldDefinition($fixtureFactory));
+        self::assertSame('number-2-is-ok', $fieldDefinition($fixtureFactory));
+        self::assertSame('number-3-is-ok', $fieldDefinition($fixtureFactory));
+    }
+
+    public function testSequenceResolvesToAStringWithPlaceholderReplacedWithSequentialNumberWhenSequenceIsStringThatContainsPlaceholder(): void
+    {
+        $string = 'there-is-no-difference-between-%d-and-%d';
+
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
+
+        $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\User::class);
+
+        $fieldDefinition = FieldDefinition::sequence($string);
+
+        self::assertSame('there-is-no-difference-between-1-and-1', $fieldDefinition($fixtureFactory));
+        self::assertSame('there-is-no-difference-between-2-and-2', $fieldDefinition($fixtureFactory));
+        self::assertSame('there-is-no-difference-between-3-and-3', $fieldDefinition($fixtureFactory));
+    }
+
+    public function testSequenceResolvesToAStringSuffixedWithSequentialNumberSequenceIsStringThatDoesNotContainPlaceholder(): void
+    {
+        $string = 'user-';
+
+        $fixtureFactory = new FixtureFactory(self::createEntityManager());
+
+        $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\User::class);
+
+        $fieldDefinition = FieldDefinition::sequence($string);
+
+        self::assertSame('user-1', $fieldDefinition($fixtureFactory));
+        self::assertSame('user-2', $fieldDefinition($fixtureFactory));
+        self::assertSame('user-3', $fieldDefinition($fixtureFactory));
     }
 }

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -23,10 +23,10 @@ use Ergebnis\Test\Util\Helper;
 /**
  * @internal
  *
- * @covers \Ergebnis\FactoryBot\FieldDefinition
  * @covers \Ergebnis\FactoryBot\FixtureFactory
  *
  * @uses \Ergebnis\FactoryBot\EntityDefinition
+ * @uses \Ergebnis\FactoryBot\FieldDefinition
  * @uses \Ergebnis\FactoryBot\Exception\ClassMetadataNotFound
  * @uses \Ergebnis\FactoryBot\Exception\ClassNotFound
  * @uses \Ergebnis\FactoryBot\Exception\EntityDefinitionAlreadyRegistered


### PR DESCRIPTION
This PR

* [x] adds tests for `FieldDefinition`

Follows #1.