### PR TITLE
Enhancement: Add FieldDefinition::value()

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -9,8 +9,8 @@ on: # yamllint disable-line rule:truthy
       - "master"
 
 env:
-  MIN_COVERED_MSI: 99
-  MIN_MSI: 97
+  MIN_COVERED_MSI: 98
+  MIN_MSI: 96
   REQUIRED_PHP_EXTENSIONS: "mbstring"
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 
 * Imported [`breerly/factory-girl-php@0e6f1b6`](https://github.com/unhashable/factory-girl-php/tree/0e6f1b6724d39108a2e7cef68a74668b7a77b856), ([#1]), by [@localheinz]
 * Imported [`ergebnis/factory-girl-definition@23e57bc`](https://github.com/ergebnis/factory-girl-definition/tree/23e57bc2105ac7a32e3ec7103c866899fe6ad20c), ([#6]), by [@localheinz]
+* Added `FieldDefinition::value()` which allows resolving a field definition to a constant value, ([#149]), by [@localheinz]
 
 ### Changed
 
@@ -78,5 +79,6 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 [#128]: https://github.com/ergebnis/factory-bot/pull/128
 [#131]: https://github.com/ergebnis/factory-bot/pull/131
 [#133]: https://github.com/ergebnis/factory-bot/pull/133
+[#149]: https://github.com/ergebnis/factory-bot/pull/149
 
 [@localheinz]: https://github.com/localheinz

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-MIN_COVERED_MSI:=99
-MIN_MSI:=97
+MIN_COVERED_MSI:=98
+MIN_MSI:=96
 
 .PHONY: it
 it: coding-standards static-code-analysis tests ## Runs the coding-standards, static-code-analysis, and tests targets

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,6 +21,11 @@ parameters:
 			path: src/FieldDefinition.php
 
 		-
+			message: "#^Method Ergebnis\\\\FactoryBot\\\\FieldDefinition\\:\\:value\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/FieldDefinition.php
+
+		-
 			message: "#^Method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:defineEntity\\(\\) has parameter \\$afterCreate with a nullable type declaration\\.$#"
 			count: 1
 			path: src/FixtureFactory.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -21,9 +21,13 @@
     </MixedReturnStatement>
   </file>
   <file src="src/FieldDefinition.php">
-    <MissingClosureReturnType occurrences="1">
+    <MissingClosureReturnType occurrences="2">
       <code>static function () use (&amp;$n, $funcOrString) {</code>
+      <code>static function () use ($value) {</code>
     </MissingClosureReturnType>
+    <MissingParamType occurrences="1">
+      <code>$value</code>
+    </MissingParamType>
     <MissingReturnType occurrences="1">
       <code>resolve</code>
     </MissingReturnType>
@@ -38,9 +42,8 @@
     </MixedOperand>
   </file>
   <file src="src/FixtureFactory.php">
-    <MissingClosureReturnType occurrences="2">
+    <MissingClosureReturnType occurrences="1">
       <code>static function () use ($fieldDefinition) {</code>
-      <code>static function () use ($defaultFieldValue) {</code>
     </MissingClosureReturnType>
     <MissingParamType occurrences="3">
       <code>$fieldValue</code>
@@ -103,9 +106,13 @@
     </MixedInferredReturnType>
   </file>
   <file src="test/Unit/FieldDefinitionTest.php">
-    <MixedInferredReturnType occurrences="2">
+    <MixedAssignment occurrences="1">
+      <code>$resolved</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="3">
       <code>string</code>
       <code>string</code>
+      <code>\Generator</code>
     </MixedInferredReturnType>
     <MixedReturnStatement occurrences="2"/>
   </file>

--- a/src/FieldDefinition.php
+++ b/src/FieldDefinition.php
@@ -127,4 +127,11 @@ final class FieldDefinition
             );
         });
     }
+
+    public static function value($value): self
+    {
+        return new self(static function () use ($value) {
+            return $value;
+        });
+    }
 }

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -123,16 +123,10 @@ final class FixtureFactory
             );
 
             if (null === $defaultFieldValue) {
-                $fieldDefinitions[$fieldName] = FieldDefinition::sequence(static function () {
-                    return null;
-                });
-
-                continue;
+                $fieldDefinitions[$fieldName] = FieldDefinition::value(null);
             }
 
-            $fieldDefinitions[$fieldName] = FieldDefinition::sequence(static function () use ($defaultFieldValue) {
-                return $defaultFieldValue;
-            });
+            $fieldDefinitions[$fieldName] = FieldDefinition::value($defaultFieldValue);
         }
 
         if (null === $afterCreate) {

--- a/test/Unit/FieldDefinitionTest.php
+++ b/test/Unit/FieldDefinitionTest.php
@@ -326,4 +326,42 @@ final class FieldDefinitionTest extends AbstractTestCase
         self::assertSame($expected(2), $fieldDefinition->resolve($fixtureFactory));
         self::assertSame($expected(3), $fieldDefinition->resolve($fixtureFactory));
     }
+
+    /**
+     * @dataProvider provideArbitraryValue
+     *
+     * @param mixed $value
+     */
+    public function testValueResolvesToValue($value): void
+    {
+        $fixtureFactory = new FixtureFactory(self::entityManager());
+
+        $fieldDefinition = FieldDefinition::value($value);
+
+        $resolved = $fieldDefinition->resolve($fixtureFactory);
+
+        self::assertSame($value, $resolved);
+    }
+
+    public function provideArbitraryValue(): \Generator
+    {
+        $faker = self::faker();
+
+        $values = [
+            'array' => $faker->words,
+            'bool-false' => false,
+            'bool-true' => true,
+            'float' => $faker->randomFloat(),
+            'int' => $faker->numberBetween(),
+            'object' => new \stdClass(),
+            'resource' => \fopen(__FILE__, 'rb'),
+            'string' => $faker->sentence,
+        ];
+
+        foreach ($values as $key => $value) {
+            yield $key => [
+                $value,
+            ];
+        }
+    }
 }


### PR DESCRIPTION
This PR

* [x] adds `FieldDefinition::value()`, which allows resolving a field definition to a constant value