### PR TITLE
Fix: Require string sequences to contain %d placeholder

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -10,7 +10,7 @@ on: # yamllint disable-line rule:truthy
 
 env:
   MIN_COVERED_MSI: 98
-  MIN_MSI: 94
+  MIN_MSI: 93
   REQUIRED_PHP_EXTENSIONS: "mbstring"
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 * Removed `FixtureFactory::provideWith()` ([#122]), by [@localheinz]
 * Removed `FixtureFactory::getAsSingleton()`, `FixtureFactory::setSingleton()`, and `FixtureFactory::unsetSingleton()` ([#124]), by [@localheinz]
 * Removed `callable` support for field definitions ([#133]) and ([#185]), by [@localheinz]
+* Removed support for `string` sequences that do not contain a `%d` placeholder ([#185]), by [@localheinz]
 
 [fa9c564...master]: https://github.com/ergebnis/factory-bot/compare/fa9c564...master
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 MIN_COVERED_MSI:=98
-MIN_MSI:=94
+MIN_MSI:=93
 
 .PHONY: it
 it: coding-standards static-code-analysis tests ## Runs the coding-standards, static-code-analysis, and tests targets

--- a/src/FieldDefinition.php
+++ b/src/FieldDefinition.php
@@ -113,14 +113,12 @@ final class FieldDefinition
      * @param string $value
      * @param int    $initialNumber
      *
+     * @throws Exception\InvalidSequence
+     *
      * @return FieldDefinition\Sequence
      */
     public static function sequence($value, int $initialNumber = 1): FieldDefinition\Sequence
     {
-        if (false === \strpos($value, '%d')) {
-            $value .= '%d';
-        }
-
         return FieldDefinition\Sequence::required(
             $value,
             $initialNumber
@@ -135,10 +133,6 @@ final class FieldDefinition
      */
     public static function optionalSequence($value, int $initialNumber = 1): FieldDefinition\Sequence
     {
-        if (false === \strpos($value, '%d')) {
-            $value .= '%d';
-        }
-
         return FieldDefinition\Sequence::optional(
             $value,
             $initialNumber

--- a/test/Unit/FieldDefinitionTest.php
+++ b/test/Unit/FieldDefinitionTest.php
@@ -196,6 +196,25 @@ final class FieldDefinitionTest extends AbstractTestCase
         self::assertEquals($expected, $fieldDefinition);
     }
 
+    public function testSequenceRejectsValueWhenItIsMissingPercentDPlaceholder(): void
+    {
+        $faker = self::faker();
+
+        $value = $faker->sentence;
+        $initialNumber = $faker->randomNumber();
+
+        $this->expectException(Exception\InvalidSequence::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Value needs to contain a placeholder "%%d", but "%s" does not',
+            $value
+        ));
+
+        FieldDefinition::sequence(
+            $value,
+            $initialNumber
+        );
+    }
+
     public function testSequenceReturnsRequiredSequenceWhenValueContainsPlaceholderAndInitialNumberIsNotSpecified(): void
     {
         $value = 'there-is-no-difference-between-%d-and-%d';
@@ -232,43 +251,26 @@ final class FieldDefinitionTest extends AbstractTestCase
         self::assertEquals($expected, $fieldDefinition);
     }
 
-    public function testSequenceReturnsRequiredSequenceWhenValueDoesNotContainPlaceholderAndInitialNumberIsNotSpecified(): void
+    public function testOptionalSequenceRejectsValueWhenItIsMissingPercentDPlaceholder(): void
     {
-        $value = 'user-';
+        $faker = self::faker();
 
-        $fieldDefinition = FieldDefinition::sequence($value);
+        $value = $faker->sentence;
+        $initialNumber = $faker->randomNumber();
 
-        $expected = FieldDefinition\Sequence::required(
-            $value . '%d',
-            1
-        );
+        $this->expectException(Exception\InvalidSequence::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Value needs to contain a placeholder "%%d", but "%s" does not',
+            $value
+        ));
 
-        self::assertEquals($expected, $fieldDefinition);
-    }
-
-    /**
-     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOne()
-     *
-     * @param int $initialNumber
-     */
-    public function testSequenceReturnsRequiredSequenceWhenValueDoesNotContainPlaceholderAndInitialNumberIsSpecified(int $initialNumber): void
-    {
-        $value = 'user-';
-
-        $fieldDefinition = FieldDefinition::sequence(
+        FieldDefinition::optionalSequence(
             $value,
             $initialNumber
         );
-
-        $expected = FieldDefinition\Sequence::required(
-            $value . '%d',
-            $initialNumber
-        );
-
-        self::assertEquals($expected, $fieldDefinition);
     }
 
-    public function testSequenceReturnsOptionalSequenceWhenValueContainsPlaceholderAndInitialNumberIsNotSpecified(): void
+    public function testOptionalSequenceReturnsOptionalSequenceWhenValueContainsPlaceholderAndInitialNumberIsNotSpecified(): void
     {
         $value = 'there-is-no-difference-between-%d-and-%d';
 
@@ -287,7 +289,7 @@ final class FieldDefinitionTest extends AbstractTestCase
      *
      * @param int $initialNumber
      */
-    public function testSequenceReturnsOptionalSequenceWhenValueContainsPlaceholderAndInitialNumberIsSpecified(int $initialNumber): void
+    public function testOptionalSequenceReturnsOptionalSequenceWhenValueContainsPlaceholderAndInitialNumberIsSpecified(int $initialNumber): void
     {
         $value = 'there-is-no-difference-between-%d-and-%d';
 
@@ -298,42 +300,6 @@ final class FieldDefinitionTest extends AbstractTestCase
 
         $expected = FieldDefinition\Sequence::optional(
             $value,
-            $initialNumber
-        );
-
-        self::assertEquals($expected, $fieldDefinition);
-    }
-
-    public function testSequenceReturnsOptionalSequenceWhenValueDoesNotContainPlaceholderAndInitialNumberIsNotSpecified(): void
-    {
-        $value = 'user-';
-
-        $fieldDefinition = FieldDefinition::optionalSequence($value);
-
-        $expected = FieldDefinition\Sequence::optional(
-            $value . '%d',
-            1
-        );
-
-        self::assertEquals($expected, $fieldDefinition);
-    }
-
-    /**
-     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOne()
-     *
-     * @param int $initialNumber
-     */
-    public function testSequenceReturnsOptionalSequenceWhenValueDoesNotContainPlaceholderAndInitialNumberIsSpecified(int $initialNumber): void
-    {
-        $value = 'user-';
-
-        $fieldDefinition = FieldDefinition::optionalSequence(
-            $value,
-            $initialNumber
-        );
-
-        $expected = FieldDefinition\Sequence::optional(
-            $value . '%d',
             $initialNumber
         );
 

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -416,32 +416,6 @@ final class FixtureFactoryTest extends AbstractTestCase
         self::assertSame('beta-4', $organizationFour->name());
     }
 
-    public function testCreateResolvesSequenceToStringValueWhenPercentDPlaceholderIsNotPresent(): void
-    {
-        $fixtureFactory = new FixtureFactory(self::entityManager());
-
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
-            'name' => FieldDefinition::sequence('gamma-'),
-        ]);
-
-        /** @var Fixture\FixtureFactory\Entity\Organization $organizationOne */
-        $organizationOne = $fixtureFactory->create(Fixture\FixtureFactory\Entity\Organization::class);
-
-        /** @var Fixture\FixtureFactory\Entity\Organization $organizationTwo */
-        $organizationTwo = $fixtureFactory->create(Fixture\FixtureFactory\Entity\Organization::class);
-
-        /** @var Fixture\FixtureFactory\Entity\Organization $organizationThree */
-        $organizationThree = $fixtureFactory->create(Fixture\FixtureFactory\Entity\Organization::class);
-
-        /** @var Fixture\FixtureFactory\Entity\Organization $organizationFour */
-        $organizationFour = $fixtureFactory->create(Fixture\FixtureFactory\Entity\Organization::class);
-
-        self::assertSame('gamma-1', $organizationOne->name());
-        self::assertSame('gamma-2', $organizationTwo->name());
-        self::assertSame('gamma-3', $organizationThree->name());
-        self::assertSame('gamma-4', $organizationFour->name());
-    }
-
     public function testCreateAllowsOverridingFieldWithDifferentValueWhenFieldDefinitionHasBeenSpecified(): void
     {
         $faker = self::faker()->unique();


### PR DESCRIPTION
This PR

* [x] requires `string` sequences to contain a `%d` placeholder