### PR TITLE
Fix: Allow zero as value for Number\Exact

### DIFF
--- a/src/Number/Exact.php
+++ b/src/Number/Exact.php
@@ -29,9 +29,9 @@ final class Exact
      */
     public function __construct(int $value)
     {
-        if (1 > $value) {
+        if (0 > $value) {
             throw Exception\InvalidNumber::notGreaterThanOrEqualTo(
-                1,
+                0,
                 $value
             );
         }

--- a/test/DataProvider/IntProvider.php
+++ b/test/DataProvider/IntProvider.php
@@ -42,10 +42,9 @@ final class IntProvider
     /**
      * @return \Generator<string, array<int>>
      */
-    public function lessThanOne(): \Generator
+    public function lessThanZero(): \Generator
     {
         $values = [
-            'int-zero' => 0,
             'int-minus-one' => -1,
             'int-less-than-minus-one' => -1 * self::faker()->numberBetween(2),
         ];
@@ -60,9 +59,10 @@ final class IntProvider
     /**
      * @return \Generator<string, array<int>>
      */
-    public function greaterThanOrEqualToOne(): \Generator
+    public function greaterThanOrEqualToZero(): \Generator
     {
         $values = [
+            'int-zero' => 0,
             'int-one' => 1,
             'int-two' => 2,
             'int-greater-than-two' => self::faker()->numberBetween(3, 10),

--- a/test/Unit/FieldDefinition/ReferencesTest.php
+++ b/test/Unit/FieldDefinition/ReferencesTest.php
@@ -34,7 +34,7 @@ use Ergebnis\FactoryBot\Test\Unit\AbstractTestCase;
 final class ReferencesTest extends AbstractTestCase
 {
     /**
-     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::greaterThanOrEqualToOne()
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::greaterThanOrEqualToZero()
      *
      * @param int $value
      */

--- a/test/Unit/FieldDefinitionTest.php
+++ b/test/Unit/FieldDefinitionTest.php
@@ -110,7 +110,7 @@ final class FieldDefinitionTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::greaterThanOrEqualToOne()
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::greaterThanOrEqualToZero()
      *
      * @param int $value
      */
@@ -166,7 +166,7 @@ final class FieldDefinitionTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::greaterThanOrEqualToOne()
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::greaterThanOrEqualToZero()
      *
      * @param int $initialNumber
      */

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -547,7 +547,7 @@ final class FixtureFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::greaterThanOrEqualToOne()
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::greaterThanOrEqualToZero()
      *
      * @param int $value
      */
@@ -579,7 +579,7 @@ final class FixtureFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::greaterThanOrEqualToOne()
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::greaterThanOrEqualToZero()
      *
      * @param int $value
      */
@@ -789,7 +789,7 @@ final class FixtureFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::greaterThanOrEqualToOne()
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::greaterThanOrEqualToZero()
      *
      * @param int $value
      */
@@ -827,7 +827,7 @@ final class FixtureFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::greaterThanOrEqualToOne()
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::greaterThanOrEqualToZero()
      *
      * @param int $value
      */
@@ -977,7 +977,7 @@ final class FixtureFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::greaterThanOrEqualToOne()
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::greaterThanOrEqualToZero()
      *
      * @param int $value
      */

--- a/test/Unit/Number/ExactTest.php
+++ b/test/Unit/Number/ExactTest.php
@@ -27,7 +27,7 @@ use PHPUnit\Framework;
 final class ExactTest extends Framework\TestCase
 {
     /**
-     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::lessThanOne()
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::lessThanZero()
      *
      * @param int $value
      */
@@ -36,7 +36,7 @@ final class ExactTest extends Framework\TestCase
         $this->expectException(Exception\InvalidNumber::class);
         $this->expectExceptionMessage(\sprintf(
             'Number needs to be greater than or equal to %d, but %d is not.',
-            1,
+            0,
             $value
         ));
 
@@ -44,7 +44,7 @@ final class ExactTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::greaterThanOrEqualToOne()
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::greaterThanOrEqualToZero()
      *
      * @param int $value
      */


### PR DESCRIPTION
This PR

* [x] allows `0` as value for `Number\Exact`