### PR TITLE
Fix: Rename named constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`0.1.0...main`][0.1.0...main].
 
+### Changed
+
+* Renamed `InvalidDefinition::fromClassNameAndException()` to `InvalidDefinition::throwsExceptionDuringInstantiation()` ([#300]), by [@localheinz]
+
 ## [`0.1.0`][0.1.0]
 
 For a full diff see [`fa9c564...0.1.0`][fa9c564...0.1.0].
@@ -134,5 +138,6 @@ For a full diff see [`fa9c564...0.1.0`][fa9c564...0.1.0].
 [#273]: https://github.com/ergebnis/factory-bot/pull/273
 [#286]: https://github.com/ergebnis/factory-bot/pull/286
 [#287]: https://github.com/ergebnis/factory-bot/pull/287
+[#300]: https://github.com/ergebnis/factory-bot/pull/300
 
 [@localheinz]: https://github.com/localheinz

--- a/src/Definitions.php
+++ b/src/Definitions.php
@@ -70,7 +70,7 @@ final class Definitions
                 /** @var Definition $definition */
                 $definition = $reflection->newInstance();
             } catch (\Exception $exception) {
-                throw Exception\InvalidDefinition::fromClassNameAndException(
+                throw Exception\InvalidDefinition::throwsExceptionDuringInstantiation(
                     $className,
                     $exception
                 );

--- a/src/Exception/InvalidDefinition.php
+++ b/src/Exception/InvalidDefinition.php
@@ -15,7 +15,7 @@ namespace Ergebnis\FactoryBot\Exception;
 
 final class InvalidDefinition extends \RuntimeException implements Exception
 {
-    public static function fromClassNameAndException(string $className, \Exception $exception): self
+    public static function throwsExceptionDuringInstantiation(string $className, \Exception $exception): self
     {
         return new self(
             \sprintf(

--- a/test/Unit/Exception/InvalidDefinitionTest.php
+++ b/test/Unit/Exception/InvalidDefinitionTest.php
@@ -26,12 +26,12 @@ final class InvalidDefinitionTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testFromClassNameCreatesException(): void
+    public function testThrowsExceptionDuringInstantiationReturnsException(): void
     {
         $className = self::faker()->word;
         $previousException = new \Exception();
 
-        $exception = Exception\InvalidDefinition::fromClassNameAndException(
+        $exception = Exception\InvalidDefinition::throwsExceptionDuringInstantiation(
             $className,
             $previousException
         );


### PR DESCRIPTION
This PR

* [x] renames `InvalidDefinition::fromClassNameAndException()` to `InvalidDefinition::throwsExceptionDuringInstantiation()`