### PR TITLE
Fix: Add assertions considered as useless by static code analysis

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -66,6 +66,156 @@ parameters:
 			path: test/Fixture/FixtureFactory/Entity/User.php
 
 		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\ClassMetadataNotFound' and Ergebnis\\\\FactoryBot\\\\Exception\\\\ClassMetadataNotFound will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/ClassMetadataNotFoundTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'RuntimeException' and Ergebnis\\\\FactoryBot\\\\Exception\\\\ClassMetadataNotFound will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/ClassMetadataNotFoundTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\Exception' and Ergebnis\\\\FactoryBot\\\\Exception\\\\ClassMetadataNotFound will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/ClassMetadataNotFoundTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\ClassNotFound' and Ergebnis\\\\FactoryBot\\\\Exception\\\\ClassNotFound will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/ClassNotFoundTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'InvalidArgumentException' and Ergebnis\\\\FactoryBot\\\\Exception\\\\ClassNotFound will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/ClassNotFoundTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\Exception' and Ergebnis\\\\FactoryBot\\\\Exception\\\\ClassNotFound will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/ClassNotFoundTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\EntityDefinitionAlreadyRegistered' and Ergebnis\\\\FactoryBot\\\\Exception\\\\EntityDefinitionAlreadyRegistered will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/EntityDefinitionAlreadyRegisteredTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'RuntimeException' and Ergebnis\\\\FactoryBot\\\\Exception\\\\EntityDefinitionAlreadyRegistered will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/EntityDefinitionAlreadyRegisteredTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\Exception' and Ergebnis\\\\FactoryBot\\\\Exception\\\\EntityDefinitionAlreadyRegistered will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/EntityDefinitionAlreadyRegisteredTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\EntityDefinitionNotRegistered' and Ergebnis\\\\FactoryBot\\\\Exception\\\\EntityDefinitionNotRegistered will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/EntityDefinitionNotRegisteredTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'RuntimeException' and Ergebnis\\\\FactoryBot\\\\Exception\\\\EntityDefinitionNotRegistered will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/EntityDefinitionNotRegisteredTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\Exception' and Ergebnis\\\\FactoryBot\\\\Exception\\\\EntityDefinitionNotRegistered will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/EntityDefinitionNotRegisteredTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\InvalidCount' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidCount will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/InvalidCountTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'InvalidArgumentException' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidCount will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/InvalidCountTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\Exception' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidCount will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/InvalidCountTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\InvalidDefinition' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidDefinition will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/InvalidDefinitionTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'RuntimeException' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidDefinition will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/InvalidDefinitionTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\Exception' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidDefinition will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/InvalidDefinitionTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\InvalidDirectory' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidDirectory will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/InvalidDirectoryTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'InvalidArgumentException' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidDirectory will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/InvalidDirectoryTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\Exception' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidDirectory will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/InvalidDirectoryTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\InvalidFieldDefinitions' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidFieldDefinitions will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/InvalidFieldDefinitionsTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'RuntimeException' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidFieldDefinitions will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/InvalidFieldDefinitionsTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\Exception' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidFieldDefinitions will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/InvalidFieldDefinitionsTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\InvalidFieldNames' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidFieldNames will always evaluate to true\\.$#"
+			count: 2
+			path: test/Unit/Exception/InvalidFieldNamesTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'InvalidArgumentException' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidFieldNames will always evaluate to true\\.$#"
+			count: 2
+			path: test/Unit/Exception/InvalidFieldNamesTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\Exception' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidFieldNames will always evaluate to true\\.$#"
+			count: 2
+			path: test/Unit/Exception/InvalidFieldNamesTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\InvalidSequence' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidSequence will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/InvalidSequenceTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'InvalidArgumentException' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidSequence will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/InvalidSequenceTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\Exception' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidSequence will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/InvalidSequenceTest.php
+
+		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertIsArray\\(\\) with array\\<int, mixed\\> will always evaluate to true\\.$#"
 			count: 2
 			path: test/Unit/FieldDefinition/ReferencesTest.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -107,6 +107,88 @@
       <code>$fieldDefinitions</code>
     </MixedArgumentTypeCoercion>
   </file>
+  <file src="test/Unit/Exception/ClassMetadataNotFoundTest.php">
+    <RedundantCondition occurrences="1">
+      <code>assertInstanceOf</code>
+    </RedundantCondition>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>assertInstanceOf</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="test/Unit/Exception/ClassNotFoundTest.php">
+    <RedundantCondition occurrences="1">
+      <code>assertInstanceOf</code>
+    </RedundantCondition>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>assertInstanceOf</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="test/Unit/Exception/EntityDefinitionAlreadyRegisteredTest.php">
+    <RedundantCondition occurrences="1">
+      <code>assertInstanceOf</code>
+    </RedundantCondition>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>assertInstanceOf</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="test/Unit/Exception/EntityDefinitionNotRegisteredTest.php">
+    <RedundantCondition occurrences="1">
+      <code>assertInstanceOf</code>
+    </RedundantCondition>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>assertInstanceOf</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="test/Unit/Exception/InvalidCountTest.php">
+    <RedundantCondition occurrences="1">
+      <code>assertInstanceOf</code>
+    </RedundantCondition>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>assertInstanceOf</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="test/Unit/Exception/InvalidDefinitionTest.php">
+    <RedundantCondition occurrences="1">
+      <code>assertInstanceOf</code>
+    </RedundantCondition>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>assertInstanceOf</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="test/Unit/Exception/InvalidDirectoryTest.php">
+    <RedundantCondition occurrences="1">
+      <code>assertInstanceOf</code>
+    </RedundantCondition>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>assertInstanceOf</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="test/Unit/Exception/InvalidFieldDefinitionsTest.php">
+    <RedundantCondition occurrences="1">
+      <code>assertInstanceOf</code>
+    </RedundantCondition>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>assertInstanceOf</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="test/Unit/Exception/InvalidFieldNamesTest.php">
+    <RedundantCondition occurrences="2">
+      <code>assertInstanceOf</code>
+      <code>assertInstanceOf</code>
+    </RedundantCondition>
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>assertInstanceOf</code>
+      <code>assertInstanceOf</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="test/Unit/Exception/InvalidSequenceTest.php">
+    <RedundantCondition occurrences="1">
+      <code>assertInstanceOf</code>
+    </RedundantCondition>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>assertInstanceOf</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
   <file src="test/Unit/FieldDefinition/ReferenceTest.php">
     <InvalidArgument occurrences="2">
       <code>$className</code>

--- a/test/Unit/Exception/ClassMetadataNotFoundTest.php
+++ b/test/Unit/Exception/ClassMetadataNotFoundTest.php
@@ -34,6 +34,9 @@ final class ClassMetadataNotFoundTest extends Framework\TestCase
             $className
         );
 
+        self::assertInstanceOf(Exception\ClassMetadataNotFound::class, $exception);
+        self::assertInstanceOf(\RuntimeException::class, $exception);
+        self::assertInstanceOf(Exception\Exception::class, $exception);
         self::assertSame($message, $exception->getMessage());
     }
 }

--- a/test/Unit/Exception/ClassNotFoundTest.php
+++ b/test/Unit/Exception/ClassNotFoundTest.php
@@ -34,6 +34,9 @@ final class ClassNotFoundTest extends Framework\TestCase
             $className
         );
 
+        self::assertInstanceOf(Exception\ClassNotFound::class, $exception);
+        self::assertInstanceOf(\InvalidArgumentException::class, $exception);
+        self::assertInstanceOf(Exception\Exception::class, $exception);
         self::assertSame($message, $exception->getMessage());
     }
 }

--- a/test/Unit/Exception/EntityDefinitionAlreadyRegisteredTest.php
+++ b/test/Unit/Exception/EntityDefinitionAlreadyRegisteredTest.php
@@ -34,6 +34,9 @@ final class EntityDefinitionAlreadyRegisteredTest extends Framework\TestCase
             $className
         );
 
+        self::assertInstanceOf(Exception\EntityDefinitionAlreadyRegistered::class, $exception);
+        self::assertInstanceOf(\RuntimeException::class, $exception);
+        self::assertInstanceOf(Exception\Exception::class, $exception);
         self::assertSame($message, $exception->getMessage());
         self::assertSame(0, $exception->getCode());
     }

--- a/test/Unit/Exception/EntityDefinitionNotRegisteredTest.php
+++ b/test/Unit/Exception/EntityDefinitionNotRegisteredTest.php
@@ -34,6 +34,10 @@ final class EntityDefinitionNotRegisteredTest extends Framework\TestCase
             $className
         );
 
+        self::assertInstanceOf(Exception\EntityDefinitionNotRegistered::class, $exception);
+        self::assertInstanceOf(\RuntimeException::class, $exception);
+        self::assertInstanceOf(Exception\Exception::class, $exception);
+
         self::assertSame($message, $exception->getMessage());
     }
 }

--- a/test/Unit/Exception/InvalidCountTest.php
+++ b/test/Unit/Exception/InvalidCountTest.php
@@ -44,6 +44,9 @@ final class InvalidCountTest extends Framework\TestCase
             $count
         );
 
+        self::assertInstanceOf(Exception\InvalidCount::class, $exception);
+        self::assertInstanceOf(\InvalidArgumentException::class, $exception);
+        self::assertInstanceOf(Exception\Exception::class, $exception);
         self::assertSame($message, $exception->getMessage());
         self::assertSame(0, $exception->getCode());
     }

--- a/test/Unit/Exception/InvalidDefinitionTest.php
+++ b/test/Unit/Exception/InvalidDefinitionTest.php
@@ -41,6 +41,9 @@ final class InvalidDefinitionTest extends Framework\TestCase
             $className
         );
 
+        self::assertInstanceOf(Exception\InvalidDefinition::class, $exception);
+        self::assertInstanceOf(\RuntimeException::class, $exception);
+        self::assertInstanceOf(Exception\Exception::class, $exception);
         self::assertSame($message, $exception->getMessage());
         self::assertSame(0, $exception->getCode());
         self::assertSame($previousException, $exception->getPrevious());

--- a/test/Unit/Exception/InvalidDirectoryTest.php
+++ b/test/Unit/Exception/InvalidDirectoryTest.php
@@ -37,6 +37,9 @@ final class InvalidDirectoryTest extends Framework\TestCase
             $directory
         );
 
+        self::assertInstanceOf(Exception\InvalidDirectory::class, $exception);
+        self::assertInstanceOf(\InvalidArgumentException::class, $exception);
+        self::assertInstanceOf(Exception\Exception::class, $exception);
         self::assertSame($message, $exception->getMessage());
     }
 }

--- a/test/Unit/Exception/InvalidFieldDefinitionsTest.php
+++ b/test/Unit/Exception/InvalidFieldDefinitionsTest.php
@@ -36,6 +36,9 @@ final class InvalidFieldDefinitionsTest extends Framework\TestCase
             FieldDefinition::class
         );
 
+        self::assertInstanceOf(Exception\InvalidFieldDefinitions::class, $exception);
+        self::assertInstanceOf(\RuntimeException::class, $exception);
+        self::assertInstanceOf(Exception\Exception::class, $exception);
         self::assertSame($message, $exception->getMessage());
     }
 }

--- a/test/Unit/Exception/InvalidFieldNamesTest.php
+++ b/test/Unit/Exception/InvalidFieldNamesTest.php
@@ -44,6 +44,9 @@ final class InvalidFieldNamesTest extends Framework\TestCase
             $fieldName
         );
 
+        self::assertInstanceOf(Exception\InvalidFieldNames::class, $exception);
+        self::assertInstanceOf(\InvalidArgumentException::class, $exception);
+        self::assertInstanceOf(Exception\Exception::class, $exception);
         self::assertSame($message, $exception->getMessage());
         self::assertSame(0, $exception->getCode());
     }
@@ -72,6 +75,9 @@ final class InvalidFieldNamesTest extends Framework\TestCase
             \implode('", "', $sortedFieldNames)
         );
 
+        self::assertInstanceOf(Exception\InvalidFieldNames::class, $exception);
+        self::assertInstanceOf(\InvalidArgumentException::class, $exception);
+        self::assertInstanceOf(Exception\Exception::class, $exception);
         self::assertSame($message, $exception->getMessage());
         self::assertSame(0, $exception->getCode());
     }

--- a/test/Unit/Exception/InvalidSequenceTest.php
+++ b/test/Unit/Exception/InvalidSequenceTest.php
@@ -37,6 +37,9 @@ final class InvalidSequenceTest extends Framework\TestCase
             $value
         );
 
+        self::assertInstanceOf(Exception\InvalidSequence::class, $exception);
+        self::assertInstanceOf(\InvalidArgumentException::class, $exception);
+        self::assertInstanceOf(Exception\Exception::class, $exception);
         self::assertSame($message, $exception->getMessage());
     }
 }


### PR DESCRIPTION
This PR

* [x] adds assertions that are considered as useless by static code analysis