### PR TITLE
Fix: Remove parameter that always has same value and rename method

### DIFF
--- a/src/Exception/InvalidNumber.php
+++ b/src/Exception/InvalidNumber.php
@@ -15,11 +15,10 @@ namespace Ergebnis\FactoryBot\Exception;
 
 final class InvalidNumber extends \InvalidArgumentException implements Exception
 {
-    public static function notGreaterThanOrEqualTo(int $minimum, int $number): self
+    public static function notGreaterThanOrEqualToZero(int $number): self
     {
         return new self(\sprintf(
-            'Number needs to be greater than or equal to %d, but %d is not.',
-            $minimum,
+            'Number needs to be greater than or equal to 0, but %d is not.',
             $number
         ));
     }

--- a/src/Number/Exact.php
+++ b/src/Number/Exact.php
@@ -30,10 +30,7 @@ final class Exact
     public function __construct(int $value)
     {
         if (0 > $value) {
-            throw Exception\InvalidNumber::notGreaterThanOrEqualTo(
-                0,
-                $value
-            );
+            throw Exception\InvalidNumber::notGreaterThanOrEqualToZero($value);
         }
 
         $this->value = $value;

--- a/test/Unit/Exception/InvalidNumberTest.php
+++ b/test/Unit/Exception/InvalidNumberTest.php
@@ -28,19 +28,12 @@ final class InvalidNumberTest extends Framework\TestCase
 
     public function testNotGreaterThanOrEqualToReturnsException(): void
     {
-        $faker = self::faker();
+        $number = -1 * self::faker()->numberBetween(1);
 
-        $minimum = $faker->numberBetween(1, 1000);
-        $number = $minimum - $faker->numberBetween(1);
-
-        $exception = Exception\InvalidNumber::notGreaterThanOrEqualTo(
-            $minimum,
-            $number
-        );
+        $exception = Exception\InvalidNumber::notGreaterThanOrEqualToZero($number);
 
         $message = \sprintf(
-            'Number needs to be greater than or equal to %d, but %d is not.',
-            $minimum,
+            'Number needs to be greater than or equal to 0, but %d is not.',
             $number
         );
 

--- a/test/Unit/Number/ExactTest.php
+++ b/test/Unit/Number/ExactTest.php
@@ -35,8 +35,7 @@ final class ExactTest extends Framework\TestCase
     {
         $this->expectException(Exception\InvalidNumber::class);
         $this->expectExceptionMessage(\sprintf(
-            'Number needs to be greater than or equal to %d, but %d is not.',
-            0,
+            'Number needs to be greater than or equal to 0, but %d is not.',
             $value
         ));
 


### PR DESCRIPTION
This PR

* [x] removes a parameter that always has the same value and renames a method