### PR TITLE
Fix: Rename createMultiple() to createMany()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ For a full diff see [`fa9c564...main`][fa9c564...main].
 * Extracted `FieldDefinition\Optional` ([#260]), by [@localheinz]
 * Extracted `Count` ([#262]), by [@localheinz]
 * Renamed `FixtureFactory::create()` to `FixtureFactory::createOne()` ([#263]), by [@localheinz]
+* Renamed `FixtureFactory::createMultiple()` to `FixtureFactory::createMany()` ([#264]), by [@localheinz]
 
 ### Fixed
 
@@ -113,5 +114,6 @@ For a full diff see [`fa9c564...main`][fa9c564...main].
 [#260]: https://github.com/ergebnis/factory-bot/pull/260
 [#262]: https://github.com/ergebnis/factory-bot/pull/262
 [#263]: https://github.com/ergebnis/factory-bot/pull/263
+[#264]: https://github.com/ergebnis/factory-bot/pull/264
 
 [@localheinz]: https://github.com/localheinz

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26,12 +26,12 @@ parameters:
 			path: src/FixtureFactory.php
 
 		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:createMultiple\\(\\) has parameter \\$count with a nullable type declaration\\.$#"
+			message: "#^Method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:createMany\\(\\) has parameter \\$count with a nullable type declaration\\.$#"
 			count: 1
 			path: src/FixtureFactory.php
 
 		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:createMultiple\\(\\) has parameter \\$count with null as default value\\.$#"
+			message: "#^Method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:createMany\\(\\) has parameter \\$count with null as default value\\.$#"
 			count: 1
 			path: src/FixtureFactory.php
 

--- a/src/FieldDefinition/References.php
+++ b/src/FieldDefinition/References.php
@@ -64,7 +64,7 @@ final class References implements Resolvable
      */
     public function resolve(FixtureFactory $fixtureFactory): array
     {
-        return $fixtureFactory->createMultiple(
+        return $fixtureFactory->createMany(
             $this->className,
             [],
             $this->count

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -250,7 +250,7 @@ final class FixtureFactory
      *
      * @return array<int, object>
      */
-    public function createMultiple(string $className, array $fieldOverrides = [], ?Count $count = null): array
+    public function createMany(string $className, array $fieldOverrides = [], ?Count $count = null): array
     {
         if (null === $count) {
             $count = new Count(1);

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -762,7 +762,7 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         /** @var Fixture\FixtureFactory\Entity\Organization $organization */
         $organization = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class, [
-            'repositories' => $fixtureFactory->createMultiple(
+            'repositories' => $fixtureFactory->createMany(
                 Fixture\FixtureFactory\Entity\Repository::class,
                 [],
                 $count
@@ -873,7 +873,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         self::assertInstanceOf(Fixture\FixtureFactory\Entity\Organization::class, $organization);
     }
 
-    public function testCreateMultipleResolvesToArrayOfEntitiesWhenCountIsNotSpecified(): void
+    public function testCreateManyResolvesToArrayOfEntitiesWhenCountIsNotSpecified(): void
     {
         $fixtureFactory = new FixtureFactory(
             self::entityManager(),
@@ -882,7 +882,7 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
 
-        $entities = $fixtureFactory->createMultiple(Fixture\FixtureFactory\Entity\Organization::class);
+        $entities = $fixtureFactory->createMany(Fixture\FixtureFactory\Entity\Organization::class);
 
         self::assertCount(1, $entities);
     }
@@ -892,7 +892,7 @@ final class FixtureFactoryTest extends AbstractTestCase
      *
      * @param int $value
      */
-    public function testCreateMultipleResolvesToArrayOfEntitiesWhenCountIsSpecified(int $value): void
+    public function testCreateManyResolvesToArrayOfEntitiesWhenCountIsSpecified(int $value): void
     {
         $count = new Count($value);
 
@@ -903,7 +903,7 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
 
-        $entities = $fixtureFactory->createMultiple(
+        $entities = $fixtureFactory->createMany(
             Fixture\FixtureFactory\Entity\Organization::class,
             [],
             $count


### PR DESCRIPTION
This PR

* [x] renames `FixtureFactory::createMultiple()` to `FixtureFactory::createMany()`