### PR TITLE
Enhancement: Introduce named constructor and mark primary constructor private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 * Extracted `FieldDefinition\Value` ([#160]), by [@localheinz]
 * Extracted `FieldDefinition\Closure` ([#161]), by [@localheinz]
 * Extracted `FieldDefinition\Sequence` ([#164]), by [@localheinz]
+* Introduced named constructors for field definitions and marked primary constructor as `private` ([#188]), by [@localheinz]
 
 ### Fixed
 
@@ -93,5 +94,6 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 [#161]: https://github.com/ergebnis/factory-bot/pull/161
 [#164]: https://github.com/ergebnis/factory-bot/pull/164
 [#185]: https://github.com/ergebnis/factory-bot/pull/185
+[#188]: https://github.com/ergebnis/factory-bot/pull/188
 
 [@localheinz]: https://github.com/localheinz

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -66,11 +66,6 @@ parameters:
 			path: test/Fixture/FixtureFactory/Entity/User.php
 
 		-
-			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Test\\\\\\\\Fixture\\\\\\\\FixtureFactory\\\\\\\\Entity\\\\\\\\User' and Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\User will always evaluate to true\\.$#"
-			count: 1
-			path: test/Unit/FieldDefinition/ReferenceTest.php
-
-		-
 			message: "#^Parameter \\#1 \\$className of method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:defineEntity\\(\\) expects class\\-string\\<NotAClass\\>, string given\\.$#"
 			count: 1
 			path: test/Unit/FixtureFactoryTest.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5,6 +5,44 @@
       <code>return !$fieldDefinition instanceof FieldDefinition\Resolvable;</code>
     </DocblockTypeContradiction>
   </file>
+  <file src="src/FieldDefinition.php">
+    <ArgumentTypeCoercion occurrences="2">
+      <code>$className</code>
+      <code>$className</code>
+    </ArgumentTypeCoercion>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$value</code>
+    </MixedArgumentTypeCoercion>
+    <MixedReturnTypeCoercion occurrences="4">
+      <code>FieldDefinition\Reference::required($className)</code>
+      <code>FieldDefinition\Reference&lt;T&gt;</code>
+      <code>FieldDefinition\References&lt;T&gt;</code>
+    </MixedReturnTypeCoercion>
+  </file>
+  <file src="src/FieldDefinition/Reference.php">
+    <MixedInferredReturnType occurrences="1">
+      <code>self&lt;T&gt;</code>
+    </MixedInferredReturnType>
+    <UndefinedDocblockClass occurrences="1">
+      <code>class-string&lt;T&gt;</code>
+    </UndefinedDocblockClass>
+  </file>
+  <file src="src/FieldDefinition/References.php">
+    <MixedInferredReturnType occurrences="1">
+      <code>self&lt;T&gt;</code>
+    </MixedInferredReturnType>
+    <UndefinedDocblockClass occurrences="1">
+      <code>class-string&lt;T&gt;</code>
+    </UndefinedDocblockClass>
+  </file>
+  <file src="src/FieldDefinition/Value.php">
+    <MixedInferredReturnType occurrences="1">
+      <code>self&lt;T&gt;</code>
+    </MixedInferredReturnType>
+    <UndefinedClass occurrences="1">
+      <code>T</code>
+    </UndefinedClass>
+  </file>
   <file src="src/FixtureFactory.php">
     <MixedAssignment occurrences="5">
       <code>$fieldValues[$fieldName]</code>
@@ -58,14 +96,33 @@
     </MixedArgumentTypeCoercion>
   </file>
   <file src="test/Unit/FieldDefinition/ReferenceTest.php">
-    <RedundantConditionGivenDocblockType occurrences="1">
-      <code>assertInstanceOf</code>
-    </RedundantConditionGivenDocblockType>
+    <InvalidArgument occurrences="1">
+      <code>$className</code>
+    </InvalidArgument>
+  </file>
+  <file src="test/Unit/FieldDefinition/ReferencesTest.php">
+    <InvalidArgument occurrences="2">
+      <code>Fixture\FixtureFactory\Entity\User::class</code>
+      <code>$className</code>
+    </InvalidArgument>
   </file>
   <file src="test/Unit/FieldDefinition/ValueTest.php">
+    <MixedArgument occurrences="1">
+      <code>$value</code>
+    </MixedArgument>
     <MixedAssignment occurrences="1">
       <code>$resolved</code>
     </MixedAssignment>
+  </file>
+  <file src="test/Unit/FieldDefinitionTest.php">
+    <InvalidArgument occurrences="3">
+      <code>$className</code>
+      <code>$className</code>
+      <code>$className</code>
+    </InvalidArgument>
+    <MixedArgument occurrences="1">
+      <code>$value</code>
+    </MixedArgument>
   </file>
   <file src="test/Unit/FixtureFactoryTest.php">
     <ArgumentTypeCoercion occurrences="1">

--- a/src/FieldDefinition.php
+++ b/src/FieldDefinition.php
@@ -17,7 +17,7 @@ final class FieldDefinition
 {
     public static function closure(\Closure $closure): FieldDefinition\Closure
     {
-        return new FieldDefinition\Closure($closure);
+        return FieldDefinition\Closure::required($closure);
     }
 
     /**
@@ -32,7 +32,7 @@ final class FieldDefinition
             $value .= '%d';
         }
 
-        return new FieldDefinition\Sequence(
+        return FieldDefinition\Sequence::required(
             $value,
             $initialNumber
         );
@@ -53,7 +53,7 @@ final class FieldDefinition
      */
     public static function reference(string $className): FieldDefinition\Reference
     {
-        return new FieldDefinition\Reference($className);
+        return FieldDefinition\Reference::required($className);
     }
 
     /**
@@ -74,7 +74,7 @@ final class FieldDefinition
      */
     public static function references(string $className, int $count = 1): FieldDefinition\References
     {
-        return new FieldDefinition\References(
+        return FieldDefinition\References::required(
             $className,
             $count
         );
@@ -95,6 +95,6 @@ final class FieldDefinition
      */
     public static function value($value): FieldDefinition\Value
     {
-        return new FieldDefinition\Value($value);
+        return FieldDefinition\Value::required($value);
     }
 }

--- a/src/FieldDefinition/Closure.php
+++ b/src/FieldDefinition/Closure.php
@@ -25,9 +25,14 @@ final class Closure implements Resolvable
      */
     private $closure;
 
-    public function __construct(\Closure $closure)
+    private function __construct(\Closure $closure)
     {
         $this->closure = $closure;
+    }
+
+    public static function required(\Closure $closure): self
+    {
+        return new self($closure);
     }
 
     public function resolve(FixtureFactory $fixtureFactory)

--- a/src/FieldDefinition/Reference.php
+++ b/src/FieldDefinition/Reference.php
@@ -40,9 +40,25 @@ final class Reference implements Resolvable
      *
      * @param string $className
      */
-    public function __construct(string $className)
+    private function __construct(string $className)
     {
         $this->className = $className;
+    }
+
+    /**
+     * @phpstan-param class-string<T> $className
+     * @phpstan-return self<T>
+     *
+     * @psalm-param class-string<T> $className
+     * @psalm-return self<T>
+     *
+     * @param string $className
+     *
+     * @return self
+     */
+    public static function required(string $className): self
+    {
+        return new self($className);
     }
 
     /**

--- a/src/FieldDefinition/References.php
+++ b/src/FieldDefinition/References.php
@@ -46,10 +46,28 @@ final class References implements Resolvable
      *
      * @param string $className
      * @param int    $count
+     */
+    private function __construct(string $className, int $count)
+    {
+        $this->className = $className;
+        $this->count = $count;
+    }
+
+    /**
+     * @phpstan-param class-string<T> $className
+     * @phpstan-return self<T>
+     *
+     * @psalm-param class-string<T> $className
+     * @psalm-return self<T>
+     *
+     * @param string $className
+     * @param int    $count
      *
      * @throws Exception\InvalidCount
+     *
+     * @return self
      */
-    public function __construct(string $className, int $count)
+    public static function required(string $className, int $count): self
     {
         if (1 > $count) {
             throw Exception\InvalidCount::notGreaterThanOrEqualTo(
@@ -58,8 +76,10 @@ final class References implements Resolvable
             );
         }
 
-        $this->className = $className;
-        $this->count = $count;
+        return new self(
+            $className,
+            $count
+        );
     }
 
     /**

--- a/src/FieldDefinition/Sequence.php
+++ b/src/FieldDefinition/Sequence.php
@@ -31,19 +31,30 @@ final class Sequence implements Resolvable
      */
     private $sequentialNumber;
 
+    private function __construct(string $value, int $initialNumber)
+    {
+        $this->value = $value;
+        $this->sequentialNumber = $initialNumber;
+    }
+
     /**
      * @param string $value
      * @param int    $initialNumber
      *
      * @throws Exception\InvalidSequence
+     *
+     * @return self
      */
-    public function __construct(string $value, int $initialNumber)
+    public static function required(string $value, int $initialNumber): self
     {
         if (false === \strpos($value, '%d')) {
             throw Exception\InvalidSequence::value($value);
         }
-        $this->value = $value;
-        $this->sequentialNumber = $initialNumber;
+
+        return new self(
+            $value,
+            $initialNumber
+        );
     }
 
     public function resolve(FixtureFactory $fixtureFactory): string

--- a/src/FieldDefinition/Value.php
+++ b/src/FieldDefinition/Value.php
@@ -40,9 +40,25 @@ final class Value implements Resolvable
      *
      * @param mixed $value
      */
-    public function __construct($value)
+    private function __construct($value)
     {
         $this->value = $value;
+    }
+
+    /**
+     * @phpstan-param T $value
+     * @phpstan-return self<T>
+     *
+     * @psalm-param T $value
+     * @psalm-return self<T>
+     *
+     * @param mixed $value
+     *
+     * @return self
+     */
+    public static function required($value): self
+    {
+        return new self($value);
     }
 
     /**

--- a/test/Unit/FieldDefinition/ClosureTest.php
+++ b/test/Unit/FieldDefinition/ClosureTest.php
@@ -40,7 +40,7 @@ final class ClosureTest extends AbstractTestCase
             return $fixtureFactory->get(Fixture\FixtureFactory\Entity\User::class);
         };
 
-        $fieldDefinition = new Closure($closure);
+        $fieldDefinition = Closure::required($closure);
 
         $resolved = $fieldDefinition->resolve($fixtureFactory);
 

--- a/test/Unit/FieldDefinition/ReferenceTest.php
+++ b/test/Unit/FieldDefinition/ReferenceTest.php
@@ -38,7 +38,7 @@ final class ReferenceTest extends AbstractTestCase
 
         $fixtureFactory->defineEntity($className);
 
-        $fieldDefinition = new Reference($className);
+        $fieldDefinition = Reference::required($className);
 
         $resolved = $fieldDefinition->resolve($fixtureFactory);
 

--- a/test/Unit/FieldDefinition/ReferencesTest.php
+++ b/test/Unit/FieldDefinition/ReferencesTest.php
@@ -45,7 +45,7 @@ final class ReferencesTest extends AbstractTestCase
             $count
         ));
 
-        new References(
+        References::required(
             Fixture\FixtureFactory\Entity\User::class,
             $count
         );
@@ -64,7 +64,7 @@ final class ReferencesTest extends AbstractTestCase
 
         $fixtureFactory->defineEntity($className);
 
-        $fieldDefinition = new References(
+        $fieldDefinition = References::required(
             $className,
             $count
         );

--- a/test/Unit/FieldDefinition/SequenceTest.php
+++ b/test/Unit/FieldDefinition/SequenceTest.php
@@ -41,7 +41,7 @@ final class SequenceTest extends AbstractTestCase
             $value
         ));
 
-        new Sequence(
+        Sequence::required(
             $value,
             $initialNumber
         );
@@ -57,7 +57,7 @@ final class SequenceTest extends AbstractTestCase
 
         $fixtureFactory = new FixtureFactory(self::entityManager());
 
-        $fieldDefinition = new Sequence(
+        $fieldDefinition = Sequence::required(
             $value,
             $initialNumber
         );

--- a/test/Unit/FieldDefinition/ValueTest.php
+++ b/test/Unit/FieldDefinition/ValueTest.php
@@ -37,7 +37,7 @@ final class ValueTest extends AbstractTestCase
     {
         $fixtureFactory = new FixtureFactory(self::entityManager());
 
-        $fieldDefinition = new Value($value);
+        $fieldDefinition = Value::required($value);
 
         $resolved = $fieldDefinition->resolve($fixtureFactory);
 

--- a/test/Unit/FieldDefinitionTest.php
+++ b/test/Unit/FieldDefinitionTest.php
@@ -45,7 +45,7 @@ final class FieldDefinitionTest extends AbstractTestCase
 
         $fieldDefinition = FieldDefinition::closure($closure);
 
-        $expected = new FieldDefinition\Closure($closure);
+        $expected = FieldDefinition\Closure::required($closure);
 
         self::assertEquals($expected, $fieldDefinition);
     }
@@ -56,7 +56,7 @@ final class FieldDefinitionTest extends AbstractTestCase
 
         $fieldDefinition = FieldDefinition::reference($className);
 
-        $expected = new FieldDefinition\Reference($className);
+        $expected = FieldDefinition\Reference::required($className);
 
         self::assertEquals($expected, $fieldDefinition);
     }
@@ -84,7 +84,7 @@ final class FieldDefinitionTest extends AbstractTestCase
 
         $fieldDefinition = FieldDefinition::references($className);
 
-        $expected = new FieldDefinition\References(
+        $expected = FieldDefinition\References::required(
             $className,
             1
         );
@@ -106,7 +106,7 @@ final class FieldDefinitionTest extends AbstractTestCase
             $count
         );
 
-        $expected = new FieldDefinition\References(
+        $expected = FieldDefinition\References::required(
             $className,
             $count
         );
@@ -120,7 +120,7 @@ final class FieldDefinitionTest extends AbstractTestCase
 
         $fieldDefinition = FieldDefinition::sequence($value);
 
-        $expected = new FieldDefinition\Sequence(
+        $expected = FieldDefinition\Sequence::required(
             $value,
             1
         );
@@ -142,7 +142,7 @@ final class FieldDefinitionTest extends AbstractTestCase
             $initialNumber
         );
 
-        $expected = new FieldDefinition\Sequence(
+        $expected = FieldDefinition\Sequence::required(
             $value,
             $initialNumber
         );
@@ -156,7 +156,7 @@ final class FieldDefinitionTest extends AbstractTestCase
 
         $fieldDefinition = FieldDefinition::sequence($value);
 
-        $expected = new FieldDefinition\Sequence(
+        $expected = FieldDefinition\Sequence::required(
             $value . '%d',
             1
         );
@@ -178,7 +178,7 @@ final class FieldDefinitionTest extends AbstractTestCase
             $initialNumber
         );
 
-        $expected = new FieldDefinition\Sequence(
+        $expected = FieldDefinition\Sequence::required(
             $value . '%d',
             $initialNumber
         );
@@ -195,7 +195,7 @@ final class FieldDefinitionTest extends AbstractTestCase
     {
         $fieldDefinition = FieldDefinition::value($value);
 
-        $expected = new FieldDefinition\Value($value);
+        $expected = FieldDefinition\Value::required($value);
 
         self::assertEquals($expected, $fieldDefinition);
     }


### PR DESCRIPTION
This PR

* [x] introduced named constructors for field definitions and marks primary constructor as `private`

Related to #167.