### PR TITLE
Fix: Use main as default branch name

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,7 +1,7 @@
 # https://github.com/probot/settings
 
 branches:
-  - name: "master"
+  - name: "main"
 
     # https://developer.github.com/v3/repos/branches/#remove-branch-protection
     # https://developer.github.com/v3/repos/branches/#update-branch-protection
@@ -81,7 +81,7 @@ repository:
   allow_rebase_merge: false
   allow_squash_merge: false
   archived: false
-  default_branch: "master"
+  default_branch: "main"
   delete_branch_on_merge: true
   description: ":robot: Provides an entity factory for doctrine/orm entities that can be used in tests."
   has_downloads: true

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -6,7 +6,7 @@ on: # yamllint disable-line rule:truthy
   pull_request: null
   push:
     branches:
-      - "master"
+      - "main"
 
 env:
   MIN_COVERED_MSI: 98

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`fa9c564...master`][fa9c564...master].
+For a full diff see [`fa9c564...main`][fa9c564...main].
 
 ### Added
 
@@ -60,7 +60,7 @@ For a full diff see [`fa9c564...master`][fa9c564...master].
 * Removed `callable` support for field definitions ([#133]) and ([#185]), by [@localheinz]
 * Removed support for `string` sequences that do not contain a `%d` placeholder ([#185]), by [@localheinz]
 
-[fa9c564...master]: https://github.com/ergebnis/factory-bot/compare/fa9c564...master
+[fa9c564...main]: https://github.com/ergebnis/factory-bot/compare/fa9c564...main
 
 [#1]: https://github.com/ergebnis/factory-bot/pull/1
 [#3]: https://github.com/ergebnis/factory-bot/pull/3

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # factory-bot
 
-[![Integrate](https://github.com/ergebnis/factory-bot/workflows/Integrate/badge.svg?branch=master)](https://github.com/ergebnis/factory-bot/actions)
-[![Prune](https://github.com/ergebnis/factory-bot/workflows/Prune/badge.svg?branch=master)](https://github.com/ergebnis/factory-bot/actions)
-[![Release](https://github.com/ergebnis/factory-bot/workflows/Release/badge.svg?branch=master)](https://github.com/ergebnis/factory-bot/actions)
-[![Renew](https://github.com/ergebnis/factory-bot/workflows/Renew/badge.svg?branch=master)](https://github.com/ergebnis/factory-bot/actions)
+[![Integrate](https://github.com/ergebnis/factory-bot/workflows/Integrate/badge.svg?branch=main)](https://github.com/ergebnis/factory-bot/actions)
+[![Prune](https://github.com/ergebnis/factory-bot/workflows/Prune/badge.svg?branch=main)](https://github.com/ergebnis/factory-bot/actions)
+[![Release](https://github.com/ergebnis/factory-bot/workflows/Release/badge.svg?branch=main)](https://github.com/ergebnis/factory-bot/actions)
+[![Renew](https://github.com/ergebnis/factory-bot/workflows/Renew/badge.svg?branch=main)](https://github.com/ergebnis/factory-bot/actions)
 
-[![Code Coverage](https://codecov.io/gh/ergebnis/factory-bot/branch/master/graph/badge.svg)](https://codecov.io/gh/ergebnis/factory-bot)
+[![Code Coverage](https://codecov.io/gh/ergebnis/factory-bot/branch/main/graph/badge.svg)](https://codecov.io/gh/ergebnis/factory-bot)
 [![Type Coverage](https://shepherd.dev/github/ergebnis/factory-bot/coverage.svg)](https://shepherd.dev/github/ergebnis/factory-bot)
 
 [![Latest Stable Version](https://poser.pugx.org/ergebnis/factory-bot/v/stable)](https://packagist.org/packages/ergebnis/factory-bot)
@@ -35,7 +35,7 @@ Please have a look at [`CONTRIBUTING.md`](.github/CONTRIBUTING.md).
 
 ## Code of Conduct
 
-Please have a look at [`CODE_OF_CONDUCT.md`](https://github.com/ergebnis/.github/blob/master/CODE_OF_CONDUCT.md).
+Please have a look at [`CODE_OF_CONDUCT.md`](https://github.com/ergebnis/.github/blob/main/CODE_OF_CONDUCT.md).
 
 ## License
 


### PR DESCRIPTION
This PR

* [x] uses `main` as default branch name

✊🏿 Black lives matter.