### PR TITLE
Fix: Wait 5 seconds before merging pull request

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -457,6 +457,9 @@ jobs:
               repo: repository.repo,
             })
 
+      - name: "Wait"
+        run: "sleep 5"
+
       - name: "Merge pull request"
         uses: "actions/github-script@0.8.0"
         with:


### PR DESCRIPTION
This PR

* [x] waits 5 seconds before merging a pull request as @ergebnis-bot 