### PR TITLE
Fix: Rename method

### DIFF
--- a/test/DataProvider/NumberProvider.php
+++ b/test/DataProvider/NumberProvider.php
@@ -40,7 +40,7 @@ final class NumberProvider
     /**
      * @return \Generator<string, array<int>>
      */
-    public function intGreaterThanOne(): \Generator
+    public function intGreaterThanOrEqualToOne(): \Generator
     {
         $values = [
             'int-one' => 1,

--- a/test/Unit/CountTest.php
+++ b/test/Unit/CountTest.php
@@ -44,7 +44,7 @@ final class CountTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOne()
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOrEqualToOne()
      *
      * @param int $value
      */

--- a/test/Unit/FieldDefinition/ReferencesTest.php
+++ b/test/Unit/FieldDefinition/ReferencesTest.php
@@ -34,7 +34,7 @@ use Ergebnis\FactoryBot\Test\Unit\AbstractTestCase;
 final class ReferencesTest extends AbstractTestCase
 {
     /**
-     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOne()
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOrEqualToOne()
      *
      * @param int $value
      */

--- a/test/Unit/FieldDefinitionTest.php
+++ b/test/Unit/FieldDefinitionTest.php
@@ -110,7 +110,7 @@ final class FieldDefinitionTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOne()
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOrEqualToOne()
      *
      * @param int $value
      */
@@ -166,7 +166,7 @@ final class FieldDefinitionTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOne()
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOrEqualToOne()
      *
      * @param int $initialNumber
      */
@@ -221,7 +221,7 @@ final class FieldDefinitionTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOne()
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOrEqualToOne()
      *
      * @param int $initialNumber
      */

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -547,7 +547,7 @@ final class FixtureFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOne()
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOrEqualToOne()
      *
      * @param int $value
      */
@@ -579,7 +579,7 @@ final class FixtureFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOne()
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOrEqualToOne()
      *
      * @param int $value
      */
@@ -789,7 +789,7 @@ final class FixtureFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOne()
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOrEqualToOne()
      *
      * @param int $value
      */
@@ -827,7 +827,7 @@ final class FixtureFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOne()
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOrEqualToOne()
      *
      * @param int $value
      */
@@ -977,7 +977,7 @@ final class FixtureFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOne()
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOrEqualToOne()
      *
      * @param int $value
      */


### PR DESCRIPTION
This PR

* [x] renames a method