### PR TITLE
Fix: Move classes into a different namespace

### DIFF
--- a/src/Definition.php
+++ b/src/Definition.php
@@ -11,9 +11,8 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Definition;
+namespace Ergebnis\FactoryBot;
 
-use Ergebnis\FactoryBot\FixtureFactory;
 use Faker\Generator;
 
 interface Definition

--- a/src/Definitions.php
+++ b/src/Definitions.php
@@ -11,11 +11,9 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Definition;
+namespace Ergebnis\FactoryBot;
 
 use Ergebnis\Classy;
-use Ergebnis\FactoryBot\Exception;
-use Ergebnis\FactoryBot\FixtureFactory;
 use Faker\Generator;
 
 final class Definitions

--- a/test/Fixture/Definitions/DoesNotImplementDefinition/RepositoryDefinition.php
+++ b/test/Fixture/Definitions/DoesNotImplementDefinition/RepositoryDefinition.php
@@ -11,20 +11,14 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Fixture\Definition\Definitions\ImplementsDefinitionButThrowsExceptionDuringConstruction;
+namespace Ergebnis\FactoryBot\Test\Fixture\Definitions\DoesNotImplementDefinition;
 
-use Ergebnis\FactoryBot\Definition\Definition;
 use Ergebnis\FactoryBot\FixtureFactory;
 use Ergebnis\FactoryBot\Test\Fixture;
 use Faker\Generator;
 
-final class RepositoryDefinition implements Definition
+final class RepositoryDefinition
 {
-    public function __construct()
-    {
-        throw new \RuntimeException();
-    }
-
     public function accept(FixtureFactory $fixtureFactory, Generator $faker): void
     {
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class);

--- a/test/Fixture/Definitions/ImplementsDefinition/RepositoryDefinition.php
+++ b/test/Fixture/Definitions/ImplementsDefinition/RepositoryDefinition.php
@@ -11,16 +11,16 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Fixture\Definition\Definitions\ImplementsDefinitionButIsAbstract;
+namespace Ergebnis\FactoryBot\Test\Fixture\Definitions\ImplementsDefinition;
 
-use Ergebnis\FactoryBot\Definition\Definition;
+use Ergebnis\FactoryBot\Definition;
 use Ergebnis\FactoryBot\FixtureFactory;
 use Ergebnis\FactoryBot\Test\Fixture;
 use Faker\Generator;
 
-abstract class RepositoryDefinition implements Definition
+final class RepositoryDefinition implements Definition
 {
-    final public function accept(FixtureFactory $fixtureFactory, Generator $faker): void
+    public function accept(FixtureFactory $fixtureFactory, Generator $faker): void
     {
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class);
     }

--- a/test/Fixture/Definitions/ImplementsDefinitionButHasPrivateConstructor/RepositoryDefinition.php
+++ b/test/Fixture/Definitions/ImplementsDefinitionButHasPrivateConstructor/RepositoryDefinition.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Fixture\Definition\Definitions\ImplementsDefinitionButHasPrivateConstructor;
+namespace Ergebnis\FactoryBot\Test\Fixture\Definitions\ImplementsDefinitionButHasPrivateConstructor;
 
-use Ergebnis\FactoryBot\Definition\Definition;
+use Ergebnis\FactoryBot\Definition;
 use Ergebnis\FactoryBot\FixtureFactory;
 use Ergebnis\FactoryBot\Test\Fixture;
 use Faker\Generator;

--- a/test/Fixture/Definitions/ImplementsDefinitionButIsAbstract/RepositoryDefinition.php
+++ b/test/Fixture/Definitions/ImplementsDefinitionButIsAbstract/RepositoryDefinition.php
@@ -11,16 +11,16 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Fixture\Definition\Definitions\ImplementsDefinition;
+namespace Ergebnis\FactoryBot\Test\Fixture\Definitions\ImplementsDefinitionButIsAbstract;
 
-use Ergebnis\FactoryBot\Definition\Definition;
+use Ergebnis\FactoryBot\Definition;
 use Ergebnis\FactoryBot\FixtureFactory;
 use Ergebnis\FactoryBot\Test\Fixture;
 use Faker\Generator;
 
-final class RepositoryDefinition implements Definition
+abstract class RepositoryDefinition implements Definition
 {
-    public function accept(FixtureFactory $fixtureFactory, Generator $faker): void
+    final public function accept(FixtureFactory $fixtureFactory, Generator $faker): void
     {
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class);
     }

--- a/test/Fixture/Definitions/ImplementsDefinitionButThrowsExceptionDuringConstruction/RepositoryDefinition.php
+++ b/test/Fixture/Definitions/ImplementsDefinitionButThrowsExceptionDuringConstruction/RepositoryDefinition.php
@@ -11,14 +11,20 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Fixture\Definition\Definitions\DoesNotImplementDefinition;
+namespace Ergebnis\FactoryBot\Test\Fixture\Definitions\ImplementsDefinitionButThrowsExceptionDuringConstruction;
 
+use Ergebnis\FactoryBot\Definition;
 use Ergebnis\FactoryBot\FixtureFactory;
 use Ergebnis\FactoryBot\Test\Fixture;
 use Faker\Generator;
 
-final class RepositoryDefinition
+final class RepositoryDefinition implements Definition
 {
+    public function __construct()
+    {
+        throw new \RuntimeException();
+    }
+
     public function accept(FixtureFactory $fixtureFactory, Generator $faker): void
     {
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Repository::class);

--- a/test/Unit/DefinitionsTest.php
+++ b/test/Unit/DefinitionsTest.php
@@ -11,18 +11,17 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Unit\Definition;
+namespace Ergebnis\FactoryBot\Test\Unit;
 
-use Ergebnis\FactoryBot\Definition\Definitions;
+use Ergebnis\FactoryBot\Definitions;
 use Ergebnis\FactoryBot\Exception;
 use Ergebnis\FactoryBot\FixtureFactory;
 use Ergebnis\FactoryBot\Test\Fixture;
-use Ergebnis\FactoryBot\Test\Unit\AbstractTestCase;
 
 /**
  * @internal
  *
- * @covers \Ergebnis\FactoryBot\Definition\Definitions
+ * @covers \Ergebnis\FactoryBot\Definitions
  *
  * @uses \Ergebnis\FactoryBot\EntityDefinition
  * @uses \Ergebnis\FactoryBot\Exception\InvalidDefinition
@@ -37,7 +36,7 @@ final class DefinitionsTest extends AbstractTestCase
     {
         $this->expectException(Exception\InvalidDirectory::class);
 
-        Definitions::in(__DIR__ . '/../../Fixture/Definition/Definitions/NonExistentDirectory');
+        Definitions::in(__DIR__ . '/../Fixture/Definitions/NonExistentDirectory');
     }
 
     public function testInIgnoresClassesWhichDoNotImplementProviderInterface(): void
@@ -46,7 +45,7 @@ final class DefinitionsTest extends AbstractTestCase
 
         $fixtureFactory = new FixtureFactory(self::entityManager());
 
-        $definitions = Definitions::in(__DIR__ . '/../../Fixture/Definition/Definitions/DoesNotImplementDefinition');
+        $definitions = Definitions::in(__DIR__ . '/../Fixture/Definitions/DoesNotImplementDefinition');
 
         $definitions->registerWith(
             $fixtureFactory,
@@ -62,7 +61,7 @@ final class DefinitionsTest extends AbstractTestCase
 
         $fixtureFactory = new FixtureFactory(self::entityManager());
 
-        $definitions = Definitions::in(__DIR__ . '/../../Fixture/Definition/Definitions/ImplementsDefinitionButIsAbstract');
+        $definitions = Definitions::in(__DIR__ . '/../Fixture/Definitions/ImplementsDefinitionButIsAbstract');
 
         $definitions->registerWith(
             $fixtureFactory,
@@ -78,7 +77,7 @@ final class DefinitionsTest extends AbstractTestCase
 
         $fixtureFactory = new FixtureFactory(self::entityManager());
 
-        $definitions = Definitions::in(__DIR__ . '/../../Fixture/Definition/Definitions/ImplementsDefinitionButHasPrivateConstructor');
+        $definitions = Definitions::in(__DIR__ . '/../Fixture/Definitions/ImplementsDefinitionButHasPrivateConstructor');
 
         $definitions->registerWith(
             $fixtureFactory,
@@ -92,7 +91,7 @@ final class DefinitionsTest extends AbstractTestCase
     {
         $this->expectException(Exception\InvalidDefinition::class);
 
-        Definitions::in(__DIR__ . '/../../Fixture/Definition/Definitions/ImplementsDefinitionButThrowsExceptionDuringConstruction');
+        Definitions::in(__DIR__ . '/../Fixture/Definitions/ImplementsDefinitionButThrowsExceptionDuringConstruction');
     }
 
     public function testInAcceptsDefinitionsThatHaveNoIssues(): void
@@ -101,7 +100,7 @@ final class DefinitionsTest extends AbstractTestCase
 
         $fixtureFactory = new FixtureFactory(self::entityManager());
 
-        $definitions = Definitions::in(__DIR__ . '/../../Fixture/Definition/Definitions/ImplementsDefinition');
+        $definitions = Definitions::in(__DIR__ . '/../Fixture/Definitions/ImplementsDefinition');
 
         $definitions->registerWith(
             $fixtureFactory,


### PR DESCRIPTION
This PR

* [x] moves classes into a different namespace

Follows #6.