### PR TITLE
Fix: Change order of parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ For a full diff see [`fa9c564...main`][fa9c564...main].
 * Extracted `Count` ([#262]), by [@localheinz]
 * Renamed `FixtureFactory::create()` to `FixtureFactory::createOne()` ([#263]), by [@localheinz]
 * Renamed `FixtureFactory::createMultiple()` to `FixtureFactory::createMany()` ([#264]), by [@localheinz]
+* Changed order of parameters for `FixtureFactory::createMany()` ([#266]), by [@localheinz]
 
 ### Fixed
 
@@ -115,5 +116,6 @@ For a full diff see [`fa9c564...main`][fa9c564...main].
 [#262]: https://github.com/ergebnis/factory-bot/pull/262
 [#263]: https://github.com/ergebnis/factory-bot/pull/263
 [#264]: https://github.com/ergebnis/factory-bot/pull/264
+[#266]: https://github.com/ergebnis/factory-bot/pull/266
 
 [@localheinz]: https://github.com/localheinz

--- a/src/FieldDefinition/References.php
+++ b/src/FieldDefinition/References.php
@@ -66,7 +66,6 @@ final class References implements Resolvable
     {
         return $fixtureFactory->createMany(
             $this->className,
-            [],
             $this->count
         );
     }

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -245,12 +245,12 @@ final class FixtureFactory
      * @psalm-template T
      *
      * @param string               $className
-     * @param array<string, mixed> $fieldOverrides
      * @param null|Count           $count
+     * @param array<string, mixed> $fieldOverrides
      *
      * @return array<int, object>
      */
-    public function createMany(string $className, array $fieldOverrides = [], ?Count $count = null): array
+    public function createMany(string $className, ?Count $count = null, array $fieldOverrides = []): array
     {
         if (null === $count) {
             $count = new Count(1);

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -764,7 +764,6 @@ final class FixtureFactoryTest extends AbstractTestCase
         $organization = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class, [
             'repositories' => $fixtureFactory->createMany(
                 Fixture\FixtureFactory\Entity\Repository::class,
-                [],
                 $count
             ),
         ]);
@@ -905,7 +904,6 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         $entities = $fixtureFactory->createMany(
             Fixture\FixtureFactory\Entity\Organization::class,
-            [],
             $count
         );
 


### PR DESCRIPTION
This PR

* [x] changes the order of parameters for `FixtureFactory::createMany()`