### PR TITLE
Fix: Rename Number\Exact to Number

### DIFF
--- a/src/FieldDefinition.php
+++ b/src/FieldDefinition.php
@@ -66,15 +66,15 @@ final class FieldDefinition
      * @psalm-return FieldDefinition\References<T>
      * @psalm-template T
      *
-     * @param string            $className
-     * @param null|Number\Exact $number
+     * @param string      $className
+     * @param null|Number $number
      *
      * @return FieldDefinition\References
      */
-    public static function references(string $className, ?Number\Exact $number = null): FieldDefinition\References
+    public static function references(string $className, ?Number $number = null): FieldDefinition\References
     {
         if (null === $number) {
-            $number = new Number\Exact(1);
+            $number = new Number(1);
         }
 
         return new FieldDefinition\References(

--- a/src/FieldDefinition/References.php
+++ b/src/FieldDefinition/References.php
@@ -36,7 +36,7 @@ final class References implements Resolvable
     private $className;
 
     /**
-     * @var Number\Exact
+     * @var Number
      */
     private $number;
 
@@ -45,10 +45,10 @@ final class References implements Resolvable
      *
      * @psalm-param class-string<T> $className
      *
-     * @param string       $className
-     * @param Number\Exact $number
+     * @param string $className
+     * @param Number $number
      */
-    public function __construct(string $className, Number\Exact $number)
+    public function __construct(string $className, Number $number)
     {
         $this->className = $className;
         $this->number = $number;

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -240,15 +240,15 @@ final class FixtureFactory
      * @psalm-template T
      *
      * @param string                                                   $className
-     * @param null|Number\Exact                                        $number
+     * @param null|Number                                              $number
      * @param array<string, \Closure|FieldDefinition\Resolvable|mixed> $fieldDefinitionOverrides
      *
      * @return array<int, object>
      */
-    public function createMany(string $className, ?Number\Exact $number = null, array $fieldDefinitionOverrides = []): array
+    public function createMany(string $className, ?Number $number = null, array $fieldDefinitionOverrides = []): array
     {
         if (null === $number) {
-            $number = new Number\Exact(1);
+            $number = new Number(1);
         }
 
         $instances = [];

--- a/src/Number.php
+++ b/src/Number.php
@@ -11,11 +11,9 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Number;
+namespace Ergebnis\FactoryBot;
 
-use Ergebnis\FactoryBot\Exception;
-
-final class Exact
+final class Number
 {
     /**
      * @var int

--- a/test/Unit/FieldDefinition/ReferencesTest.php
+++ b/test/Unit/FieldDefinition/ReferencesTest.php
@@ -29,7 +29,7 @@ use Ergebnis\FactoryBot\Test\Unit\AbstractTestCase;
  * @uses \Ergebnis\FactoryBot\FieldDefinition
  * @uses \Ergebnis\FactoryBot\FieldDefinition\Value
  * @uses \Ergebnis\FactoryBot\FixtureFactory
- * @uses \Ergebnis\FactoryBot\Number\Exact
+ * @uses \Ergebnis\FactoryBot\Number
  */
 final class ReferencesTest extends AbstractTestCase
 {
@@ -41,7 +41,7 @@ final class ReferencesTest extends AbstractTestCase
     public function testResolvesToArrayOfObjectsCreatedByFixtureFactory(int $value): void
     {
         $className = Fixture\FixtureFactory\Entity\User::class;
-        $number = new Number\Exact($value);
+        $number = new Number($value);
 
         $faker = self::faker();
 

--- a/test/Unit/FieldDefinitionTest.php
+++ b/test/Unit/FieldDefinitionTest.php
@@ -32,7 +32,7 @@ use Ergebnis\FactoryBot\Test\Fixture;
  * @uses \Ergebnis\FactoryBot\FieldDefinition\References
  * @uses \Ergebnis\FactoryBot\FieldDefinition\Sequence
  * @uses \Ergebnis\FactoryBot\FieldDefinition\Value
- * @uses \Ergebnis\FactoryBot\Number\Exact
+ * @uses \Ergebnis\FactoryBot\Number
  */
 final class FieldDefinitionTest extends AbstractTestCase
 {
@@ -97,7 +97,7 @@ final class FieldDefinitionTest extends AbstractTestCase
     public function testReferencesReturnsRequiredReferencesWhenNumberIsNotSpecified(): void
     {
         $className = Fixture\FixtureFactory\Entity\User::class;
-        $number = new Number\Exact(1);
+        $number = new Number(1);
 
         $fieldDefinition = FieldDefinition::references($className);
 
@@ -117,7 +117,7 @@ final class FieldDefinitionTest extends AbstractTestCase
     public function testReferencesReturnsRequiredReferencesWhenNumberIsSpecified(int $value): void
     {
         $className = Fixture\FixtureFactory\Entity\User::class;
-        $number = new Number\Exact($value);
+        $number = new Number($value);
 
         $fieldDefinition = FieldDefinition::references(
             $className,

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -40,7 +40,7 @@ use Faker\Generator;
  * @uses \Ergebnis\FactoryBot\FieldDefinition\References
  * @uses \Ergebnis\FactoryBot\FieldDefinition\Sequence
  * @uses \Ergebnis\FactoryBot\FieldDefinition\Value
- * @uses \Ergebnis\FactoryBot\Number\Exact
+ * @uses \Ergebnis\FactoryBot\Number
  */
 final class FixtureFactoryTest extends AbstractTestCase
 {
@@ -554,7 +554,7 @@ final class FixtureFactoryTest extends AbstractTestCase
      */
     public function testCreateOneResolvesRequiredReferencesToArrayCollectionOfEntitiesWhenFakerReturnsFalse(int $value): void
     {
-        $number = new Number\Exact($value);
+        $number = new Number($value);
 
         $fixtureFactory = new FixtureFactory(
             self::entityManager(),
@@ -586,7 +586,7 @@ final class FixtureFactoryTest extends AbstractTestCase
      */
     public function testCreateOneResolvesRequiredReferencesToArrayCollectionOfEntitiesWhenFakerReturnsTrue(int $value): void
     {
-        $number = new Number\Exact($value);
+        $number = new Number($value);
 
         $fixtureFactory = new FixtureFactory(
             self::entityManager(),
@@ -796,7 +796,7 @@ final class FixtureFactoryTest extends AbstractTestCase
      */
     public function testCreateOneAllowsOverridingAssociationWithCollectionOfEntitiesWhenFieldDefinitionOverrideHasBeenSpecifiedAsArray(int $value): void
     {
-        $number = new Number\Exact($value);
+        $number = new Number($value);
 
         $faker = self::faker();
 
@@ -834,7 +834,7 @@ final class FixtureFactoryTest extends AbstractTestCase
      */
     public function testCreateOneAllowsOverridingAssociationWithCollectionOfEntitiesWhenFieldDefinitionOverrideHasBeenSpecifiedAsFieldDefinition(int $value): void
     {
-        $number = new Number\Exact($value);
+        $number = new Number($value);
 
         $faker = self::faker();
 
@@ -986,7 +986,7 @@ final class FixtureFactoryTest extends AbstractTestCase
      */
     public function testCreateManyResolvesToArrayOfEntitiesWhenNumberIsSpecified(int $value): void
     {
-        $number = new Number\Exact($value);
+        $number = new Number($value);
 
         $fixtureFactory = new FixtureFactory(
             self::entityManager(),
@@ -1018,7 +1018,7 @@ final class FixtureFactoryTest extends AbstractTestCase
             $faker
         );
 
-        $number = new Number\Exact($faker->numberBetween(1, 5));
+        $number = new Number($faker->numberBetween(1, 5));
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
 
@@ -1048,7 +1048,7 @@ final class FixtureFactoryTest extends AbstractTestCase
             $faker
         );
 
-        $number = new Number\Exact($faker->numberBetween(1, 5));
+        $number = new Number($faker->numberBetween(1, 5));
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
 

--- a/test/Unit/NumberTest.php
+++ b/test/Unit/NumberTest.php
@@ -11,20 +11,20 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Unit\Number;
+namespace Ergebnis\FactoryBot\Test\Unit;
 
 use Ergebnis\FactoryBot\Exception;
-use Ergebnis\FactoryBot\Number\Exact;
+use Ergebnis\FactoryBot\Number;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Ergebnis\FactoryBot\Number\Exact
+ * @covers \Ergebnis\FactoryBot\Number
  *
  * @uses \Ergebnis\FactoryBot\Exception\InvalidNumber
  */
-final class ExactTest extends Framework\TestCase
+final class NumberTest extends Framework\TestCase
 {
     /**
      * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::lessThanZero()
@@ -39,7 +39,7 @@ final class ExactTest extends Framework\TestCase
             $value
         ));
 
-        new Exact($value);
+        new Number($value);
     }
 
     /**
@@ -49,7 +49,7 @@ final class ExactTest extends Framework\TestCase
      */
     public function testConstructorSetsValue(int $value): void
     {
-        $number = new Exact($value);
+        $number = new Number($value);
 
         self::assertSame($value, $number->value());
     }


### PR DESCRIPTION
This PR

* [x] renames `Number\Exact` to `Number`

Slightly reverts #273.