### PR TITLE
Fix: Remove unneeded parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ For a full diff see [`fa9c564...main`][fa9c564...main].
 * Removed `callable` support for field definitions ([#133]) and ([#185]), by [@localheinz]
 * Removed support for `string` sequences that do not contain a `%d` placeholder ([#185]), by [@localheinz]
 * Removed `FieldDefinition::optionalReferences()` and `FieldDefinition\References::optional()` ([#259]), by [@localheinz]
+* Removed parameter `$faker` from `Definition::registerWith()` ([#286]), by [@localheinz]
 
 [fa9c564...main]: https://github.com/ergebnis/factory-bot/compare/fa9c564...main
 
@@ -123,5 +124,6 @@ For a full diff see [`fa9c564...main`][fa9c564...main].
 [#266]: https://github.com/ergebnis/factory-bot/pull/266
 [#270]: https://github.com/ergebnis/factory-bot/pull/270
 [#273]: https://github.com/ergebnis/factory-bot/pull/273
+[#286]: https://github.com/ergebnis/factory-bot/pull/286
 
 [@localheinz]: https://github.com/localheinz

--- a/src/Definition.php
+++ b/src/Definition.php
@@ -13,9 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\FactoryBot;
 
-use Faker\Generator;
-
 interface Definition
 {
-    public function accept(FixtureFactory $fixtureFactory, Generator $faker): void;
+    public function accept(FixtureFactory $fixtureFactory): void;
 }

--- a/src/Definitions.php
+++ b/src/Definitions.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Ergebnis\FactoryBot;
 
 use Ergebnis\Classy;
-use Faker\Generator;
 
 final class Definitions
 {
@@ -83,15 +82,11 @@ final class Definitions
      * Registers all found definitions with the specified fixture factory.
      *
      * @param FixtureFactory $fixtureFactory
-     * @param Generator      $faker
      */
-    public function registerWith(FixtureFactory $fixtureFactory, Generator $faker): void
+    public function registerWith(FixtureFactory $fixtureFactory): void
     {
         foreach ($this->definitions as $definition) {
-            $definition->accept(
-                $fixtureFactory,
-                $faker
-            );
+            $definition->accept($fixtureFactory);
         }
     }
 }

--- a/test/Fixture/Definitions/DoesNotImplementDefinition/RepositoryDefinition.php
+++ b/test/Fixture/Definitions/DoesNotImplementDefinition/RepositoryDefinition.php
@@ -15,11 +15,10 @@ namespace Ergebnis\FactoryBot\Test\Fixture\Definitions\DoesNotImplementDefinitio
 
 use Ergebnis\FactoryBot\FixtureFactory;
 use Ergebnis\FactoryBot\Test\Fixture;
-use Faker\Generator;
 
 final class RepositoryDefinition
 {
-    public function accept(FixtureFactory $fixtureFactory, Generator $faker): void
+    public function accept(FixtureFactory $fixtureFactory): void
     {
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class);
     }

--- a/test/Fixture/Definitions/ImplementsDefinition/RepositoryDefinition.php
+++ b/test/Fixture/Definitions/ImplementsDefinition/RepositoryDefinition.php
@@ -16,11 +16,10 @@ namespace Ergebnis\FactoryBot\Test\Fixture\Definitions\ImplementsDefinition;
 use Ergebnis\FactoryBot\Definition;
 use Ergebnis\FactoryBot\FixtureFactory;
 use Ergebnis\FactoryBot\Test\Fixture;
-use Faker\Generator;
 
 final class RepositoryDefinition implements Definition
 {
-    public function accept(FixtureFactory $fixtureFactory, Generator $faker): void
+    public function accept(FixtureFactory $fixtureFactory): void
     {
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class);
     }

--- a/test/Fixture/Definitions/ImplementsDefinitionButHasPrivateConstructor/RepositoryDefinition.php
+++ b/test/Fixture/Definitions/ImplementsDefinitionButHasPrivateConstructor/RepositoryDefinition.php
@@ -16,7 +16,6 @@ namespace Ergebnis\FactoryBot\Test\Fixture\Definitions\ImplementsDefinitionButHa
 use Ergebnis\FactoryBot\Definition;
 use Ergebnis\FactoryBot\FixtureFactory;
 use Ergebnis\FactoryBot\Test\Fixture;
-use Faker\Generator;
 
 final class RepositoryDefinition implements Definition
 {
@@ -24,7 +23,7 @@ final class RepositoryDefinition implements Definition
     {
     }
 
-    public function accept(FixtureFactory $fixtureFactory, Generator $faker): void
+    public function accept(FixtureFactory $fixtureFactory): void
     {
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class);
     }

--- a/test/Fixture/Definitions/ImplementsDefinitionButIsAbstract/RepositoryDefinition.php
+++ b/test/Fixture/Definitions/ImplementsDefinitionButIsAbstract/RepositoryDefinition.php
@@ -16,11 +16,10 @@ namespace Ergebnis\FactoryBot\Test\Fixture\Definitions\ImplementsDefinitionButIs
 use Ergebnis\FactoryBot\Definition;
 use Ergebnis\FactoryBot\FixtureFactory;
 use Ergebnis\FactoryBot\Test\Fixture;
-use Faker\Generator;
 
 abstract class RepositoryDefinition implements Definition
 {
-    final public function accept(FixtureFactory $fixtureFactory, Generator $faker): void
+    final public function accept(FixtureFactory $fixtureFactory): void
     {
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class);
     }

--- a/test/Fixture/Definitions/ImplementsDefinitionButThrowsExceptionDuringConstruction/RepositoryDefinition.php
+++ b/test/Fixture/Definitions/ImplementsDefinitionButThrowsExceptionDuringConstruction/RepositoryDefinition.php
@@ -16,7 +16,6 @@ namespace Ergebnis\FactoryBot\Test\Fixture\Definitions\ImplementsDefinitionButTh
 use Ergebnis\FactoryBot\Definition;
 use Ergebnis\FactoryBot\FixtureFactory;
 use Ergebnis\FactoryBot\Test\Fixture;
-use Faker\Generator;
 
 final class RepositoryDefinition implements Definition
 {
@@ -25,7 +24,7 @@ final class RepositoryDefinition implements Definition
         throw new \RuntimeException();
     }
 
-    public function accept(FixtureFactory $fixtureFactory, Generator $faker): void
+    public function accept(FixtureFactory $fixtureFactory): void
     {
         $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class);
     }

--- a/test/Unit/DefinitionsTest.php
+++ b/test/Unit/DefinitionsTest.php
@@ -41,57 +41,42 @@ final class DefinitionsTest extends AbstractTestCase
 
     public function testInIgnoresClassesWhichDoNotImplementProviderInterface(): void
     {
-        $faker = self::faker();
-
         $fixtureFactory = new FixtureFactory(
             self::entityManager(),
-            $faker
+            self::faker()
         );
 
         $definitions = Definitions::in(__DIR__ . '/../Fixture/Definitions/DoesNotImplementDefinition');
 
-        $definitions->registerWith(
-            $fixtureFactory,
-            $faker
-        );
+        $definitions->registerWith($fixtureFactory);
 
         self::assertSame([], $fixtureFactory->definitions());
     }
 
     public function testInIgnoresDefinitionsThatAreAbstract(): void
     {
-        $faker = self::faker();
-
         $fixtureFactory = new FixtureFactory(
             self::entityManager(),
-            $faker
+            self::faker()
         );
 
         $definitions = Definitions::in(__DIR__ . '/../Fixture/Definitions/ImplementsDefinitionButIsAbstract');
 
-        $definitions->registerWith(
-            $fixtureFactory,
-            $faker
-        );
+        $definitions->registerWith($fixtureFactory);
 
         self::assertSame([], $fixtureFactory->definitions());
     }
 
     public function testInIgnoresDefinitionsThatHavePrivateConstructors(): void
     {
-        $faker = self::faker();
-
         $fixtureFactory = new FixtureFactory(
             self::entityManager(),
-            $faker
+            self::faker()
         );
 
         $definitions = Definitions::in(__DIR__ . '/../Fixture/Definitions/ImplementsDefinitionButHasPrivateConstructor');
 
-        $definitions->registerWith(
-            $fixtureFactory,
-            $faker
-        );
+        $definitions->registerWith($fixtureFactory);
 
         self::assertSame([], $fixtureFactory->definitions());
     }
@@ -105,19 +90,14 @@ final class DefinitionsTest extends AbstractTestCase
 
     public function testInAcceptsDefinitionsThatHaveNoIssues(): void
     {
-        $faker = self::faker();
-
         $fixtureFactory = new FixtureFactory(
             self::entityManager(),
-            $faker
+            self::faker()
         );
 
         $definitions = Definitions::in(__DIR__ . '/../Fixture/Definitions/ImplementsDefinition');
 
-        $definitions->registerWith(
-            $fixtureFactory,
-            $faker
-        );
+        $definitions->registerWith($fixtureFactory);
 
         self::assertArrayHasKey(Fixture\FixtureFactory\Entity\Repository::class, $fixtureFactory->definitions());
     }


### PR DESCRIPTION
This PR

* [x] removes an unneeded parameter

Follows #144.