### PR TITLE
Fix: Rename Count to Number\Exact

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -10,7 +10,7 @@ on: # yamllint disable-line rule:truthy
 
 env:
   MIN_COVERED_MSI: 97
-  MIN_MSI: 96
+  MIN_MSI: 95
   PHP_EXTENSIONS: "mbstring"
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ For a full diff see [`fa9c564...main`][fa9c564...main].
 * Renamed `FixtureFactory::create()` to `FixtureFactory::createOne()` ([#263]), by [@localheinz]
 * Renamed `FixtureFactory::createMultiple()` to `FixtureFactory::createMany()` ([#264]), by [@localheinz]
 * Changed order of parameters for `FixtureFactory::createMany()` ([#266]), by [@localheinz]
+* Renamed `Count` to `Number\Exact` and `InvalidCount` to `InvalidNumber` ([#273]), by [@localheinz]
 
 ### Fixed
 
@@ -119,5 +120,6 @@ For a full diff see [`fa9c564...main`][fa9c564...main].
 [#264]: https://github.com/ergebnis/factory-bot/pull/264
 [#266]: https://github.com/ergebnis/factory-bot/pull/266
 [#270]: https://github.com/ergebnis/factory-bot/pull/270
+[#273]: https://github.com/ergebnis/factory-bot/pull/273
 
 [@localheinz]: https://github.com/localheinz

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 MIN_COVERED_MSI:=97
-MIN_MSI:=96
+MIN_MSI:=95
 
 .PHONY: it
 it: coding-standards static-code-analysis tests ## Runs the coding-standards, static-code-analysis, and tests targets

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,12 +6,12 @@ parameters:
 			path: src/EntityDefinition.php
 
 		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\FieldDefinition\\:\\:references\\(\\) has parameter \\$count with a nullable type declaration\\.$#"
+			message: "#^Method Ergebnis\\\\FactoryBot\\\\FieldDefinition\\:\\:references\\(\\) has parameter \\$number with a nullable type declaration\\.$#"
 			count: 1
 			path: src/FieldDefinition.php
 
 		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\FieldDefinition\\:\\:references\\(\\) has parameter \\$count with null as default value\\.$#"
+			message: "#^Method Ergebnis\\\\FactoryBot\\\\FieldDefinition\\:\\:references\\(\\) has parameter \\$number with null as default value\\.$#"
 			count: 1
 			path: src/FieldDefinition.php
 
@@ -26,12 +26,12 @@ parameters:
 			path: src/FixtureFactory.php
 
 		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:createMany\\(\\) has parameter \\$count with a nullable type declaration\\.$#"
+			message: "#^Method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:createMany\\(\\) has parameter \\$number with a nullable type declaration\\.$#"
 			count: 1
 			path: src/FixtureFactory.php
 
 		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:createMany\\(\\) has parameter \\$count with null as default value\\.$#"
+			message: "#^Method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:createMany\\(\\) has parameter \\$number with null as default value\\.$#"
 			count: 1
 			path: src/FixtureFactory.php
 
@@ -196,21 +196,6 @@ parameters:
 			path: test/Unit/Exception/EntityDefinitionNotRegisteredTest.php
 
 		-
-			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\InvalidCount' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidCount will always evaluate to true\\.$#"
-			count: 1
-			path: test/Unit/Exception/InvalidCountTest.php
-
-		-
-			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'InvalidArgumentException' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidCount will always evaluate to true\\.$#"
-			count: 1
-			path: test/Unit/Exception/InvalidCountTest.php
-
-		-
-			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\Exception' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidCount will always evaluate to true\\.$#"
-			count: 1
-			path: test/Unit/Exception/InvalidCountTest.php
-
-		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\InvalidDefinition' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidDefinition will always evaluate to true\\.$#"
 			count: 1
 			path: test/Unit/Exception/InvalidDefinitionTest.php
@@ -269,6 +254,21 @@ parameters:
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\Exception' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidFieldNames will always evaluate to true\\.$#"
 			count: 2
 			path: test/Unit/Exception/InvalidFieldNamesTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\InvalidNumber' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidNumber will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/InvalidNumberTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'InvalidArgumentException' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidNumber will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/InvalidNumberTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\Exception' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidNumber will always evaluate to true\\.$#"
+			count: 1
+			path: test/Unit/Exception/InvalidNumberTest.php
 
 		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\InvalidSequence' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidSequence will always evaluate to true\\.$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -97,14 +97,6 @@
       <code>assertInstanceOf</code>
     </RedundantConditionGivenDocblockType>
   </file>
-  <file src="test/Unit/Exception/InvalidCountTest.php">
-    <RedundantCondition occurrences="1">
-      <code>assertInstanceOf</code>
-    </RedundantCondition>
-    <RedundantConditionGivenDocblockType occurrences="1">
-      <code>assertInstanceOf</code>
-    </RedundantConditionGivenDocblockType>
-  </file>
   <file src="test/Unit/Exception/InvalidDefinitionTest.php">
     <RedundantCondition occurrences="1">
       <code>assertInstanceOf</code>
@@ -136,6 +128,14 @@
     </RedundantCondition>
     <RedundantConditionGivenDocblockType occurrences="2">
       <code>assertInstanceOf</code>
+      <code>assertInstanceOf</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="test/Unit/Exception/InvalidNumberTest.php">
+    <RedundantCondition occurrences="1">
+      <code>assertInstanceOf</code>
+    </RedundantCondition>
+    <RedundantConditionGivenDocblockType occurrences="1">
       <code>assertInstanceOf</code>
     </RedundantConditionGivenDocblockType>
   </file>

--- a/src/Exception/InvalidNumber.php
+++ b/src/Exception/InvalidNumber.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace Ergebnis\FactoryBot\Exception;
 
-final class InvalidCount extends \InvalidArgumentException implements Exception
+final class InvalidNumber extends \InvalidArgumentException implements Exception
 {
-    public static function notGreaterThanOrEqualTo(int $minimumCount, int $count): self
+    public static function notGreaterThanOrEqualTo(int $minimum, int $number): self
     {
         return new self(\sprintf(
-            'Count needs to be greater than or equal to %d, but %d is not.',
-            $minimumCount,
-            $count
+            'Number needs to be greater than or equal to %d, but %d is not.',
+            $minimum,
+            $number
         ));
     }
 }

--- a/src/FieldDefinition.php
+++ b/src/FieldDefinition.php
@@ -66,20 +66,20 @@ final class FieldDefinition
      * @psalm-return FieldDefinition\References<T>
      * @psalm-template T
      *
-     * @param string     $className
-     * @param null|Count $count
+     * @param string            $className
+     * @param null|Number\Exact $number
      *
      * @return FieldDefinition\References
      */
-    public static function references(string $className, ?Count $count = null): FieldDefinition\References
+    public static function references(string $className, ?Number\Exact $number = null): FieldDefinition\References
     {
-        if (null === $count) {
-            $count = new Count(1);
+        if (null === $number) {
+            $number = new Number\Exact(1);
         }
 
         return new FieldDefinition\References(
             $className,
-            $count
+            $number
         );
     }
 

--- a/src/FieldDefinition/References.php
+++ b/src/FieldDefinition/References.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Ergebnis\FactoryBot\FieldDefinition;
 
-use Ergebnis\FactoryBot\Count;
 use Ergebnis\FactoryBot\FixtureFactory;
+use Ergebnis\FactoryBot\Number;
 
 /**
  * @internal
@@ -35,22 +35,22 @@ final class References implements Resolvable
     private $className;
 
     /**
-     * @var Count
+     * @var Number\Exact
      */
-    private $count;
+    private $number;
 
     /**
      * @phpstan-param class-string<T> $className
      *
      * @psalm-param class-string<T> $className
      *
-     * @param string $className
-     * @param Count  $count
+     * @param string       $className
+     * @param Number\Exact $number
      */
-    public function __construct(string $className, Count $count)
+    public function __construct(string $className, Number\Exact $number)
     {
         $this->className = $className;
-        $this->count = $count;
+        $this->number = $number;
     }
 
     /**
@@ -66,7 +66,7 @@ final class References implements Resolvable
     {
         return $fixtureFactory->createMany(
             $this->className,
-            $this->count
+            $this->number
         );
     }
 }

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -237,20 +237,20 @@ final class FixtureFactory
      * @psalm-template T
      *
      * @param string                                                   $className
-     * @param null|Count                                               $count
+     * @param null|Number\Exact                                        $number
      * @param array<string, \Closure|FieldDefinition\Resolvable|mixed> $fieldDefinitionOverrides
      *
      * @return array<int, object>
      */
-    public function createMany(string $className, ?Count $count = null, array $fieldDefinitionOverrides = []): array
+    public function createMany(string $className, ?Number\Exact $number = null, array $fieldDefinitionOverrides = []): array
     {
-        if (null === $count) {
-            $count = new Count(1);
+        if (null === $number) {
+            $number = new Number\Exact(1);
         }
 
         $instances = [];
 
-        for ($i = 0; $count->value() > $i; ++$i) {
+        for ($i = 0; $number->value() > $i; ++$i) {
             $instances[] = $this->createOne(
                 $className,
                 $fieldDefinitionOverrides

--- a/src/Number/Exact.php
+++ b/src/Number/Exact.php
@@ -11,9 +11,11 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot;
+namespace Ergebnis\FactoryBot\Number;
 
-final class Count
+use Ergebnis\FactoryBot\Exception;
+
+final class Exact
 {
     /**
      * @var int
@@ -23,12 +25,12 @@ final class Count
     /**
      * @param int $value
      *
-     * @throws Exception\InvalidCount
+     * @throws Exception\InvalidNumber
      */
     public function __construct(int $value)
     {
         if (1 > $value) {
-            throw Exception\InvalidCount::notGreaterThanOrEqualTo(
+            throw Exception\InvalidNumber::notGreaterThanOrEqualTo(
                 1,
                 $value
             );

--- a/test/Unit/Exception/InvalidNumberTest.php
+++ b/test/Unit/Exception/InvalidNumberTest.php
@@ -20,9 +20,9 @@ use PHPUnit\Framework;
 /**
  * @internal
  *
- * @covers \Ergebnis\FactoryBot\Exception\InvalidCount
+ * @covers \Ergebnis\FactoryBot\Exception\InvalidNumber
  */
-final class InvalidCountTest extends Framework\TestCase
+final class InvalidNumberTest extends Framework\TestCase
 {
     use Helper;
 
@@ -30,21 +30,21 @@ final class InvalidCountTest extends Framework\TestCase
     {
         $faker = self::faker();
 
-        $minimumCount = $faker->numberBetween(1, 1000);
-        $count = $minimumCount - $faker->numberBetween(1);
+        $minimum = $faker->numberBetween(1, 1000);
+        $number = $minimum - $faker->numberBetween(1);
 
-        $exception = Exception\InvalidCount::notGreaterThanOrEqualTo(
-            $minimumCount,
-            $count
+        $exception = Exception\InvalidNumber::notGreaterThanOrEqualTo(
+            $minimum,
+            $number
         );
 
         $message = \sprintf(
-            'Count needs to be greater than or equal to %d, but %d is not.',
-            $minimumCount,
-            $count
+            'Number needs to be greater than or equal to %d, but %d is not.',
+            $minimum,
+            $number
         );
 
-        self::assertInstanceOf(Exception\InvalidCount::class, $exception);
+        self::assertInstanceOf(Exception\InvalidNumber::class, $exception);
         self::assertInstanceOf(\InvalidArgumentException::class, $exception);
         self::assertInstanceOf(Exception\Exception::class, $exception);
         self::assertSame($message, $exception->getMessage());

--- a/test/Unit/FieldDefinition/ReferencesTest.php
+++ b/test/Unit/FieldDefinition/ReferencesTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Ergebnis\FactoryBot\Test\Unit\FieldDefinition;
 
-use Ergebnis\FactoryBot\Count;
 use Ergebnis\FactoryBot\FieldDefinition\References;
 use Ergebnis\FactoryBot\FixtureFactory;
+use Ergebnis\FactoryBot\Number;
 use Ergebnis\FactoryBot\Test\Fixture;
 use Ergebnis\FactoryBot\Test\Unit\AbstractTestCase;
 
@@ -24,12 +24,12 @@ use Ergebnis\FactoryBot\Test\Unit\AbstractTestCase;
  *
  * @covers \Ergebnis\FactoryBot\FieldDefinition\References
  *
- * @uses \Ergebnis\FactoryBot\Count
  * @uses \Ergebnis\FactoryBot\EntityDefinition
- * @uses \Ergebnis\FactoryBot\Exception\InvalidCount
+ * @uses \Ergebnis\FactoryBot\Exception\InvalidNumber
  * @uses \Ergebnis\FactoryBot\FieldDefinition
  * @uses \Ergebnis\FactoryBot\FieldDefinition\Value
  * @uses \Ergebnis\FactoryBot\FixtureFactory
+ * @uses \Ergebnis\FactoryBot\Number\Exact
  */
 final class ReferencesTest extends AbstractTestCase
 {
@@ -41,7 +41,7 @@ final class ReferencesTest extends AbstractTestCase
     public function testResolvesToArrayOfObjectsCreatedByFixtureFactory(int $value): void
     {
         $className = Fixture\FixtureFactory\Entity\User::class;
-        $count = new Count($value);
+        $number = new Number\Exact($value);
 
         $fixtureFactory = new FixtureFactory(
             self::entityManager(),
@@ -52,13 +52,13 @@ final class ReferencesTest extends AbstractTestCase
 
         $fieldDefinition = new References(
             $className,
-            $count
+            $number
         );
 
         $resolved = $fieldDefinition->resolve($fixtureFactory);
 
         self::assertIsArray($resolved);
-        self::assertCount($count->value(), $resolved);
+        self::assertCount($number->value(), $resolved);
         self::assertContainsOnly($className, $resolved);
     }
 }

--- a/test/Unit/FieldDefinitionTest.php
+++ b/test/Unit/FieldDefinitionTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Ergebnis\FactoryBot\Test\Unit;
 
-use Ergebnis\FactoryBot\Count;
 use Ergebnis\FactoryBot\Exception;
 use Ergebnis\FactoryBot\FieldDefinition;
 use Ergebnis\FactoryBot\FixtureFactory;
+use Ergebnis\FactoryBot\Number;
 use Ergebnis\FactoryBot\Test\Fixture;
 
 /**
@@ -24,8 +24,7 @@ use Ergebnis\FactoryBot\Test\Fixture;
  *
  * @covers \Ergebnis\FactoryBot\FieldDefinition
  *
- * @uses \Ergebnis\FactoryBot\Count
- * @uses \Ergebnis\FactoryBot\Exception\InvalidCount
+ * @uses \Ergebnis\FactoryBot\Exception\InvalidNumber
  * @uses \Ergebnis\FactoryBot\Exception\InvalidSequence
  * @uses \Ergebnis\FactoryBot\FieldDefinition\Closure
  * @uses \Ergebnis\FactoryBot\FieldDefinition\Optional
@@ -33,6 +32,7 @@ use Ergebnis\FactoryBot\Test\Fixture;
  * @uses \Ergebnis\FactoryBot\FieldDefinition\References
  * @uses \Ergebnis\FactoryBot\FieldDefinition\Sequence
  * @uses \Ergebnis\FactoryBot\FieldDefinition\Value
+ * @uses \Ergebnis\FactoryBot\Number\Exact
  */
 final class FieldDefinitionTest extends AbstractTestCase
 {
@@ -94,16 +94,16 @@ final class FieldDefinitionTest extends AbstractTestCase
         self::assertEquals($expected, $fieldDefinition);
     }
 
-    public function testReferencesReturnsRequiredReferencesWhenCountIsNotSpecified(): void
+    public function testReferencesReturnsRequiredReferencesWhenNumberIsNotSpecified(): void
     {
         $className = Fixture\FixtureFactory\Entity\User::class;
-        $count = new Count(1);
+        $number = new Number\Exact(1);
 
         $fieldDefinition = FieldDefinition::references($className);
 
         $expected = new FieldDefinition\References(
             $className,
-            $count
+            $number
         );
 
         self::assertEquals($expected, $fieldDefinition);
@@ -114,19 +114,19 @@ final class FieldDefinitionTest extends AbstractTestCase
      *
      * @param int $value
      */
-    public function testReferencesReturnsRequiredReferencesWhenCountIsSpecified(int $value): void
+    public function testReferencesReturnsRequiredReferencesWhenNumberIsSpecified(int $value): void
     {
         $className = Fixture\FixtureFactory\Entity\User::class;
-        $count = new Count($value);
+        $number = new Number\Exact($value);
 
         $fieldDefinition = FieldDefinition::references(
             $className,
-            $count
+            $number
         );
 
         $expected = new FieldDefinition\References(
             $className,
-            $count
+            $number
         );
 
         self::assertEquals($expected, $fieldDefinition);

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Ergebnis\FactoryBot\Test\Unit;
 
-use Ergebnis\FactoryBot\Count;
 use Ergebnis\FactoryBot\Exception;
 use Ergebnis\FactoryBot\FieldDefinition;
 use Ergebnis\FactoryBot\FixtureFactory;
+use Ergebnis\FactoryBot\Number;
 use Ergebnis\FactoryBot\Test\Double;
 use Ergebnis\FactoryBot\Test\Fixture;
 
@@ -25,14 +25,13 @@ use Ergebnis\FactoryBot\Test\Fixture;
  *
  * @covers \Ergebnis\FactoryBot\FixtureFactory
  *
- * @uses \Ergebnis\FactoryBot\Count
  * @uses \Ergebnis\FactoryBot\EntityDefinition
  * @uses \Ergebnis\FactoryBot\Exception\ClassMetadataNotFound
  * @uses \Ergebnis\FactoryBot\Exception\ClassNotFound
  * @uses \Ergebnis\FactoryBot\Exception\EntityDefinitionAlreadyRegistered
  * @uses \Ergebnis\FactoryBot\Exception\EntityDefinitionNotRegistered
- * @uses \Ergebnis\FactoryBot\Exception\InvalidCount
  * @uses \Ergebnis\FactoryBot\Exception\InvalidFieldNames
+ * @uses \Ergebnis\FactoryBot\Exception\InvalidNumber
  * @uses \Ergebnis\FactoryBot\FieldDefinition
  * @uses \Ergebnis\FactoryBot\FieldDefinition\Closure
  * @uses \Ergebnis\FactoryBot\FieldDefinition\Optional
@@ -40,6 +39,7 @@ use Ergebnis\FactoryBot\Test\Fixture;
  * @uses \Ergebnis\FactoryBot\FieldDefinition\References
  * @uses \Ergebnis\FactoryBot\FieldDefinition\Sequence
  * @uses \Ergebnis\FactoryBot\FieldDefinition\Value
+ * @uses \Ergebnis\FactoryBot\Number\Exact
  */
 final class FixtureFactoryTest extends AbstractTestCase
 {
@@ -553,7 +553,7 @@ final class FixtureFactoryTest extends AbstractTestCase
      */
     public function testCreateOneResolvesRequiredReferencesToArrayCollectionOfEntitiesWhenFakerReturnsFalse(int $value): void
     {
-        $count = new Count($value);
+        $number = new Number\Exact($value);
 
         $fixtureFactory = new FixtureFactory(
             self::entityManager(),
@@ -563,7 +563,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
             'repositories' => FieldDefinition::references(
                 Fixture\FixtureFactory\Entity\Repository::class,
-                $count
+                $number
             ),
         ]);
 
@@ -575,7 +575,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         $organization = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class);
 
         self::assertContainsOnly(Fixture\FixtureFactory\Entity\Repository::class, $organization->repositories());
-        self::assertCount($count->value(), $organization->repositories());
+        self::assertCount($number->value(), $organization->repositories());
     }
 
     /**
@@ -585,7 +585,7 @@ final class FixtureFactoryTest extends AbstractTestCase
      */
     public function testCreateOneResolvesRequiredReferencesToArrayCollectionOfEntitiesWhenFakerReturnsTrue(int $value): void
     {
-        $count = new Count($value);
+        $number = new Number\Exact($value);
 
         $fixtureFactory = new FixtureFactory(
             self::entityManager(),
@@ -595,7 +595,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
             'repositories' => FieldDefinition::references(
                 Fixture\FixtureFactory\Entity\Repository::class,
-                $count
+                $number
             ),
         ]);
 
@@ -609,7 +609,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         $repositories = $organization->repositories();
 
         self::assertContainsOnly(Fixture\FixtureFactory\Entity\Repository::class, $repositories);
-        self::assertCount($count->value(), $repositories);
+        self::assertCount($number->value(), $repositories);
     }
 
     public function testCreateOneResolvesOptionalSequenceNullWhenFakerReturnsFalse(): void
@@ -795,7 +795,7 @@ final class FixtureFactoryTest extends AbstractTestCase
      */
     public function testCreateOneAllowsOverridingAssociationWithCollectionOfEntitiesWhenFieldDefinitionOverrideHasBeenSpecifiedAsArray(int $value): void
     {
-        $count = new Count($value);
+        $number = new Number\Exact($value);
 
         $faker = self::faker();
 
@@ -816,14 +816,14 @@ final class FixtureFactoryTest extends AbstractTestCase
         $organization = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class, [
             'repositories' => $fixtureFactory->createMany(
                 Fixture\FixtureFactory\Entity\Repository::class,
-                $count
+                $number
             ),
         ]);
 
         $repositories = $organization->repositories();
 
         self::assertContainsOnly(Fixture\FixtureFactory\Entity\Repository::class, $repositories);
-        self::assertCount($count->value(), $repositories);
+        self::assertCount($number->value(), $repositories);
     }
 
     /**
@@ -833,7 +833,7 @@ final class FixtureFactoryTest extends AbstractTestCase
      */
     public function testCreateOneAllowsOverridingAssociationWithCollectionOfEntitiesWhenFieldDefinitionOverrideHasBeenSpecifiedAsFieldDefinition(int $value): void
     {
-        $count = new Count($value);
+        $number = new Number\Exact($value);
 
         $faker = self::faker();
 
@@ -854,14 +854,14 @@ final class FixtureFactoryTest extends AbstractTestCase
         $organization = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class, [
             'repositories' => FieldDefinition::references(
                 Fixture\FixtureFactory\Entity\Repository::class,
-                $count
+                $number
             ),
         ]);
 
         $repositories = $organization->repositories();
 
         self::assertContainsOnly(Fixture\FixtureFactory\Entity\Repository::class, $repositories);
-        self::assertCount($count->value(), $repositories);
+        self::assertCount($number->value(), $repositories);
     }
 
     public function testDefineAcceptsClosureThatWillBeInvokedAfterEntityCreation(): void
@@ -962,7 +962,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         self::assertInstanceOf(Fixture\FixtureFactory\Entity\Organization::class, $organization);
     }
 
-    public function testCreateManyResolvesToArrayOfEntitiesWhenCountIsNotSpecified(): void
+    public function testCreateManyResolvesToArrayOfEntitiesWhenNumberIsNotSpecified(): void
     {
         $fixtureFactory = new FixtureFactory(
             self::entityManager(),
@@ -981,9 +981,9 @@ final class FixtureFactoryTest extends AbstractTestCase
      *
      * @param int $value
      */
-    public function testCreateManyResolvesToArrayOfEntitiesWhenCountIsSpecified(int $value): void
+    public function testCreateManyResolvesToArrayOfEntitiesWhenNumberIsSpecified(int $value): void
     {
-        $count = new Count($value);
+        $number = new Number\Exact($value);
 
         $fixtureFactory = new FixtureFactory(
             self::entityManager(),
@@ -994,16 +994,16 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         $entities = $fixtureFactory->createMany(
             Fixture\FixtureFactory\Entity\Organization::class,
-            $count
+            $number
         );
 
-        self::assertCount($count->value(), $entities);
+        self::assertCount($number->value(), $entities);
 
         $unverifiedEntities = \array_filter($entities, static function (Fixture\FixtureFactory\Entity\Organization $organization): bool {
             return !$organization->isVerified();
         });
 
-        self::assertCount($count->value(), $unverifiedEntities);
+        self::assertCount($number->value(), $unverifiedEntities);
     }
 
     public function testCreateManyResolvesToArrayOfEntitiesWhenFieldDefinitionOverridesAreSpecifiedAsValue(): void
@@ -1014,25 +1014,25 @@ final class FixtureFactoryTest extends AbstractTestCase
             $faker
         );
 
-        $count = new Count($faker->numberBetween(1, 5));
+        $number = new Number\Exact($faker->numberBetween(1, 5));
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
 
         $entities = $fixtureFactory->createMany(
             Fixture\FixtureFactory\Entity\Organization::class,
-            $count,
+            $number,
             [
                 'isVerified' => true,
             ]
         );
 
-        self::assertCount($count->value(), $entities);
+        self::assertCount($number->value(), $entities);
 
         $verifiedEntities = \array_filter($entities, static function (Fixture\FixtureFactory\Entity\Organization $organization): bool {
             return $organization->isVerified();
         });
 
-        self::assertCount($count->value(), $verifiedEntities);
+        self::assertCount($number->value(), $verifiedEntities);
     }
 
     public function testCreateManyResolvesToArrayOfEntitiesWhenFieldDefinitionOverridesAreSpecifiedAsFieldDefinition(): void
@@ -1043,24 +1043,24 @@ final class FixtureFactoryTest extends AbstractTestCase
             $faker
         );
 
-        $count = new Count($faker->numberBetween(1, 5));
+        $number = new Number\Exact($faker->numberBetween(1, 5));
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
 
         $entities = $fixtureFactory->createMany(
             Fixture\FixtureFactory\Entity\Organization::class,
-            $count,
+            $number,
             [
                 'isVerified' => FieldDefinition::value(true),
             ]
         );
 
-        self::assertCount($count->value(), $entities);
+        self::assertCount($number->value(), $entities);
 
         $verifiedEntities = \array_filter($entities, static function (Fixture\FixtureFactory\Entity\Organization $organization): bool {
             return $organization->isVerified();
         });
 
-        self::assertCount($count->value(), $verifiedEntities);
+        self::assertCount($number->value(), $verifiedEntities);
     }
 }

--- a/test/Unit/Number/ExactTest.php
+++ b/test/Unit/Number/ExactTest.php
@@ -11,20 +11,20 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Unit;
+namespace Ergebnis\FactoryBot\Test\Unit\Number;
 
-use Ergebnis\FactoryBot\Count;
 use Ergebnis\FactoryBot\Exception;
+use Ergebnis\FactoryBot\Number\Exact;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Ergebnis\FactoryBot\Count
+ * @covers \Ergebnis\FactoryBot\Number\Exact
  *
- * @uses \Ergebnis\FactoryBot\Exception\InvalidCount
+ * @uses \Ergebnis\FactoryBot\Exception\InvalidNumber
  */
-final class CountTest extends Framework\TestCase
+final class ExactTest extends Framework\TestCase
 {
     /**
      * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::lessThanOne()
@@ -33,14 +33,14 @@ final class CountTest extends Framework\TestCase
      */
     public function testConstructorRejectsInvalidValue(int $value): void
     {
-        $this->expectException(Exception\InvalidCount::class);
+        $this->expectException(Exception\InvalidNumber::class);
         $this->expectExceptionMessage(\sprintf(
-            'Count needs to be greater than or equal to %d, but %d is not.',
+            'Number needs to be greater than or equal to %d, but %d is not.',
             1,
             $value
         ));
 
-        new Count($value);
+        new Exact($value);
     }
 
     /**
@@ -50,8 +50,8 @@ final class CountTest extends Framework\TestCase
      */
     public function testConstructorSetsValue(int $value): void
     {
-        $count = new Count($value);
+        $number = new Exact($value);
 
-        self::assertSame($value, $count->value());
+        self::assertSame($value, $number->value());
     }
 }


### PR DESCRIPTION
This PR

* [x] renames `Count` to `Number\Exact` and `InvalidCount` to `InvalidNumber`