### PR TITLE
Fix: Remove FieldDefinition::optionalReferences() and FieldDefinition\References::optional()

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -10,7 +10,7 @@ on: # yamllint disable-line rule:truthy
 
 env:
   MIN_COVERED_MSI: 98
-  MIN_MSI: 93
+  MIN_MSI: 91
   PHP_EXTENSIONS: "mbstring"
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ For a full diff see [`fa9c564...main`][fa9c564...main].
 * Removed `FixtureFactory::getAsSingleton()`, `FixtureFactory::setSingleton()`, and `FixtureFactory::unsetSingleton()` ([#124]), by [@localheinz]
 * Removed `callable` support for field definitions ([#133]) and ([#185]), by [@localheinz]
 * Removed support for `string` sequences that do not contain a `%d` placeholder ([#185]), by [@localheinz]
+* Removed `FieldDefinition::optionalReferences()` and `FieldDefinition\References::optional()` ([#259]), by [@localheinz]
 
 [fa9c564...main]: https://github.com/ergebnis/factory-bot/compare/fa9c564...main
 
@@ -105,5 +106,6 @@ For a full diff see [`fa9c564...main`][fa9c564...main].
 [#190]: https://github.com/ergebnis/factory-bot/pull/190
 [#196]: https://github.com/ergebnis/factory-bot/pull/196
 [#197]: https://github.com/ergebnis/factory-bot/pull/197
+[#259]: https://github.com/ergebnis/factory-bot/pull/259
 
 [@localheinz]: https://github.com/localheinz

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 MIN_COVERED_MSI:=98
-MIN_MSI:=93
+MIN_MSI:=91
 
 .PHONY: it
 it: coding-standards static-code-analysis tests ## Runs the coding-standards, static-code-analysis, and tests targets

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -227,9 +227,7 @@
     </MixedAssignment>
   </file>
   <file src="test/Unit/FieldDefinitionTest.php">
-    <InvalidArgument occurrences="6">
-      <code>$className</code>
-      <code>$className</code>
+    <InvalidArgument occurrences="4">
       <code>$className</code>
       <code>$className</code>
       <code>$className</code>

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -203,10 +203,6 @@ final class FixtureFactory
 
             /** @var FieldDefinition\Resolvable $fieldDefinition */
             if (!$fieldDefinition->isRequired() && !$this->faker->boolean()) {
-                if ($fieldDefinition instanceof FieldDefinition\References) {
-                    $fieldValues[$fieldName] = new Common\Collections\ArrayCollection();
-                }
-
                 continue;
             }
 

--- a/test/Unit/FieldDefinitionTest.php
+++ b/test/Unit/FieldDefinitionTest.php
@@ -144,59 +144,6 @@ final class FieldDefinitionTest extends AbstractTestCase
         self::assertEquals($expected, $fieldDefinition);
     }
 
-    /**
-     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intLessThanOne()
-     *
-     * @param int $count
-     */
-    public function testOptionalReferencesThrowsInvalidCountExceptionWhenCountIsLessThanOne(int $count): void
-    {
-        $className = self::class;
-
-        $this->expectException(Exception\InvalidCount::class);
-
-        FieldDefinition::optionalReferences(
-            $className,
-            $count
-        );
-    }
-
-    public function testOptionalReferencesReturnsOptionalReferencesWhenCountIsNotSpecified(): void
-    {
-        $className = Fixture\FixtureFactory\Entity\User::class;
-
-        $fieldDefinition = FieldDefinition::optionalReferences($className);
-
-        $expected = FieldDefinition\References::optional(
-            $className,
-            1
-        );
-
-        self::assertEquals($expected, $fieldDefinition);
-    }
-
-    /**
-     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOne()
-     *
-     * @param int $count
-     */
-    public function testOptionalReferencesReturnsOptionalReferencesWhenCountIsSpecified(int $count): void
-    {
-        $className = Fixture\FixtureFactory\Entity\User::class;
-
-        $fieldDefinition = FieldDefinition::optionalReferences(
-            $className,
-            $count
-        );
-
-        $expected = FieldDefinition\References::optional(
-            $className,
-            $count
-        );
-
-        self::assertEquals($expected, $fieldDefinition);
-    }
-
     public function testSequenceRejectsValueWhenItIsMissingPercentDPlaceholder(): void
     {
         $faker = self::faker();

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -538,65 +538,6 @@ final class FixtureFactoryTest extends AbstractTestCase
      *
      * @param int $count
      */
-    public function testCreateResolvesOptionalReferencesToEmptyArrayCollectionWhenFakerReturnsFalse(int $count): void
-    {
-        $fixtureFactory = new FixtureFactory(
-            self::entityManager(),
-            new Double\Faker\FalseGenerator()
-        );
-
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
-            'repositories' => FieldDefinition::optionalReferences(
-                Fixture\FixtureFactory\Entity\Repository::class,
-                $count
-            ),
-        ]);
-
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
-            'name' => self::faker()->word,
-        ]);
-
-        /** @var Fixture\FixtureFactory\Entity\Organization $organization */
-        $organization = $fixtureFactory->create(Fixture\FixtureFactory\Entity\Organization::class);
-
-        self::assertCount(0, $organization->repositories());
-    }
-
-    /**
-     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOne()
-     *
-     * @param int $count
-     */
-    public function testCreateResolvesOptionalReferencesToArrayCollectionOfEntitiesWhenFakerReturnsTrue(int $count): void
-    {
-        $fixtureFactory = new FixtureFactory(
-            self::entityManager(),
-            new Double\Faker\TrueGenerator()
-        );
-
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
-            'repositories' => FieldDefinition::optionalReferences(
-                Fixture\FixtureFactory\Entity\Repository::class,
-                $count
-            ),
-        ]);
-
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
-            'name' => self::faker()->word,
-        ]);
-
-        /** @var Fixture\FixtureFactory\Entity\Organization $organization */
-        $organization = $fixtureFactory->create(Fixture\FixtureFactory\Entity\Organization::class);
-
-        self::assertContainsOnly(Fixture\FixtureFactory\Entity\Repository::class, $organization->repositories());
-        self::assertCount($count, $organization->repositories());
-    }
-
-    /**
-     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOne()
-     *
-     * @param int $count
-     */
     public function testCreateResolvesRequiredReferencesToArrayCollectionOfEntitiesWhenFakerReturnsFalse(int $count): void
     {
         $fixtureFactory = new FixtureFactory(


### PR DESCRIPTION
This PR

* [x] removes `FieldDefinition::optionalReferences()` and `FieldDefinition\References::optional()`

💁‍♂️ This should be resolved differently, for example, by

- allowing to resolve to an exact number of references
- allowing to resolve to a number of references between a minimum and maximum (where the minimum can be set to `0`)