### PR TITLE
Fix: Reject invalid field definition values

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,11 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Instanceof between Ergebnis\\\\FactoryBot\\\\FieldDefinition and Ergebnis\\\\FactoryBot\\\\FieldDefinition will always evaluate to true\\.$#"
+			count: 1
+			path: src/EntityDefinition.php
+
+		-
 			message: "#^Method Ergebnis\\\\FactoryBot\\\\FieldDefinition\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: src/FieldDefinition.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="3.10.1@eeed5ecccc10131397f0eb7ee6da810c0be3a7fc">
+  <file src="src/EntityDefinition.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>return !$fieldDefinition instanceof FieldDefinition;</code>
+    </DocblockTypeContradiction>
+    <MissingPropertyType occurrences="3">
+      <code>$classMetadata</code>
+      <code>$fieldDefinitions</code>
+      <code>$afterCreate</code>
+    </MissingPropertyType>
+    <MixedInferredReturnType occurrences="3">
+      <code>ORM\Mapping\ClassMetadata</code>
+      <code>array&lt;string, FieldDefinition&gt;</code>
+      <code>\Closure</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="3">
+      <code>$this-&gt;classMetadata</code>
+      <code>$this-&gt;fieldDefinitions</code>
+      <code>$this-&gt;afterCreate</code>
+    </MixedReturnStatement>
+  </file>
   <file src="src/FieldDefinition.php">
     <MissingClosureReturnType occurrences="1">
       <code>static function () use (&amp;$n, $funcOrString) {</code>
@@ -71,9 +91,16 @@
     </InternalMethod>
   </file>
   <file src="test/Unit/EntityDefinitionTest.php">
-    <MissingClosureParamType occurrences="1">
+    <MissingClosureParamType occurrences="2">
+      <code>$entity</code>
       <code>$entity</code>
     </MissingClosureParamType>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$fieldDefinitions</code>
+    </MixedArgumentTypeCoercion>
+    <MixedInferredReturnType occurrences="1">
+      <code>\Generator</code>
+    </MixedInferredReturnType>
   </file>
   <file src="test/Unit/FixtureFactoryTest.php">
     <ArgumentTypeCoercion occurrences="1">

--- a/src/EntityDefinition.php
+++ b/src/EntityDefinition.php
@@ -30,9 +30,19 @@ final class EntityDefinition
      * @param ORM\Mapping\ClassMetadata      $classMetadata
      * @param array<string, FieldDefinition> $fieldDefinitions
      * @param \Closure                       $afterCreate
+     *
+     * @throws Exception\InvalidFieldDefinitions
      */
     public function __construct(ORM\Mapping\ClassMetadata $classMetadata, array $fieldDefinitions, \Closure $afterCreate)
     {
+        $invalidFieldDefinitions = \array_filter($fieldDefinitions, static function ($fieldDefinition): bool {
+            return !$fieldDefinition instanceof FieldDefinition;
+        });
+
+        if ([] !== $invalidFieldDefinitions) {
+            throw Exception\InvalidFieldDefinitions::values();
+        }
+
         $this->classMetadata = $classMetadata;
         $this->fieldDefinitions = $fieldDefinitions;
         $this->afterCreate = $afterCreate;

--- a/src/Exception/InvalidFieldDefinitions.php
+++ b/src/Exception/InvalidFieldDefinitions.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/factory-bot
+ */
+
+namespace Ergebnis\FactoryBot\Exception;
+
+use Ergebnis\FactoryBot\FieldDefinition;
+
+final class InvalidFieldDefinitions extends \RuntimeException implements Exception
+{
+    public static function values(): self
+    {
+        return new self(\sprintf(
+            'Field definitions need to be instances of "%s".',
+            FieldDefinition::class
+        ));
+    }
+}

--- a/test/Unit/Exception/InvalidFieldDefinitionsTest.php
+++ b/test/Unit/Exception/InvalidFieldDefinitionsTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/factory-bot
+ */
+
+namespace Ergebnis\FactoryBot\Test\Unit\Exception;
+
+use Ergebnis\FactoryBot\Exception;
+use Ergebnis\FactoryBot\FieldDefinition;
+use Ergebnis\Test\Util\Helper;
+use PHPUnit\Framework;
+
+/**
+ * @internal
+ *
+ * @covers \Ergebnis\FactoryBot\Exception\InvalidFieldDefinitions
+ */
+final class InvalidFieldDefinitionsTest extends Framework\TestCase
+{
+    use Helper;
+
+    public function testFromClassNameCreatesException(): void
+    {
+        $exception = Exception\InvalidFieldDefinitions::values();
+
+        $message = \sprintf(
+            'Field definitions need to be instances of "%s".',
+            FieldDefinition::class
+        );
+
+        self::assertSame($message, $exception->getMessage());
+    }
+}


### PR DESCRIPTION
This PR

* [x] rejects invalid field definition values from the constructor of `EntityDefinition`