### PR TITLE
Fix: Verify that class implements interface

### DIFF
--- a/src/Definitions.php
+++ b/src/Definitions.php
@@ -58,7 +58,7 @@ final class Definitions
                 continue;
             }
 
-            if (!$reflection->isSubclassOf(Definition::class)) {
+            if (!$reflection->implementsInterface(Definition::class)) {
                 continue;
             }
 


### PR DESCRIPTION
This PR

* [x] verifies that a candidate class implements `Definition`, instead of that it is a subclass of `Definition`