### PR TITLE
Fix: Require Number to be passed in

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,32 +6,12 @@ parameters:
 			path: src/EntityDefinition.php
 
 		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\FieldDefinition\\:\\:references\\(\\) has parameter \\$number with a nullable type declaration\\.$#"
-			count: 1
-			path: src/FieldDefinition.php
-
-		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\FieldDefinition\\:\\:references\\(\\) has parameter \\$number with null as default value\\.$#"
-			count: 1
-			path: src/FieldDefinition.php
-
-		-
 			message: "#^Method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:define\\(\\) has parameter \\$afterCreate with a nullable type declaration\\.$#"
 			count: 1
 			path: src/FixtureFactory.php
 
 		-
 			message: "#^Method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:define\\(\\) has parameter \\$afterCreate with null as default value\\.$#"
-			count: 1
-			path: src/FixtureFactory.php
-
-		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:createMany\\(\\) has parameter \\$number with a nullable type declaration\\.$#"
-			count: 1
-			path: src/FixtureFactory.php
-
-		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:createMany\\(\\) has parameter \\$number with null as default value\\.$#"
 			count: 1
 			path: src/FixtureFactory.php
 

--- a/src/FieldDefinition.php
+++ b/src/FieldDefinition.php
@@ -66,17 +66,13 @@ final class FieldDefinition
      * @psalm-return FieldDefinition\References<T>
      * @psalm-template T
      *
-     * @param string      $className
-     * @param null|Number $number
+     * @param string $className
+     * @param Number $number
      *
      * @return FieldDefinition\References
      */
-    public static function references(string $className, ?Number $number = null): FieldDefinition\References
+    public static function references(string $className, Number $number): FieldDefinition\References
     {
-        if (null === $number) {
-            $number = Number::exact(1);
-        }
-
         return new FieldDefinition\References(
             $className,
             $number

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -240,17 +240,13 @@ final class FixtureFactory
      * @psalm-template T
      *
      * @param string                                                   $className
-     * @param null|Number                                              $number
+     * @param Number                                                   $number
      * @param array<string, \Closure|FieldDefinition\Resolvable|mixed> $fieldDefinitionOverrides
      *
      * @return array<int, object>
      */
-    public function createMany(string $className, ?Number $number = null, array $fieldDefinitionOverrides = []): array
+    public function createMany(string $className, Number $number, array $fieldDefinitionOverrides = []): array
     {
-        if (null === $number) {
-            $number = Number::exact(1);
-        }
-
         $instances = [];
 
         $value = $number->resolve($this->faker);

--- a/test/Unit/FieldDefinitionTest.php
+++ b/test/Unit/FieldDefinitionTest.php
@@ -94,20 +94,6 @@ final class FieldDefinitionTest extends AbstractTestCase
         self::assertEquals($expected, $fieldDefinition);
     }
 
-    public function testReferencesReturnsRequiredReferencesWhenNumberIsNotSpecified(): void
-    {
-        $className = Fixture\FixtureFactory\Entity\User::class;
-
-        $fieldDefinition = FieldDefinition::references($className);
-
-        $expected = new FieldDefinition\References(
-            $className,
-            Number::exact(1)
-        );
-
-        self::assertEquals($expected, $fieldDefinition);
-    }
-
     /**
      * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::greaterThanOrEqualToZero()
      *

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -823,7 +823,10 @@ final class FixtureFactoryTest extends AbstractTestCase
         );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
-            'template' => FieldDefinition::references(Fixture\FixtureFactory\Entity\Repository::class),
+            'template' => FieldDefinition::references(
+                Fixture\FixtureFactory\Entity\Repository::class,
+                Number::between(0, 5)
+            ),
         ]);
 
         /** @var Fixture\FixtureFactory\Entity\Repository $repository */
@@ -842,7 +845,10 @@ final class FixtureFactoryTest extends AbstractTestCase
         );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
-            'template' => FieldDefinition::references(Fixture\FixtureFactory\Entity\Repository::class),
+            'template' => FieldDefinition::references(
+                Fixture\FixtureFactory\Entity\Repository::class,
+                Number::between(0, 5)
+            ),
         ]);
 
         /** @var Fixture\FixtureFactory\Entity\Repository $repository */
@@ -868,7 +874,10 @@ final class FixtureFactoryTest extends AbstractTestCase
         );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
-            'repositories' => FieldDefinition::references(Fixture\FixtureFactory\Entity\Repository::class),
+            'repositories' => FieldDefinition::references(
+                Fixture\FixtureFactory\Entity\Repository::class,
+                Number::between(0, 5)
+            ),
         ]);
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
@@ -904,7 +913,10 @@ final class FixtureFactoryTest extends AbstractTestCase
         );
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
-            'repositories' => FieldDefinition::references(Fixture\FixtureFactory\Entity\Repository::class),
+            'repositories' => FieldDefinition::references(
+                Fixture\FixtureFactory\Entity\Repository::class,
+                Number::between(0, 5)
+            ),
         ]);
 
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
@@ -1023,20 +1035,6 @@ final class FixtureFactoryTest extends AbstractTestCase
         $organization = $repository->organization();
 
         self::assertInstanceOf(Fixture\FixtureFactory\Entity\Organization::class, $organization);
-    }
-
-    public function testCreateManyResolvesToArrayOfEntitiesWhenNumberIsNotSpecified(): void
-    {
-        $fixtureFactory = new FixtureFactory(
-            self::entityManager(),
-            self::faker()
-        );
-
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
-
-        $entities = $fixtureFactory->createMany(Fixture\FixtureFactory\Entity\Organization::class);
-
-        self::assertCount(1, $entities);
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] requires a `Number` to be passed into `FieldDefinition::references()` and `FixtureFactory::createMany()`