### PR TITLE
Fix: Allow arbitrary integers for sequences

### DIFF
--- a/test/DataProvider/NumberProvider.php
+++ b/test/DataProvider/NumberProvider.php
@@ -22,6 +22,26 @@ final class NumberProvider
     /**
      * @return \Generator<string, array<int>>
      */
+    public function intArbitrary(): \Generator
+    {
+        $values = [
+            'int-less-than-minus-one' => -1 * self::faker()->numberBetween(2),
+            'int-minus-one' => -1,
+            'int-zero' => 0,
+            'int-one' => 1,
+            'int-greater-than-one' => self::faker()->numberBetween(2),
+        ];
+
+        foreach ($values as $key => $value) {
+            yield $key => [
+                $value,
+            ];
+        }
+    }
+
+    /**
+     * @return \Generator<string, array<int>>
+     */
     public function intLessThanOne(): \Generator
     {
         $values = [

--- a/test/Unit/FieldDefinitionTest.php
+++ b/test/Unit/FieldDefinitionTest.php
@@ -221,7 +221,7 @@ final class FieldDefinitionTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intGreaterThanOrEqualToOne()
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\NumberProvider::intArbitrary()
      *
      * @param int $initialNumber
      */


### PR DESCRIPTION
This PR

* [x] allows arbitrary integers for sequences