### PR TITLE
Fix: Use vendor-specific annotations

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,57 +6,12 @@ parameters:
 			path: src/EntityDefinition.php
 
 		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\FieldDefinition\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: src/FieldDefinition.php
-
-		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\FieldDefinition\\:\\:value\\(\\) has parameter \\$value with no typehint specified\\.$#"
-			count: 1
-			path: src/FieldDefinition.php
-
-		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\FieldDefinition\\\\Closure\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: src/FieldDefinition/Closure.php
-
-		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\FieldDefinition\\\\Resolvable\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: src/FieldDefinition/Resolvable.php
-
-		-
-			message: "#^Property Ergebnis\\\\FactoryBot\\\\FieldDefinition\\\\Value\\:\\:\\$value has no typehint specified\\.$#"
-			count: 1
-			path: src/FieldDefinition/Value.php
-
-		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\FieldDefinition\\\\Value\\:\\:__construct\\(\\) has parameter \\$value with no typehint specified\\.$#"
-			count: 1
-			path: src/FieldDefinition/Value.php
-
-		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\FieldDefinition\\\\Value\\:\\:resolve\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: src/FieldDefinition/Value.php
-
-		-
 			message: "#^Method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:defineEntity\\(\\) has parameter \\$afterCreate with a nullable type declaration\\.$#"
 			count: 1
 			path: src/FixtureFactory.php
 
 		-
 			message: "#^Method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:defineEntity\\(\\) has parameter \\$afterCreate with null as default value\\.$#"
-			count: 1
-			path: src/FixtureFactory.php
-
-		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:setField\\(\\) has parameter \\$fieldValue with no typehint specified\\.$#"
-			count: 1
-			path: src/FixtureFactory.php
-
-		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:createCollectionFrom\\(\\) has parameter \\$array with no typehint specified\\.$#"
 			count: 1
 			path: src/FixtureFactory.php
 
@@ -111,7 +66,17 @@ parameters:
 			path: test/Fixture/FixtureFactory/Entity/User.php
 
 		-
-			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertIsArray\\(\\) with array will always evaluate to true\\.$#"
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot…' and Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\User will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/FieldDefinition/ReferenceTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot…' and Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\User will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/FieldDefinitionTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertIsArray\\(\\) with array\\<int, Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\User\\> will always evaluate to true\\.$#"
 			count: 2
 			path: test/Unit/FieldDefinitionTest.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4,92 +4,17 @@
     <DocblockTypeContradiction occurrences="1">
       <code>return !$fieldDefinition instanceof FieldDefinition\Resolvable;</code>
     </DocblockTypeContradiction>
-    <MissingPropertyType occurrences="3">
-      <code>$classMetadata</code>
-      <code>$fieldDefinitions</code>
-      <code>$afterCreate</code>
-    </MissingPropertyType>
-    <MixedInferredReturnType occurrences="3">
-      <code>ORM\Mapping\ClassMetadata</code>
-      <code>array&lt;string, FieldDefinition\Resolvable&gt;</code>
-      <code>\Closure</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="3">
-      <code>$this-&gt;classMetadata</code>
-      <code>$this-&gt;fieldDefinitions</code>
-      <code>$this-&gt;afterCreate</code>
-    </MixedReturnStatement>
   </file>
   <file src="src/FieldDefinition.php">
     <MissingClosureReturnType occurrences="1">
       <code>static function () use (&amp;$n, $funcOrString) {</code>
     </MissingClosureReturnType>
-    <MissingParamType occurrences="1">
-      <code>$value</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="1">
-      <code>resolve</code>
-    </MissingReturnType>
     <MixedOperand occurrences="1">
       <code>$n</code>
     </MixedOperand>
   </file>
-  <file src="src/FieldDefinition/Closure.php">
-    <MissingReturnType occurrences="1">
-      <code>resolve</code>
-    </MissingReturnType>
-  </file>
-  <file src="src/FieldDefinition/References.php">
-    <MissingPropertyType occurrences="2">
-      <code>$className</code>
-      <code>$count</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="2">
-      <code>$this-&gt;className</code>
-      <code>$this-&gt;count</code>
-    </MixedArgument>
-  </file>
-  <file src="src/FieldDefinition/Resolvable.php">
-    <MissingReturnType occurrences="1">
-      <code>resolve</code>
-    </MissingReturnType>
-  </file>
-  <file src="src/FieldDefinition/Sequence.php">
-    <MissingPropertyType occurrences="2">
-      <code>$value</code>
-      <code>$sequentialNumber</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="1">
-      <code>$this-&gt;value</code>
-    </MixedArgument>
-    <MixedOperand occurrences="1">
-      <code>$this-&gt;sequentialNumber</code>
-    </MixedOperand>
-  </file>
-  <file src="src/FieldDefinition/Value.php">
-    <MissingParamType occurrences="1">
-      <code>$value</code>
-    </MissingParamType>
-    <MissingPropertyType occurrences="1">
-      <code>$value</code>
-    </MissingPropertyType>
-    <MissingReturnType occurrences="1">
-      <code>resolve</code>
-    </MissingReturnType>
-  </file>
   <file src="src/FixtureFactory.php">
-    <MissingClosureReturnType occurrences="1">
-      <code>static function () use ($fieldDefinition) {</code>
-    </MissingClosureReturnType>
-    <MissingParamType occurrences="2">
-      <code>$fieldValue</code>
-      <code>$array</code>
-    </MissingParamType>
-    <MixedArgumentTypeCoercion occurrences="1">
-      <code>$fieldOverrides</code>
-    </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="6">
-      <code>$defaultFieldValue</code>
+    <MixedAssignment occurrences="5">
       <code>$fieldValues[$fieldName]</code>
       <code>$fieldValues[$fieldName]</code>
       <code>$fieldValue</code>
@@ -140,6 +65,11 @@
       <code>$fieldDefinitions</code>
     </MixedArgumentTypeCoercion>
   </file>
+  <file src="test/Unit/FieldDefinition/ReferenceTest.php">
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>assertInstanceOf</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
   <file src="test/Unit/FieldDefinition/ValueTest.php">
     <MixedAssignment occurrences="1">
       <code>$resolved</code>
@@ -159,6 +89,9 @@
       <code>assertIsArray</code>
       <code>assertIsArray</code>
     </RedundantCondition>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>assertInstanceOf</code>
+    </RedundantConditionGivenDocblockType>
   </file>
   <file src="test/Unit/FixtureFactoryTest.php">
     <ArgumentTypeCoercion occurrences="1">

--- a/src/Definitions.php
+++ b/src/Definitions.php
@@ -19,7 +19,9 @@ use Faker\Generator;
 final class Definitions
 {
     /**
-     * @var Definition[]
+     * @psalm-var list<Definition>
+     *
+     * @var array<int, Definition>
      */
     private $definitions = [];
 

--- a/src/EntityDefinition.php
+++ b/src/EntityDefinition.php
@@ -20,10 +20,19 @@ use Doctrine\ORM;
  */
 final class EntityDefinition
 {
+    /**
+     * @var ORM\Mapping\ClassMetadata
+     */
     private $classMetadata;
 
+    /**
+     * @var array<string, FieldDefinition\Resolvable>
+     */
     private $fieldDefinitions;
 
+    /**
+     * @var \Closure
+     */
     private $afterCreate;
 
     /**

--- a/src/FieldDefinition.php
+++ b/src/FieldDefinition.php
@@ -15,6 +15,9 @@ namespace Ergebnis\FactoryBot;
 
 final class FieldDefinition implements FieldDefinition\Resolvable
 {
+    /**
+     * @var \Closure
+     */
     private $closure;
 
     private function __construct(\Closure $closure)
@@ -74,13 +77,15 @@ final class FieldDefinition implements FieldDefinition\Resolvable
     }
 
     /**
-     * Defines a field to `get()` a named entity from the factory.
+     * @phpstan-param class-string<T> $className
+     * @phpstan-return FieldDefinition\Reference<T>
+     * @phpstan-template T
      *
-     * The normal semantics of `get()` apply.
+     * @psalm-param class-string<T> $className
+     * @psalm-return FieldDefinition\Reference<T>
+     * @psalm-template T
      *
-     * @template T
-     *
-     * @param class-string<T> $className
+     * @param string $className
      *
      * @return FieldDefinition\Reference
      */
@@ -90,10 +95,16 @@ final class FieldDefinition implements FieldDefinition\Resolvable
     }
 
     /**
-     * @template T
+     * @phpstan-param class-string<T> $className
+     * @phpstan-return FieldDefinition\References<T>
+     * @phpstan-template T
      *
-     * @param class-string<T> $className
-     * @param int             $count
+     * @psalm-param class-string<T> $className
+     * @psalm-return FieldDefinition\References<T>
+     * @psalm-template T
+     *
+     * @param string $className
+     * @param int    $count
      *
      * @throws Exception\InvalidCount
      *
@@ -107,6 +118,19 @@ final class FieldDefinition implements FieldDefinition\Resolvable
         );
     }
 
+    /**
+     * @phpstan-param T $value
+     * @phpstan-return FieldDefinition\Value<T>
+     * @phpstan-template T
+     *
+     * @psalm-param T $value
+     * @psalm-return FieldDefinition\Value<T>
+     * @psalm-template T
+     *
+     * @param mixed $value
+     *
+     * @return FieldDefinition\Value
+     */
     public static function value($value): FieldDefinition\Value
     {
         return new FieldDefinition\Value($value);

--- a/src/FieldDefinition/Closure.php
+++ b/src/FieldDefinition/Closure.php
@@ -20,6 +20,9 @@ use Ergebnis\FactoryBot\FixtureFactory;
  */
 final class Closure implements Resolvable
 {
+    /**
+     * @var \Closure
+     */
     private $closure;
 
     public function __construct(\Closure $closure)

--- a/src/FieldDefinition/Reference.php
+++ b/src/FieldDefinition/Reference.php
@@ -17,20 +17,44 @@ use Ergebnis\FactoryBot\FixtureFactory;
 
 /**
  * @internal
+ *
+ * @phpstan-template T
+ *
+ * @psalm-template T
  */
 final class Reference implements Resolvable
 {
+    /**
+     * @phpstan-var class-string<T>
+     *
+     * @psalm-var class-string<T>
+     *
+     * @var string
+     */
     private $className;
 
     /**
-     * @param class-string $className
+     * @phpstan-param class-string<T> $className
+     *
+     * @psalm-param class-string<T> $className
+     *
+     * @param string $className
      */
     public function __construct(string $className)
     {
         $this->className = $className;
     }
 
-    public function resolve(FixtureFactory $fixtureFactory): object
+    /**
+     * @phpstan-return T
+     *
+     * @psalm-return T
+     *
+     * @param FixtureFactory $fixtureFactory
+     *
+     * @return object
+     */
+    public function resolve(FixtureFactory $fixtureFactory)
     {
         return $fixtureFactory->get($this->className);
     }

--- a/src/FieldDefinition/References.php
+++ b/src/FieldDefinition/References.php
@@ -18,16 +18,34 @@ use Ergebnis\FactoryBot\FixtureFactory;
 
 /**
  * @internal
+ *
+ * @phpstan-template T
+ *
+ * @psalm-template T
  */
 final class References implements Resolvable
 {
+    /**
+     * @phpstan-var class-string<T>
+     *
+     * @psalm-var class-string<T>
+     *
+     * @var string
+     */
     private $className;
 
+    /**
+     * @var int
+     */
     private $count;
 
     /**
-     * @param class-string $className
-     * @param int          $count
+     * @phpstan-param class-string<T> $className
+     *
+     * @psalm-param class-string<T> $className
+     *
+     * @param string $className
+     * @param int    $count
      *
      * @throws Exception\InvalidCount
      */
@@ -44,6 +62,15 @@ final class References implements Resolvable
         $this->count = $count;
     }
 
+    /**
+     * @phpstan-return array<int, T>
+     *
+     * @psalm-return list<T>
+     *
+     * @param FixtureFactory $fixtureFactory
+     *
+     * @return array<int, object>
+     */
     public function resolve(FixtureFactory $fixtureFactory): array
     {
         return $fixtureFactory->getList(

--- a/src/FieldDefinition/Resolvable.php
+++ b/src/FieldDefinition/Resolvable.php
@@ -17,5 +17,10 @@ use Ergebnis\FactoryBot\FixtureFactory;
 
 interface Resolvable
 {
+    /**
+     * @param FixtureFactory $fixtureFactory
+     *
+     * @return mixed
+     */
     public function resolve(FixtureFactory $fixtureFactory);
 }

--- a/src/FieldDefinition/Sequence.php
+++ b/src/FieldDefinition/Sequence.php
@@ -21,8 +21,14 @@ use Ergebnis\FactoryBot\FixtureFactory;
  */
 final class Sequence implements Resolvable
 {
+    /**
+     * @var string
+     */
     private $value;
 
+    /**
+     * @var int
+     */
     private $sequentialNumber;
 
     /**

--- a/src/FieldDefinition/Value.php
+++ b/src/FieldDefinition/Value.php
@@ -17,16 +17,43 @@ use Ergebnis\FactoryBot\FixtureFactory;
 
 /**
  * @internal
+ *
+ * @phpstan-template T
+ *
+ * @psalm-template T
  */
 final class Value implements Resolvable
 {
+    /**
+     * @phpstan-var T
+     *
+     * @psalm-var T
+     *
+     * @var mixed
+     */
     private $value;
 
+    /**
+     * @phpstan-param T $value
+     *
+     * @psalm-param T $value
+     *
+     * @param mixed $value
+     */
     public function __construct($value)
     {
         $this->value = $value;
     }
 
+    /**
+     * @phpstan-return T
+     *
+     * @psalm-return T
+     *
+     * @param FixtureFactory $fixtureFactory
+     *
+     * @return mixed
+     */
     public function resolve(FixtureFactory $fixtureFactory)
     {
         return $this->value;

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -45,9 +45,14 @@ final class FixtureFactory
      *
      * See the readme for a tutorial.
      *
-     * @template T
+     * @phpstan-param class-string<T> $className
+     * @phpstan-template T
      *
-     * @param class-string<T>               $className
+     * @psalm-param class-string<T> $className
+     * @psalm-param class-string<T> $className
+     * @psalm-template T
+     *
+     * @param string                        $className
      * @param array<string, \Closure|mixed> $fieldDefinitions
      * @param \Closure                      $afterCreate
      *
@@ -72,7 +77,7 @@ final class FixtureFactory
             throw Exception\ClassMetadataNotFound::for($className);
         }
 
-        /** @var string[] $allFieldNames */
+        /** @var array<int, string> $allFieldNames */
         $allFieldNames = \array_merge(
             \array_keys($classMetadata->fieldMappings),
             \array_keys($classMetadata->associationMappings),
@@ -105,9 +110,7 @@ final class FixtureFactory
                 return FieldDefinition::sequence($fieldDefinition);
             }
 
-            return FieldDefinition::sequence(static function () use ($fieldDefinition) {
-                return $fieldDefinition;
-            });
+            return FieldDefinition::value($fieldDefinition);
         }, $fieldDefinitions);
 
         $defaultEntity = $classMetadata->newInstance();
@@ -117,6 +120,7 @@ final class FixtureFactory
                 continue;
             }
 
+            /** @var mixed $defaultFieldValue */
             $defaultFieldValue = $classMetadata->getFieldValue(
                 $defaultEntity,
                 $fieldName
@@ -143,15 +147,21 @@ final class FixtureFactory
      *
      * If you've called `persistOnGet()` then the entity is also persisted.
      *
-     * @template T
+     * @phpstan-param class-string<T> $className
+     * @phpstan-return T
+     * @phpstan-template T
      *
-     * @param class-string<T>      $className
+     * @psalm-param class-string<T> $className
+     * @psalm-return T
+     * @psalm-template T
+     *
+     * @param string               $className
      * @param array<string, mixed> $fieldOverrides
      *
      * @throws Exception\EntityDefinitionNotRegistered
      * @throws Exception\InvalidFieldNames
      *
-     * @return T
+     * @return object
      */
     public function get(string $className, array $fieldOverrides = [])
     {
@@ -221,15 +231,21 @@ final class FixtureFactory
      *
      * If you've called `persistOnGet()` then the entities are also persisted.
      *
-     * @template T
+     * @phpstan-param class-string<T> $className
+     * @phpstan-return array<int, T>
+     * @phpstan-template T
      *
-     * @param class-string<T> $className
-     * @param array           $fieldOverrides
-     * @param int             $count
+     * @psalm-param class-string<T> $className
+     * @psalm-return list<T>
+     * @psalm-template T
+     *
+     * @param string               $className
+     * @param array<string, mixed> $fieldOverrides
+     * @param int                  $count
      *
      * @throws Exception\InvalidCount
      *
-     * @return array<int, T>
+     * @return array<int, object>
      */
     public function getList(string $className, array $fieldOverrides = [], int $count = 1): array
     {
@@ -267,13 +283,19 @@ final class FixtureFactory
     }
 
     /**
-     * @return EntityDefinition[]
+     * @return array<string, EntityDefinition>
      */
     public function definitions(): array
     {
         return $this->entityDefinitions;
     }
 
+    /**
+     * @param object           $entity
+     * @param EntityDefinition $entityDefinition
+     * @param string           $fieldName
+     * @param mixed            $fieldValue
+     */
     private function setField(object $entity, EntityDefinition $entityDefinition, string $fieldName, $fieldValue): void
     {
         $classMetadata = $entityDefinition->classMetadata();
@@ -302,10 +324,15 @@ final class FixtureFactory
         }
     }
 
-    private static function createCollectionFrom($array = []): Common\Collections\ArrayCollection
+    /**
+     * @param mixed $value
+     *
+     * @return Common\Collections\ArrayCollection
+     */
+    private static function createCollectionFrom($value = []): Common\Collections\ArrayCollection
     {
-        if (\is_array($array)) {
-            return new Common\Collections\ArrayCollection($array);
+        if (\is_array($value)) {
+            return new Common\Collections\ArrayCollection($value);
         }
 
         return new Common\Collections\ArrayCollection();


### PR DESCRIPTION
This PR

* [x] uses vendor-specific annotations to assist with static code analysis