### PR TITLE
Fix: Use --generate-baseline to generate baseline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,7 @@ static-code-analysis: vendor ## Runs a static code analysis with phpstan/phpstan
 .PHONY: static-code-analysis-baseline
 static-code-analysis-baseline: vendor ## Generates a baseline for static code analysis with phpstan/phpstan and vimeo/psalm
 	mkdir -p .build/phpstan
-	echo '' > phpstan-baseline.neon
-	vendor/bin/phpstan analyze --configuration=phpstan.neon --error-format=baselineNeon > phpstan-baseline.neon || true
+	vendor/bin/phpstan analyze --configuration=phpstan.neon --generate-baseline=phpstan-baseline.neon
 	mkdir -p .build/psalm
 	vendor/bin/psalm --config=psalm.xml --set-baseline=psalm-baseline.xml
 


### PR DESCRIPTION
This PR

* [x] uses `--generate-baseline` to generate the baseline for `phpstan`