### PR TITLE
Enhancement: Resolve optional field definitions randomly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 * Imported [`ergebnis/factory-girl-definition@23e57bc`](https://github.com/ergebnis/factory-girl-definition/tree/23e57bc2105ac7a32e3ec7103c866899fe6ad20c) ([#6]), by [@localheinz]
 * Added `FieldDefinition::value()` which allows resolving a field definition to a constant value ([#149]), by [@localheinz]
 * Added `FieldDefinition::closure()` which allows resolving a field definition to the return value of a closure that is invoked with the `FixtureFactory` ([#155]), by [@localheinz]
-* Allowed creation of optional field definitions ([#167]), by [@localheinz]
+* Allowed creation of optional field definitions ([#167]) and ([#196]), by [@localheinz]
 
 ### Changed
 
@@ -103,6 +103,7 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 [#188]: https://github.com/ergebnis/factory-bot/pull/188
 [#189]: https://github.com/ergebnis/factory-bot/pull/189
 [#190]: https://github.com/ergebnis/factory-bot/pull/190
+[#196]: https://github.com/ergebnis/factory-bot/pull/196
 [#197]: https://github.com/ergebnis/factory-bot/pull/197
 
 [@localheinz]: https://github.com/localheinz

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,6 +21,16 @@ parameters:
 			path: src/FixtureFactory.php
 
 		-
+			message: "#^Method Ergebnis\\\\FactoryBot\\\\Test\\\\Double\\\\Faker\\\\FalseGenerator\\:\\:boolean\\(\\) has parameter \\$chanceOfGettingTrue with no typehint specified\\.$#"
+			count: 1
+			path: test/Double/Faker/FalseGenerator.php
+
+		-
+			message: "#^Method Ergebnis\\\\FactoryBot\\\\Test\\\\Double\\\\Faker\\\\TrueGenerator\\:\\:boolean\\(\\) has parameter \\$chanceOfGettingTrue with no typehint specified\\.$#"
+			count: 1
+			path: test/Double/Faker/TrueGenerator.php
+
+		-
 			message: "#^Method Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\Organization\\:\\:id\\(\\) has a nullable return type declaration\\.$#"
 			count: 1
 			path: test/Fixture/FixtureFactory/Entity/Organization.php
@@ -36,7 +46,22 @@ parameters:
 			path: test/Fixture/FixtureFactory/Entity/Project.php
 
 		-
+			message: "#^Constructor in Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\Repository has parameter \\$codeOfConduct with default value\\.$#"
+			count: 1
+			path: test/Fixture/FixtureFactory/Entity/Repository.php
+
+		-
 			message: "#^Constructor in Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\Repository has parameter \\$template with default value\\.$#"
+			count: 1
+			path: test/Fixture/FixtureFactory/Entity/Repository.php
+
+		-
+			message: "#^Method Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\Repository\\:\\:__construct\\(\\) has parameter \\$codeOfConduct with a nullable type declaration\\.$#"
+			count: 1
+			path: test/Fixture/FixtureFactory/Entity/Repository.php
+
+		-
+			message: "#^Method Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\Repository\\:\\:__construct\\(\\) has parameter \\$codeOfConduct with null as default value\\.$#"
 			count: 1
 			path: test/Fixture/FixtureFactory/Entity/Repository.php
 
@@ -61,7 +86,32 @@ parameters:
 			path: test/Fixture/FixtureFactory/Entity/Repository.php
 
 		-
+			message: "#^Method Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\Repository\\:\\:codeOfConduct\\(\\) has a nullable return type declaration\\.$#"
+			count: 1
+			path: test/Fixture/FixtureFactory/Entity/Repository.php
+
+		-
+			message: "#^Constructor in Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\User has parameter \\$location with default value\\.$#"
+			count: 1
+			path: test/Fixture/FixtureFactory/Entity/User.php
+
+		-
+			message: "#^Method Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\User\\:\\:__construct\\(\\) has parameter \\$location with a nullable type declaration\\.$#"
+			count: 1
+			path: test/Fixture/FixtureFactory/Entity/User.php
+
+		-
+			message: "#^Method Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\User\\:\\:__construct\\(\\) has parameter \\$location with null as default value\\.$#"
+			count: 1
+			path: test/Fixture/FixtureFactory/Entity/User.php
+
+		-
 			message: "#^Method Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\User\\:\\:id\\(\\) has a nullable return type declaration\\.$#"
+			count: 1
+			path: test/Fixture/FixtureFactory/Entity/User.php
+
+		-
+			message: "#^Method Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\User\\:\\:location\\(\\) has a nullable return type declaration\\.$#"
 			count: 1
 			path: test/Fixture/FixtureFactory/Entity/User.php
 
@@ -231,17 +281,17 @@ parameters:
 			path: test/Unit/FixtureFactoryTest.php
 
 		-
-			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Test\\\\\\\\Fixture\\\\\\\\FixtureFactory\\\\\\\\Entity\\\\\\\\Repository' and Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\Repository will always evaluate to true\\.$#"
-			count: 2
-			path: test/Unit/FixtureFactoryTest.php
-
-		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNotNull\\(\\) with Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\Organization will always evaluate to true\\.$#"
 			count: 2
 			path: test/Unit/FixtureFactoryTest.php
 
 		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Test\\\\\\\\Fixture\\\\\\\\FixtureFactory\\\\\\\\Entity\\\\\\\\Project' and Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\Project will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/FixtureFactoryTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Test\\\\\\\\Fixture\\\\\\\\FixtureFactory\\\\\\\\Entity\\\\\\\\Repository' and Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\Repository will always evaluate to true\\.$#"
 			count: 1
 			path: test/Unit/FixtureFactoryTest.php
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,6 +10,7 @@ parameters:
 			- Ergebnis\FactoryBot\Definition\AbstractDefinition
 			- Ergebnis\FactoryBot\Test\Integration\AbstractTestCase
 			- Ergebnis\FactoryBot\Test\Unit\AbstractTestCase
+			- Faker\Generator
 			- InvalidArgumentException
 			- RuntimeException
 	inferPrivatePropertyTypeFromConstructor: true

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -72,6 +72,16 @@
       <code>\Generator&lt;string, array&lt;string[], bool, float, int, object, \stdClass, string&gt;&gt;</code>
     </TooManyTemplateParams>
   </file>
+  <file src="test/Double/Faker/FalseGenerator.php">
+    <MissingParamType occurrences="1">
+      <code>$chanceOfGettingTrue</code>
+    </MissingParamType>
+  </file>
+  <file src="test/Double/Faker/TrueGenerator.php">
+    <MissingParamType occurrences="1">
+      <code>$chanceOfGettingTrue</code>
+    </MissingParamType>
+  </file>
   <file src="test/Fixture/FixtureFactory/Entity/Organization.php">
     <PropertyNotSetInConstructor occurrences="1">
       <code>$id</code>
@@ -88,9 +98,8 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="test/Fixture/FixtureFactory/Entity/User.php">
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor occurrences="1">
       <code>$id</code>
-      <code>$organizations</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="test/Integration/FixtureFactoryTest.php">

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -15,6 +15,7 @@ namespace Ergebnis\FactoryBot;
 
 use Doctrine\Common;
 use Doctrine\ORM;
+use Faker\Generator;
 
 /**
  * Creates Doctrine entities for use in tests.
@@ -26,6 +27,11 @@ final class FixtureFactory
     private $entityManager;
 
     /**
+     * @var Generator
+     */
+    private $faker;
+
+    /**
      * @var array<string, EntityDefinition>
      */
     private $entityDefinitions = [];
@@ -35,9 +41,10 @@ final class FixtureFactory
      */
     private $persist = false;
 
-    public function __construct(ORM\EntityManagerInterface $entityManager)
+    public function __construct(ORM\EntityManagerInterface $entityManager, Generator $faker)
     {
         $this->entityManager = $entityManager;
+        $this->faker = $faker;
     }
 
     /**
@@ -196,6 +203,14 @@ final class FixtureFactory
             }
 
             /** @var FieldDefinition\Resolvable $fieldDefinition */
+            if (!$fieldDefinition->isRequired() && !$this->faker->boolean()) {
+                if ($fieldDefinition instanceof FieldDefinition\References) {
+                    $fieldValues[$fieldName] = new Common\Collections\ArrayCollection();
+                }
+
+                continue;
+            }
+
             $fieldValues[$fieldName] = $fieldDefinition->resolve($this);
         }
 

--- a/test/Double/Faker/FalseGenerator.php
+++ b/test/Double/Faker/FalseGenerator.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/factory-bot
+ */
+
+namespace Ergebnis\FactoryBot\Test\Double\Faker;
+
+use Faker\Generator;
+
+final class FalseGenerator extends Generator
+{
+    public function boolean($chanceOfGettingTrue = 50): bool
+    {
+        return false;
+    }
+}

--- a/test/Double/Faker/TrueGenerator.php
+++ b/test/Double/Faker/TrueGenerator.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/factory-bot
+ */
+
+namespace Ergebnis\FactoryBot\Test\Double\Faker;
+
+use Faker\Generator;
+
+final class TrueGenerator extends Generator
+{
+    public function boolean($chanceOfGettingTrue = 50): bool
+    {
+        return true;
+    }
+}

--- a/test/Fixture/FixtureFactory/Entity/CodeOfConduct.php
+++ b/test/Fixture/FixtureFactory/Entity/CodeOfConduct.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/factory-bot
+ */
+
+namespace Ergebnis\FactoryBot\Test\Fixture\FixtureFactory\Entity;
+
+use Doctrine\ORM;
+
+/**
+ * @ORM\Mapping\Entity
+ * @ORM\Mapping\Table(name="code_of_conduct")
+ */
+class CodeOfConduct
+{
+    /**
+     * @ORM\Mapping\Id
+     * @ORM\Mapping\Column(type="string")
+     *
+     * @var string
+     */
+    private $key;
+
+    /**
+     * @ORM\Mapping\Column(
+     *     name="name",
+     *     type="string"
+     * )
+     *
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @ORM\Mapping\Column(
+     *     name="url",
+     *     type="string"
+     * )
+     *
+     * @var string
+     */
+    private $url;
+
+    /**
+     * @ORM\Mapping\Column(
+     *     name="body",
+     *     type="text"
+     * )
+     *
+     * @var string
+     */
+    private $body;
+
+    public function __construct(string $key, string $name, string $url, string $body)
+    {
+        $this->key = $key;
+        $this->name = $name;
+        $this->url = $url;
+        $this->body = $body;
+    }
+
+    public function key(): string
+    {
+        return $this->key;
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function url(): string
+    {
+        return $this->url;
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+}

--- a/test/Fixture/FixtureFactory/Entity/Repository.php
+++ b/test/Fixture/FixtureFactory/Entity/Repository.php
@@ -69,11 +69,27 @@ class Repository
      */
     private $template;
 
-    public function __construct(Organization $organization, string $name, ?self $template = null)
-    {
+    /**
+     * @ORM\Mapping\ManyToOne(targetEntity="Ergebnis\FactoryBot\Test\Fixture\FixtureFactory\Entity\CodeOfConduct")
+     * @ORM\Mapping\JoinColumn(
+     *     name="code_of_conduct_key",
+     *     referencedColumnName="key"
+     * )
+     *
+     * @var null|CodeOfConduct
+     */
+    private $codeOfConduct;
+
+    public function __construct(
+        Organization $organization,
+        string $name,
+        ?self $template = null,
+        ?CodeOfConduct $codeOfConduct = null
+    ) {
         $this->organization = $organization;
         $this->name = $name;
         $this->template = $template;
+        $this->codeOfConduct = $codeOfConduct;
     }
 
     public function id(): ?int
@@ -94,5 +110,10 @@ class Repository
     public function template(): ?self
     {
         return $this->template;
+    }
+
+    public function codeOfConduct(): ?CodeOfConduct
+    {
+        return $this->codeOfConduct;
     }
 }

--- a/test/Fixture/FixtureFactory/Entity/User.php
+++ b/test/Fixture/FixtureFactory/Entity/User.php
@@ -45,6 +45,17 @@ class User
     private $login;
 
     /**
+     * @ORM\Mapping\Column(
+     *     name="location",
+     *     type="string",
+     *     nullable=true
+     * )
+     *
+     * @var null|string
+     */
+    private $location;
+
+    /**
      * @ORM\Mapping\Embedded(
      *     class="Ergebnis\FactoryBot\Test\Fixture\FixtureFactory\Entity\Avatar",
      *     columnPrefix="avatar"
@@ -64,10 +75,12 @@ class User
      */
     private $organizations;
 
-    public function __construct(string $login, Avatar $avatar)
+    public function __construct(string $login, Avatar $avatar, ?string $location = null)
     {
         $this->login = $login;
         $this->avatar = $avatar;
+        $this->location = $location;
+        $this->organizations = new Common\Collections\ArrayCollection();
     }
 
     public function id(): ?int
@@ -88,6 +101,11 @@ class User
     public function renameTo(string $login): void
     {
         $this->login = $login;
+    }
+
+    public function location(): ?string
+    {
+        return $this->location;
     }
 
     /**

--- a/test/Integration/FixtureFactoryTest.php
+++ b/test/Integration/FixtureFactoryTest.php
@@ -33,11 +33,15 @@ final class FixtureFactoryTest extends AbstractTestCase
     public function testCreatePersistsEntityWhenPersistOnGetHasBeenTurnedOn(): void
     {
         $entityManager = self::entityManager();
+        $faker = self::faker();
 
-        $fixtureFactory = new FixtureFactory($entityManager);
+        $fixtureFactory = new FixtureFactory(
+            $entityManager,
+            $faker
+        );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
-            'name' => self::faker()->word,
+            'name' => $faker->word,
         ]);
 
         $fixtureFactory->persistOnGet();
@@ -54,11 +58,15 @@ final class FixtureFactoryTest extends AbstractTestCase
     public function testCreateDoesNotNotPersistEntityByDefault(): void
     {
         $entityManager = self::entityManager();
+        $faker = self::faker();
 
-        $fixtureFactory = new FixtureFactory($entityManager);
+        $fixtureFactory = new FixtureFactory(
+            $entityManager,
+            $faker
+        );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
-            'name' => self::faker()->word,
+            'name' => $faker->word,
         ]);
 
         /** @var Fixture\FixtureFactory\Entity\Organization $organization */
@@ -78,11 +86,13 @@ final class FixtureFactoryTest extends AbstractTestCase
 
     public function testCreateDoesNotPersistEmbeddablesWhenPersistOnGetHasBeenTurnedOn(): void
     {
+        $entityManager = self::entityManager();
         $faker = self::faker();
 
-        $entityManager = self::entityManager();
-
-        $fixtureFactory = new FixtureFactory($entityManager);
+        $fixtureFactory = new FixtureFactory(
+            $entityManager,
+            $faker
+        );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Avatar::class, [
             'url' => FieldDefinition::closure(static function () use ($faker): string {

--- a/test/Unit/DefinitionsTest.php
+++ b/test/Unit/DefinitionsTest.php
@@ -43,7 +43,10 @@ final class DefinitionsTest extends AbstractTestCase
     {
         $faker = self::faker();
 
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            $faker
+        );
 
         $definitions = Definitions::in(__DIR__ . '/../Fixture/Definitions/DoesNotImplementDefinition');
 
@@ -59,7 +62,10 @@ final class DefinitionsTest extends AbstractTestCase
     {
         $faker = self::faker();
 
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            $faker
+        );
 
         $definitions = Definitions::in(__DIR__ . '/../Fixture/Definitions/ImplementsDefinitionButIsAbstract');
 
@@ -75,7 +81,10 @@ final class DefinitionsTest extends AbstractTestCase
     {
         $faker = self::faker();
 
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            $faker
+        );
 
         $definitions = Definitions::in(__DIR__ . '/../Fixture/Definitions/ImplementsDefinitionButHasPrivateConstructor');
 
@@ -98,7 +107,10 @@ final class DefinitionsTest extends AbstractTestCase
     {
         $faker = self::faker();
 
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            $faker
+        );
 
         $definitions = Definitions::in(__DIR__ . '/../Fixture/Definitions/ImplementsDefinition');
 

--- a/test/Unit/FieldDefinition/ClosureTest.php
+++ b/test/Unit/FieldDefinition/ClosureTest.php
@@ -32,7 +32,10 @@ final class ClosureTest extends AbstractTestCase
 {
     public function testRequiredResolvesToResultOfInvokingClosureWithFixtureFactory(): void
     {
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            self::faker()
+        );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\User::class);
 
@@ -51,7 +54,10 @@ final class ClosureTest extends AbstractTestCase
 
     public function testOptionalResolvedToResultOfInvokingClosureWithFixtureFactory(): void
     {
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            self::faker()
+        );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\User::class);
 

--- a/test/Unit/FieldDefinition/ReferenceTest.php
+++ b/test/Unit/FieldDefinition/ReferenceTest.php
@@ -34,7 +34,10 @@ final class ReferenceTest extends AbstractTestCase
     {
         $className = Fixture\FixtureFactory\Entity\User::class;
 
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            self::faker()
+        );
 
         $fixtureFactory->define($className);
 
@@ -51,7 +54,10 @@ final class ReferenceTest extends AbstractTestCase
     {
         $className = Fixture\FixtureFactory\Entity\User::class;
 
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            self::faker()
+        );
 
         $fixtureFactory->define($className);
 

--- a/test/Unit/FieldDefinition/ReferencesTest.php
+++ b/test/Unit/FieldDefinition/ReferencesTest.php
@@ -60,7 +60,10 @@ final class ReferencesTest extends AbstractTestCase
     {
         $className = Fixture\FixtureFactory\Entity\User::class;
 
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            self::faker()
+        );
 
         $fixtureFactory->define($className);
 
@@ -106,7 +109,10 @@ final class ReferencesTest extends AbstractTestCase
     {
         $className = Fixture\FixtureFactory\Entity\User::class;
 
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            self::faker()
+        );
 
         $fixtureFactory->define($className);
 

--- a/test/Unit/FieldDefinition/SequenceTest.php
+++ b/test/Unit/FieldDefinition/SequenceTest.php
@@ -51,11 +51,14 @@ final class SequenceTest extends AbstractTestCase
     {
         $faker = self::faker();
 
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            $faker
+        );
+
         $value = '%d Why, hello - this is a nice thing, if you need it! %d';
 
         $initialNumber = $faker->numberBetween();
-
-        $fixtureFactory = new FixtureFactory(self::entityManager());
 
         $fieldDefinition = Sequence::optional(
             $value,
@@ -100,11 +103,14 @@ final class SequenceTest extends AbstractTestCase
     {
         $faker = self::faker();
 
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            $faker
+        );
+
         $value = '%d Why, hello - this is a nice thing, if you need it! %d';
 
         $initialNumber = $faker->numberBetween();
-
-        $fixtureFactory = new FixtureFactory(self::entityManager());
 
         $fieldDefinition = Sequence::required(
             $value,

--- a/test/Unit/FieldDefinition/ValueTest.php
+++ b/test/Unit/FieldDefinition/ValueTest.php
@@ -35,7 +35,10 @@ final class ValueTest extends AbstractTestCase
      */
     public function testOptionalResolvesToValue($value): void
     {
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            self::faker()
+        );
 
         $fieldDefinition = Value::required($value);
 
@@ -53,7 +56,10 @@ final class ValueTest extends AbstractTestCase
      */
     public function testRequiredResolvesToValue($value): void
     {
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            self::faker()
+        );
 
         $fieldDefinition = Value::required($value);
 

--- a/test/Unit/FieldDefinitionTest.php
+++ b/test/Unit/FieldDefinitionTest.php
@@ -24,6 +24,7 @@ use Ergebnis\FactoryBot\Test\Fixture;
  * @covers \Ergebnis\FactoryBot\FieldDefinition
  *
  * @uses \Ergebnis\FactoryBot\Exception\InvalidCount
+ * @uses \Ergebnis\FactoryBot\Exception\InvalidSequence
  * @uses \Ergebnis\FactoryBot\FieldDefinition\Closure
  * @uses \Ergebnis\FactoryBot\FieldDefinition\Reference
  * @uses \Ergebnis\FactoryBot\FieldDefinition\References

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Ergebnis\FactoryBot\Test\Unit;
 
-use Doctrine\ORM;
 use Ergebnis\FactoryBot\Exception;
 use Ergebnis\FactoryBot\FieldDefinition;
 use Ergebnis\FactoryBot\FixtureFactory;
+use Ergebnis\FactoryBot\Test\Double;
 use Ergebnis\FactoryBot\Test\Fixture;
 
 /**
@@ -42,7 +42,10 @@ final class FixtureFactoryTest extends AbstractTestCase
 {
     public function testDefineThrowsEntityDefinitionAlreadyRegisteredExceptionWhenDefinitionHasAlreadyBeenProvidedForEntity(): void
     {
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            self::faker()
+        );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
 
@@ -55,7 +58,10 @@ final class FixtureFactoryTest extends AbstractTestCase
     {
         $className = 'NotAClass';
 
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            self::faker()
+        );
 
         $this->expectException(Exception\ClassNotFound::class);
 
@@ -66,7 +72,10 @@ final class FixtureFactoryTest extends AbstractTestCase
     {
         $className = Fixture\FixtureFactory\NotAnEntity\User::class;
 
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            self::faker()
+        );
 
         $this->expectException(Exception\ClassMetadataNotFound::class);
 
@@ -77,7 +86,10 @@ final class FixtureFactoryTest extends AbstractTestCase
     {
         $faker = self::faker();
 
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            $faker
+        );
 
         $this->expectException(Exception\InvalidFieldNames::class);
 
@@ -92,9 +104,10 @@ final class FixtureFactoryTest extends AbstractTestCase
     {
         $className = self::class;
 
-        $entityManager = $this->prophesize(ORM\EntityManagerInterface::class)->reveal();
-
-        $fixtureFactory = new FixtureFactory($entityManager);
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            self::faker()
+        );
 
         $this->expectException(Exception\EntityDefinitionNotRegistered::class);
 
@@ -103,11 +116,12 @@ final class FixtureFactoryTest extends AbstractTestCase
 
     public function testCreateThrowsInvalidFieldNamesExceptionWhenReferencingFieldsThatDoNotExistInEntity(): void
     {
-        $faker = self::faker()->unique();
+        $faker = self::faker();
 
-        $fieldName = $faker->word;
-
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            $faker
+        );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
             'name' => $faker->word,
@@ -116,15 +130,20 @@ final class FixtureFactoryTest extends AbstractTestCase
         $this->expectException(Exception\InvalidFieldNames::class);
 
         $fixtureFactory->create(Fixture\FixtureFactory\Entity\Organization::class, [
-            $fieldName => 'blueberry',
+            'flavour' => 'strawberry',
         ]);
     }
 
     public function testDefineAllowsDefiningAndReferencingEmbeddables(): void
     {
-        $url = self::faker()->imageUrl();
+        $faker = self::faker();
 
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $url = $faker->imageUrl();
+
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            $faker
+        );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Avatar::class, [
             'url' => $url,
@@ -148,7 +167,10 @@ final class FixtureFactoryTest extends AbstractTestCase
     {
         $faker = self::faker();
 
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            $faker
+        );
 
         $this->expectException(Exception\InvalidFieldNames::class);
 
@@ -162,9 +184,12 @@ final class FixtureFactoryTest extends AbstractTestCase
 
     public function testCreateThrowsInvalidFieldNamesExceptionWhenReferencingFieldsOfEmbeddablesUsingDotNotation(): void
     {
-        $faker = self::faker()->unique();
+        $faker = self::faker();
 
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            self::faker()
+        );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\User::class);
 
@@ -180,9 +205,14 @@ final class FixtureFactoryTest extends AbstractTestCase
 
     public function testDefineAcceptsConstantValuesInEntityDefinitions(): void
     {
-        $name = self::faker()->word;
+        $faker = self::faker();
 
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $name = $faker->word;
+
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            $faker
+        );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
             'name' => $name,
@@ -198,7 +228,10 @@ final class FixtureFactoryTest extends AbstractTestCase
     {
         $name = 'foo';
 
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            self::faker()
+        );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
             'name' => static function () use (&$name): string {
@@ -223,7 +256,10 @@ final class FixtureFactoryTest extends AbstractTestCase
 
     public function testCreateResolvesFieldWithoutDefaultValueToNullWhenFieldDefinitionWasNotSpecified(): void
     {
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            self::faker()
+        );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
 
@@ -235,7 +271,10 @@ final class FixtureFactoryTest extends AbstractTestCase
 
     public function testCreateResolvesFieldWithDefaultValueToItsDefaultValueWhenFieldDefinitionWasNotSpecified(): void
     {
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            self::faker()
+        );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
 
@@ -247,7 +286,10 @@ final class FixtureFactoryTest extends AbstractTestCase
 
     public function testCreateDoesNotInvokeEntityConstructor(): void
     {
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            self::faker()
+        );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, []);
 
@@ -257,12 +299,17 @@ final class FixtureFactoryTest extends AbstractTestCase
         self::assertFalse($organization->constructorWasCalled());
     }
 
-    public function testCreateAssignsEmptyCollectionToCollectionAssociationWhenFieldDefinitionWasNotSpecified(): void
+    public function testCreateResolvesOneToManyAssociationToEmptyArrayCollectionWhenFieldDefinitionWasNotSpecified(): void
     {
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $faker = self::faker();
+
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            $faker
+        );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
-            'name' => self::faker()->word,
+            'name' => $faker->word,
         ]);
 
         /** @var Fixture\FixtureFactory\Entity\Organization $organization */
@@ -273,7 +320,12 @@ final class FixtureFactoryTest extends AbstractTestCase
 
     public function testCreateMapsArraysToCollectionAsscociationFields(): void
     {
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $faker = self::faker();
+
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            $faker
+        );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
 
@@ -289,7 +341,7 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         /** @var Fixture\FixtureFactory\Entity\Organization $organization */
         $organization = $fixtureFactory->create(Fixture\FixtureFactory\Entity\Organization::class, [
-            'name' => self::faker()->word,
+            'name' => $faker->word,
             'repositories' => [
                 $repositoryOne,
                 $repositoryTwo,
@@ -302,7 +354,10 @@ final class FixtureFactoryTest extends AbstractTestCase
 
     public function testCreateEstablishesBidirectionalOneToManyAssociations(): void
     {
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            self::faker()
+        );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
 
@@ -318,47 +373,164 @@ final class FixtureFactoryTest extends AbstractTestCase
         self::assertContains($repository, $organization->repositories());
     }
 
-    public function testCreateResolvesClosureToResultOfClosureInvokedWithFixtureFactory(): void
+    public function testCreateResolvesOptionalClosureToNullWhenFakerReturnsFalse(): void
     {
-        $count = self::faker()->numberBetween(2, 5);
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\FalseGenerator()
+        );
 
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\CodeOfConduct::class);
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
-
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\User::class, [
-            'organizations' => FieldDefinition::closure(static function (FixtureFactory $fixtureFactory) use ($count): array {
-                return $fixtureFactory->createMultiple(
-                    Fixture\FixtureFactory\Entity\Organization::class,
-                    [],
-                    $count
-                );
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
+            'codeOfConduct' => FieldDefinition::optionalClosure(static function (FixtureFactory $fixtureFactory): Fixture\FixtureFactory\Entity\CodeOfConduct {
+                return $fixtureFactory->create(Fixture\FixtureFactory\Entity\CodeOfConduct::class);
             }),
         ]);
 
-        /** @var Fixture\FixtureFactory\Entity\User $user */
-        $user = $fixtureFactory->create(Fixture\FixtureFactory\Entity\User::class);
+        /** @var Fixture\FixtureFactory\Entity\Repository $repository */
+        $repository = $fixtureFactory->create(Fixture\FixtureFactory\Entity\Repository::class);
 
-        $organizations = $user->organizations();
-
-        self::assertCount($count, $organizations);
-        self::assertContainsOnly(Fixture\FixtureFactory\Entity\Organization::class, $organizations);
+        self::assertNull($repository->codeOfConduct());
     }
 
-    public function testCreateResolvesReferenceToReferencedEntity(): void
+    public function testCreateResolvesOptionalClosureToResultOfClosureInvokedWithFixtureFactoryWhenFakerReturnsTrue(): void
     {
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\TrueGenerator()
+        );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Project::class, [
-            'repository' => FieldDefinition::reference(Fixture\FixtureFactory\Entity\Repository::class),
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\CodeOfConduct::class);
+
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
+            'codeOfConduct' => FieldDefinition::optionalClosure(static function (FixtureFactory $fixtureFactory): Fixture\FixtureFactory\Entity\CodeOfConduct {
+                return $fixtureFactory->create(Fixture\FixtureFactory\Entity\CodeOfConduct::class);
+            }),
         ]);
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class);
+        /** @var Fixture\FixtureFactory\Entity\Repository $repository */
+        $repository = $fixtureFactory->create(Fixture\FixtureFactory\Entity\Repository::class);
 
-        /** @var Fixture\FixtureFactory\Entity\Project $project */
-        $project = $fixtureFactory->create(Fixture\FixtureFactory\Entity\Project::class);
+        self::assertInstanceOf(Fixture\FixtureFactory\Entity\CodeOfConduct::class, $repository->codeOfConduct());
+    }
 
-        self::assertInstanceOf(Fixture\FixtureFactory\Entity\Repository::class, $project->repository());
+    public function testCreateResolvesRequiredClosureToResultOfClosureInvokedWithFixtureFactoryWhenFakerReturnsFalse(): void
+    {
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\FalseGenerator()
+        );
+
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\CodeOfConduct::class);
+
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
+            'codeOfConduct' => FieldDefinition::closure(static function (FixtureFactory $fixtureFactory): Fixture\FixtureFactory\Entity\CodeOfConduct {
+                return $fixtureFactory->create(Fixture\FixtureFactory\Entity\CodeOfConduct::class);
+            }),
+        ]);
+
+        /** @var Fixture\FixtureFactory\Entity\Repository $repository */
+        $repository = $fixtureFactory->create(Fixture\FixtureFactory\Entity\Repository::class);
+
+        self::assertInstanceOf(Fixture\FixtureFactory\Entity\CodeOfConduct::class, $repository->codeOfConduct());
+    }
+
+    public function testCreateResolvesRequiredClosureToResultOfClosureInvokedWithFixtureFactoryWhenFakerReturnsTrue(): void
+    {
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\TrueGenerator()
+        );
+
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\CodeOfConduct::class);
+
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
+            'codeOfConduct' => FieldDefinition::closure(static function (FixtureFactory $fixtureFactory): Fixture\FixtureFactory\Entity\CodeOfConduct {
+                return $fixtureFactory->create(Fixture\FixtureFactory\Entity\CodeOfConduct::class);
+            }),
+        ]);
+
+        /** @var Fixture\FixtureFactory\Entity\Repository $repository */
+        $repository = $fixtureFactory->create(Fixture\FixtureFactory\Entity\Repository::class);
+
+        self::assertInstanceOf(Fixture\FixtureFactory\Entity\CodeOfConduct::class, $repository->codeOfConduct());
+    }
+
+    public function testCreateResolvesOptionalReferenceToNullWhenFakerReturnsFalse(): void
+    {
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\FalseGenerator()
+        );
+
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\CodeOfConduct::class);
+
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
+            'codeOfConduct' => FieldDefinition::optionalReference(Fixture\FixtureFactory\Entity\CodeOfConduct::class),
+        ]);
+
+        /** @var Fixture\FixtureFactory\Entity\Repository $repository */
+        $repository = $fixtureFactory->create(Fixture\FixtureFactory\Entity\Repository::class);
+
+        self::assertNull($repository->codeOfConduct());
+    }
+
+    public function testCreateResolvesOptionalReferenceToEntityWhenFakerReturnsTrue(): void
+    {
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\TrueGenerator()
+        );
+
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\CodeOfConduct::class);
+
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
+            'codeOfConduct' => FieldDefinition::optionalReference(Fixture\FixtureFactory\Entity\CodeOfConduct::class),
+        ]);
+
+        /** @var Fixture\FixtureFactory\Entity\Repository $repository */
+        $repository = $fixtureFactory->create(Fixture\FixtureFactory\Entity\Repository::class);
+
+        self::assertInstanceOf(Fixture\FixtureFactory\Entity\CodeOfConduct::class, $repository->codeOfConduct());
+    }
+
+    public function testCreateResolvesRequiredReferenceToEntityWhenFakerReturnsFalse(): void
+    {
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\FalseGenerator()
+        );
+
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\CodeOfConduct::class);
+
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
+            'codeOfConduct' => FieldDefinition::reference(Fixture\FixtureFactory\Entity\CodeOfConduct::class),
+        ]);
+
+        /** @var Fixture\FixtureFactory\Entity\Repository $repository */
+        $repository = $fixtureFactory->create(Fixture\FixtureFactory\Entity\Repository::class);
+
+        self::assertInstanceOf(Fixture\FixtureFactory\Entity\CodeOfConduct::class, $repository->codeOfConduct());
+    }
+
+    public function testCreateResolvesRequiredReferenceToEntityWhenFakerReturnsTrue(): void
+    {
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\TrueGenerator()
+        );
+
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\CodeOfConduct::class);
+
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
+            'codeOfConduct' => FieldDefinition::reference(Fixture\FixtureFactory\Entity\CodeOfConduct::class),
+        ]);
+
+        /** @var Fixture\FixtureFactory\Entity\Repository $repository */
+        $repository = $fixtureFactory->create(Fixture\FixtureFactory\Entity\Repository::class);
+
+        self::assertInstanceOf(Fixture\FixtureFactory\Entity\CodeOfConduct::class, $repository->codeOfConduct());
     }
 
     /**
@@ -366,9 +538,101 @@ final class FixtureFactoryTest extends AbstractTestCase
      *
      * @param int $count
      */
-    public function testCreateResolvesReferencesToCollectionOfReferencedEntity(int $count): void
+    public function testCreateResolvesOptionalReferencesToEmptyArrayCollectionWhenFakerReturnsFalse(int $count): void
     {
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\FalseGenerator()
+        );
+
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
+            'repositories' => FieldDefinition::optionalReferences(
+                Fixture\FixtureFactory\Entity\Repository::class,
+                $count
+            ),
+        ]);
+
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
+            'name' => self::faker()->word,
+        ]);
+
+        /** @var Fixture\FixtureFactory\Entity\Organization $organization */
+        $organization = $fixtureFactory->create(Fixture\FixtureFactory\Entity\Organization::class);
+
+        self::assertCount(0, $organization->repositories());
+    }
+
+    /**
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOne()
+     *
+     * @param int $count
+     */
+    public function testCreateResolvesOptionalReferencesToArrayCollectionOfEntitiesWhenFakerReturnsTrue(int $count): void
+    {
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\TrueGenerator()
+        );
+
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
+            'repositories' => FieldDefinition::optionalReferences(
+                Fixture\FixtureFactory\Entity\Repository::class,
+                $count
+            ),
+        ]);
+
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
+            'name' => self::faker()->word,
+        ]);
+
+        /** @var Fixture\FixtureFactory\Entity\Organization $organization */
+        $organization = $fixtureFactory->create(Fixture\FixtureFactory\Entity\Organization::class);
+
+        self::assertContainsOnly(Fixture\FixtureFactory\Entity\Repository::class, $organization->repositories());
+        self::assertCount($count, $organization->repositories());
+    }
+
+    /**
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOne()
+     *
+     * @param int $count
+     */
+    public function testCreateResolvesRequiredReferencesToArrayCollectionOfEntitiesWhenFakerReturnsFalse(int $count): void
+    {
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\FalseGenerator()
+        );
+
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
+            'repositories' => FieldDefinition::references(
+                Fixture\FixtureFactory\Entity\Repository::class,
+                $count
+            ),
+        ]);
+
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
+            'name' => self::faker()->word,
+        ]);
+
+        /** @var Fixture\FixtureFactory\Entity\Organization $organization */
+        $organization = $fixtureFactory->create(Fixture\FixtureFactory\Entity\Organization::class);
+
+        self::assertContainsOnly(Fixture\FixtureFactory\Entity\Repository::class, $organization->repositories());
+        self::assertCount($count, $organization->repositories());
+    }
+
+    /**
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOne()
+     *
+     * @param int $count
+     */
+    public function testCreateResolvesRequiredReferencesToArrayCollectionOfEntitiesWhenFakerReturnsTrue(int $count): void
+    {
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\TrueGenerator()
+        );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
             'repositories' => FieldDefinition::references(
@@ -390,43 +654,112 @@ final class FixtureFactoryTest extends AbstractTestCase
         self::assertCount($count, $repositories);
     }
 
-    public function testCreateResolvesSequenceToStringValueWhenPercentDPlaceholderIsPresent(): void
+    public function testCreateResolvesOptionalSequenceNullWhenFakerReturnsFalse(): void
     {
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\FalseGenerator()
+        );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
-            'name' => FieldDefinition::sequence('beta-%d'),
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\User::class, [
+            'location' => FieldDefinition::optionalSequence('City (%d)'),
         ]);
 
-        /** @var Fixture\FixtureFactory\Entity\Organization $organizationOne */
-        $organizationOne = $fixtureFactory->create(Fixture\FixtureFactory\Entity\Organization::class);
+        /** @var Fixture\FixtureFactory\Entity\User $user */
+        $user = $fixtureFactory->create(Fixture\FixtureFactory\Entity\User::class);
 
-        /** @var Fixture\FixtureFactory\Entity\Organization $organizationTwo */
-        $organizationTwo = $fixtureFactory->create(Fixture\FixtureFactory\Entity\Organization::class);
+        self::assertNull($user->location());
+    }
 
-        /** @var Fixture\FixtureFactory\Entity\Organization $organizationThree */
-        $organizationThree = $fixtureFactory->create(Fixture\FixtureFactory\Entity\Organization::class);
+    public function testCreateResolvesOptionalSequenceToStringValueWhenPercentDPlaceholderIsPresentAndFakerReturnsTrue(): void
+    {
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\TrueGenerator()
+        );
 
-        /** @var Fixture\FixtureFactory\Entity\Organization $organizationFour */
-        $organizationFour = $fixtureFactory->create(Fixture\FixtureFactory\Entity\Organization::class);
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\User::class, [
+            'location' => FieldDefinition::optionalSequence('City (%d)'),
+        ]);
 
-        self::assertSame('beta-1', $organizationOne->name());
-        self::assertSame('beta-2', $organizationTwo->name());
-        self::assertSame('beta-3', $organizationThree->name());
-        self::assertSame('beta-4', $organizationFour->name());
+        /** @var Fixture\FixtureFactory\Entity\User $userOne */
+        $userOne = $fixtureFactory->create(Fixture\FixtureFactory\Entity\User::class);
+
+        /** @var Fixture\FixtureFactory\Entity\User $userTwo */
+        $userTwo = $fixtureFactory->create(Fixture\FixtureFactory\Entity\User::class);
+
+        /** @var Fixture\FixtureFactory\Entity\User $userThree */
+        $userThree = $fixtureFactory->create(Fixture\FixtureFactory\Entity\User::class);
+
+        self::assertSame('City (1)', $userOne->location());
+        self::assertSame('City (2)', $userTwo->location());
+        self::assertSame('City (3)', $userThree->location());
+    }
+
+    public function testCreateResolvesRequiredSequenceToStringValueWhenPercentDPlaceholderIsPresentAndFakerReturnsFalse(): void
+    {
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\FalseGenerator()
+        );
+
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\User::class, [
+            'location' => FieldDefinition::sequence('City (%d)'),
+        ]);
+
+        /** @var Fixture\FixtureFactory\Entity\User $userOne */
+        $userOne = $fixtureFactory->create(Fixture\FixtureFactory\Entity\User::class);
+
+        /** @var Fixture\FixtureFactory\Entity\User $userTwo */
+        $userTwo = $fixtureFactory->create(Fixture\FixtureFactory\Entity\User::class);
+
+        /** @var Fixture\FixtureFactory\Entity\User $userThree */
+        $userThree = $fixtureFactory->create(Fixture\FixtureFactory\Entity\User::class);
+
+        self::assertSame('City (1)', $userOne->location());
+        self::assertSame('City (2)', $userTwo->location());
+        self::assertSame('City (3)', $userThree->location());
+    }
+
+    public function testCreateResolvesRequiredSequenceToStringValueWhenPercentDPlaceholderIsPresentAndFakerReturnsTrue(): void
+    {
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\TrueGenerator()
+        );
+
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\User::class, [
+            'location' => FieldDefinition::sequence('City (%d)'),
+        ]);
+
+        /** @var Fixture\FixtureFactory\Entity\User $userOne */
+        $userOne = $fixtureFactory->create(Fixture\FixtureFactory\Entity\User::class);
+
+        /** @var Fixture\FixtureFactory\Entity\User $userTwo */
+        $userTwo = $fixtureFactory->create(Fixture\FixtureFactory\Entity\User::class);
+
+        /** @var Fixture\FixtureFactory\Entity\User $userThree */
+        $userThree = $fixtureFactory->create(Fixture\FixtureFactory\Entity\User::class);
+
+        self::assertSame('City (1)', $userOne->location());
+        self::assertSame('City (2)', $userTwo->location());
+        self::assertSame('City (3)', $userThree->location());
     }
 
     public function testCreateAllowsOverridingFieldWithDifferentValueWhenFieldDefinitionHasBeenSpecified(): void
     {
-        $faker = self::faker()->unique();
+        $faker = self::faker();
 
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            $faker
+        );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
-            'name' => $faker->word,
+            'name' => $faker->unique()->word,
         ]);
 
-        $name = $faker->word;
+        $name = $faker->unique()->word;
 
         /** @var Fixture\FixtureFactory\Entity\Organization $organization */
         $organization = $fixtureFactory->create(Fixture\FixtureFactory\Entity\Organization::class, [
@@ -438,7 +771,10 @@ final class FixtureFactoryTest extends AbstractTestCase
 
     public function testCreateAllowsOverridingAssociationWithNullWhenFieldDefinitionHasBeenSpecified(): void
     {
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            self::faker()
+        );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
             'template' => FieldDefinition::references(Fixture\FixtureFactory\Entity\Repository::class),
@@ -459,14 +795,19 @@ final class FixtureFactoryTest extends AbstractTestCase
      */
     public function testCreateAllowsOverridingAssociationWithCollectionOfEntitiesWhenFieldDefinitionHasBeenSpecified(int $count): void
     {
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $faker = self::faker();
+
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            $faker
+        );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
             'repositories' => FieldDefinition::references(Fixture\FixtureFactory\Entity\Repository::class),
         ]);
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
-            'name' => self::faker()->word,
+            'name' => $faker->word,
         ]);
 
         /** @var Fixture\FixtureFactory\Entity\Organization $organization */
@@ -482,9 +823,14 @@ final class FixtureFactoryTest extends AbstractTestCase
 
     public function testDefineAcceptsClosureThatWillBeInvokedAfterEntityCreation(): void
     {
-        $name = self::faker()->word;
+        $faker = self::faker();
 
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $name = $faker->word;
+
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            $faker
+        );
 
         $fixtureFactory->define(
             Fixture\FixtureFactory\Entity\Organization::class,
@@ -516,7 +862,10 @@ final class FixtureFactoryTest extends AbstractTestCase
 
     public function testCreateCreatesReferencedObjectAutomatically(): void
     {
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            self::faker()
+        );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
 
@@ -541,7 +890,10 @@ final class FixtureFactoryTest extends AbstractTestCase
 
     public function testCreatesCreatesReferencedObjectsTransitively(): void
     {
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            self::faker()
+        );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
 
@@ -574,7 +926,10 @@ final class FixtureFactoryTest extends AbstractTestCase
      */
     public function testCreateMultipleThrowsInvalidCountExceptionWhenCountIsLessThanOne(int $count): void
     {
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            self::faker()
+        );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
 
@@ -589,7 +944,10 @@ final class FixtureFactoryTest extends AbstractTestCase
 
     public function testCreateMultipleResolvesToArrayOfEntitiesWhenCountIsNotSpecified(): void
     {
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            self::faker()
+        );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
 
@@ -605,7 +963,10 @@ final class FixtureFactoryTest extends AbstractTestCase
      */
     public function testCreateMultipleResolvesToArrayOfEntitiesWhenCountIsSpecified(int $count): void
     {
-        $fixtureFactory = new FixtureFactory(self::entityManager());
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            self::faker()
+        );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
 


### PR DESCRIPTION
This PR

* [ ] resolves optional field definitions depending on whether `Faker\Generator::boolean()` returns `true` or `false`

Follows #167.