### PR TITLE
Fix: Remove unnecessary default value

### DIFF
--- a/src/FieldDefinition/Reference.php
+++ b/src/FieldDefinition/Reference.php
@@ -36,7 +36,7 @@ final class Reference implements Resolvable
     /**
      * @var bool
      */
-    private $isRequired = false;
+    private $isRequired;
 
     /**
      * @phpstan-param class-string<T> $className

--- a/src/FieldDefinition/Sequence.php
+++ b/src/FieldDefinition/Sequence.php
@@ -34,7 +34,7 @@ final class Sequence implements Resolvable
     /**
      * @var bool
      */
-    private $isRequired = false;
+    private $isRequired;
 
     private function __construct(string $value, int $initialNumber, bool $isRequired)
     {


### PR DESCRIPTION
This PR

* [x] removes unnecessary default values