### PR TITLE
Fix: Rename get() to create()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 * Extracted `FieldDefinition\Closure` ([#161]), by [@localheinz]
 * Extracted `FieldDefinition\Sequence` ([#164]), by [@localheinz]
 * Introduced named constructors for field definitions and marked primary constructor as `private` ([#188]), by [@localheinz]
+* Renamed `FixtureFactory::get()` to `FixtureFactory::create()` ([#189]), by [@localheinz]
 
 ### Fixed
 
@@ -95,5 +96,6 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 [#164]: https://github.com/ergebnis/factory-bot/pull/164
 [#185]: https://github.com/ergebnis/factory-bot/pull/185
 [#188]: https://github.com/ergebnis/factory-bot/pull/188
+[#189]: https://github.com/ergebnis/factory-bot/pull/189
 
 [@localheinz]: https://github.com/localheinz

--- a/src/FieldDefinition/Reference.php
+++ b/src/FieldDefinition/Reference.php
@@ -72,6 +72,6 @@ final class Reference implements Resolvable
      */
     public function resolve(FixtureFactory $fixtureFactory)
     {
-        return $fixtureFactory->get($this->className);
+        return $fixtureFactory->create($this->className);
     }
 }

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -143,10 +143,6 @@ final class FixtureFactory
     }
 
     /**
-     * Get an entity and its dependencies.
-     *
-     * If you've called `persistOnGet()` then the entity is also persisted.
-     *
      * @phpstan-param class-string<T> $className
      * @phpstan-return T
      * @phpstan-template T
@@ -163,7 +159,7 @@ final class FixtureFactory
      *
      * @return object
      */
-    public function get(string $className, array $fieldOverrides = [])
+    public function create(string $className, array $fieldOverrides = [])
     {
         if (!\array_key_exists($className, $this->entityDefinitions)) {
             throw Exception\EntityDefinitionNotRegistered::for($className);
@@ -261,7 +257,7 @@ final class FixtureFactory
         $instances = [];
 
         for ($i = 0; $i < $count; ++$i) {
-            $instances[] = $this->get(
+            $instances[] = $this->create(
                 $className,
                 $fieldOverrides
             );

--- a/test/Integration/FixtureFactoryTest.php
+++ b/test/Integration/FixtureFactoryTest.php
@@ -30,7 +30,7 @@ use Ergebnis\FactoryBot\Test\Fixture;
  */
 final class FixtureFactoryTest extends AbstractTestCase
 {
-    public function testAutomaticPersistCanBeTurnedOn(): void
+    public function testCreatePersistsEntityWhenPersistOnGetHasBeenTurnedOn(): void
     {
         $entityManager = self::entityManager();
 
@@ -43,7 +43,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         $fixtureFactory->persistOnGet();
 
         /** @var Fixture\FixtureFactory\Entity\Organization $organization */
-        $organization = $fixtureFactory->get(Fixture\FixtureFactory\Entity\Organization::class);
+        $organization = $fixtureFactory->create(Fixture\FixtureFactory\Entity\Organization::class);
 
         $entityManager->flush();
 
@@ -51,7 +51,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         self::assertSame($organization, $entityManager->find(Fixture\FixtureFactory\Entity\Organization::class, $organization->id()));
     }
 
-    public function testDoesNotPersistByDefault(): void
+    public function testCreateDoesNotNotPersistEntityByDefault(): void
     {
         $entityManager = self::entityManager();
 
@@ -62,7 +62,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         ]);
 
         /** @var Fixture\FixtureFactory\Entity\Organization $organization */
-        $organization = $fixtureFactory->get(Fixture\FixtureFactory\Entity\Organization::class);
+        $organization = $fixtureFactory->create(Fixture\FixtureFactory\Entity\Organization::class);
 
         $entityManager->flush();
 
@@ -76,7 +76,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         self::assertEmpty($query->getResult());
     }
 
-    public function testDoesNotPersistEmbeddableWhenAutomaticPersistingIsTurnedOn(): void
+    public function testCreateDoesNotPersistEmbeddablesWhenPersistOnGetHasBeenTurnedOn(): void
     {
         $faker = self::faker();
 
@@ -97,7 +97,7 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         $fixtureFactory->persistOnGet();
 
-        $fixtureFactory->get(Fixture\FixtureFactory\Entity\User::class);
+        $fixtureFactory->create(Fixture\FixtureFactory\Entity\User::class);
 
         $entityManager->flush();
 

--- a/test/Unit/FieldDefinition/ClosureTest.php
+++ b/test/Unit/FieldDefinition/ClosureTest.php
@@ -37,7 +37,7 @@ final class ClosureTest extends AbstractTestCase
         $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\User::class);
 
         $closure = static function (FixtureFactory $fixtureFactory): Fixture\FixtureFactory\Entity\User {
-            return $fixtureFactory->get(Fixture\FixtureFactory\Entity\User::class);
+            return $fixtureFactory->create(Fixture\FixtureFactory\Entity\User::class);
         };
 
         $fieldDefinition = Closure::required($closure);

--- a/test/Unit/FieldDefinitionTest.php
+++ b/test/Unit/FieldDefinitionTest.php
@@ -36,7 +36,7 @@ final class FieldDefinitionTest extends AbstractTestCase
     {
         $closure = static function (FixtureFactory $fixtureFactory): Fixture\FixtureFactory\Entity\User {
             /** @var Fixture\FixtureFactory\Entity\User $user */
-            $user = $fixtureFactory->get(Fixture\FixtureFactory\Entity\User::class);
+            $user = $fixtureFactory->create(Fixture\FixtureFactory\Entity\User::class);
 
             $user->renameTo(self::faker()->userName);
 


### PR DESCRIPTION
This PR

* [x] renames `FixtureFactory::get()` to `FixtureFactory::create()`