### PR TITLE
Fix: Rename getList() to createMultiple()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 * Extracted `FieldDefinition\Sequence` ([#164]), by [@localheinz]
 * Introduced named constructors for field definitions and marked primary constructor as `private` ([#188]), by [@localheinz]
 * Renamed `FixtureFactory::get()` to `FixtureFactory::create()` ([#189]), by [@localheinz]
+* Renamed `FixtureFactory::getList()` to `FixtureFactory::createMultiple()` ([#190]), by [@localheinz]
 
 ### Fixed
 
@@ -97,5 +98,6 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 [#185]: https://github.com/ergebnis/factory-bot/pull/185
 [#188]: https://github.com/ergebnis/factory-bot/pull/188
 [#189]: https://github.com/ergebnis/factory-bot/pull/189
+[#190]: https://github.com/ergebnis/factory-bot/pull/190
 
 [@localheinz]: https://github.com/localheinz

--- a/src/FieldDefinition/References.php
+++ b/src/FieldDefinition/References.php
@@ -93,7 +93,7 @@ final class References implements Resolvable
      */
     public function resolve(FixtureFactory $fixtureFactory): array
     {
-        return $fixtureFactory->getList(
+        return $fixtureFactory->createMultiple(
             $this->className,
             [],
             $this->count

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -243,7 +243,7 @@ final class FixtureFactory
      *
      * @return array<int, object>
      */
-    public function getList(string $className, array $fieldOverrides = [], int $count = 1): array
+    public function createMultiple(string $className, array $fieldOverrides = [], int $count = 1): array
     {
         $minimumCount = 1;
 

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -178,26 +178,6 @@ final class FixtureFactoryTest extends AbstractTestCase
         ]);
     }
 
-    /**
-     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intLessThanOne()
-     *
-     * @param int $count
-     */
-    public function testGetListThrowsInvalidCountExceptionWhenCountIsLessThanOne(int $count): void
-    {
-        $fixtureFactory = new FixtureFactory(self::entityManager());
-
-        $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Organization::class);
-
-        $this->expectException(Exception\InvalidCount::class);
-
-        $fixtureFactory->getList(
-            Fixture\FixtureFactory\Entity\Organization::class,
-            [],
-            $count
-        );
-    }
-
     public function testDefineEntityAcceptsConstantValuesInEntityDefinitions(): void
     {
         $name = self::faker()->word;
@@ -320,24 +300,6 @@ final class FixtureFactoryTest extends AbstractTestCase
         self::assertContains($repositoryTwo, $organization->repositories());
     }
 
-    public function testReturnsListOfEntities(): void
-    {
-        $fixtureFactory = new FixtureFactory(self::entityManager());
-
-        $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Organization::class);
-
-        self::assertCount(1, $fixtureFactory->getList(Fixture\FixtureFactory\Entity\Organization::class));
-    }
-
-    public function testCanSpecifyNumberOfReturnedInstances(): void
-    {
-        $fixtureFactory = new FixtureFactory(self::entityManager());
-
-        $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Organization::class);
-
-        self::assertCount(5, $fixtureFactory->getList(Fixture\FixtureFactory\Entity\Organization::class, [], 5));
-    }
-
     public function testCreateEstablishesBidirectionalOneToManyAssociations(): void
     {
         $fixtureFactory = new FixtureFactory(self::entityManager());
@@ -456,7 +418,7 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         /** @var Fixture\FixtureFactory\Entity\Organization $organization */
         $organization = $fixtureFactory->create(Fixture\FixtureFactory\Entity\Organization::class, [
-            'repositories' => $fixtureFactory->getList(Fixture\FixtureFactory\Entity\Repository::class, [], $count),
+            'repositories' => $fixtureFactory->createMultiple(Fixture\FixtureFactory\Entity\Repository::class, [], $count),
         ]);
 
         $repositories = $organization->repositories();
@@ -602,5 +564,56 @@ final class FixtureFactoryTest extends AbstractTestCase
         self::assertSame('gamma-2', $organizationTwo->name());
         self::assertSame('gamma-3', $organizationThree->name());
         self::assertSame('gamma-4', $organizationFour->name());
+    }
+
+    /**
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intLessThanOne()
+     *
+     * @param int $count
+     */
+    public function testCreateMultipleThrowsInvalidCountExceptionWhenCountIsLessThanOne(int $count): void
+    {
+        $fixtureFactory = new FixtureFactory(self::entityManager());
+
+        $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Organization::class);
+
+        $this->expectException(Exception\InvalidCount::class);
+
+        $fixtureFactory->createMultiple(
+            Fixture\FixtureFactory\Entity\Organization::class,
+            [],
+            $count
+        );
+    }
+
+    public function testCreateMultipleReturnsArrayOfEntitiesWhenCountIsNotSpecified(): void
+    {
+        $fixtureFactory = new FixtureFactory(self::entityManager());
+
+        $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Organization::class);
+
+        $entities = $fixtureFactory->createMultiple(Fixture\FixtureFactory\Entity\Organization::class);
+
+        self::assertCount(1, $entities);
+    }
+
+    /**
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOne()
+     *
+     * @param int $count
+     */
+    public function testCreateMultipleReturnsArrayOfEntitiesWhenCountIsSpecified(int $count): void
+    {
+        $fixtureFactory = new FixtureFactory(self::entityManager());
+
+        $fixtureFactory->defineEntity(Fixture\FixtureFactory\Entity\Organization::class);
+
+        $entities = $fixtureFactory->createMultiple(
+            Fixture\FixtureFactory\Entity\Organization::class,
+            [],
+            $count
+        );
+
+        self::assertCount($count, $entities);
     }
 }


### PR DESCRIPTION
This PR

* [x] renames `FixtureFactory::getList()` to `FixtureFactory::createMultiple()`