### PR TITLE
Fix: Throw InvalidDefinition exception when concrete definition can not be instantiated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ For a full diff see [`0.1.0...main`][0.1.0...main].
 
 * Renamed `InvalidDefinition::fromClassNameAndException()` to `InvalidDefinition::throwsExceptionDuringInstantiation()` ([#300]), by [@localheinz]
 
+### Fixed
+
+* Started throwing an `InvalidDefinition` exception when a definition is concrete but cannot be instantiated ([#301]), by [@localheinz]
+
 ## [`0.1.0`][0.1.0]
 
 For a full diff see [`fa9c564...0.1.0`][fa9c564...0.1.0].
@@ -139,5 +143,6 @@ For a full diff see [`fa9c564...0.1.0`][fa9c564...0.1.0].
 [#286]: https://github.com/ergebnis/factory-bot/pull/286
 [#287]: https://github.com/ergebnis/factory-bot/pull/287
 [#300]: https://github.com/ergebnis/factory-bot/pull/300
+[#301]: https://github.com/ergebnis/factory-bot/pull/301
 
 [@localheinz]: https://github.com/localheinz

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -197,17 +197,17 @@ parameters:
 
 		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\InvalidDefinition' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidDefinition will always evaluate to true\\.$#"
-			count: 1
+			count: 2
 			path: test/Unit/Exception/InvalidDefinitionTest.php
 
 		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'RuntimeException' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidDefinition will always evaluate to true\\.$#"
-			count: 1
+			count: 2
 			path: test/Unit/Exception/InvalidDefinitionTest.php
 
 		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\Exception' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidDefinition will always evaluate to true\\.$#"
-			count: 1
+			count: 2
 			path: test/Unit/Exception/InvalidDefinitionTest.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -6,8 +6,7 @@
     </DocblockTypeContradiction>
   </file>
   <file src="src/FixtureFactory.php">
-    <MixedAssignment occurrences="4">
-      <code>$fieldValues[$fieldName]</code>
+    <MixedAssignment occurrences="3">
       <code>$fieldValue</code>
       <code>$inversedBy</code>
       <code>$collection</code>
@@ -110,10 +109,12 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="test/Unit/Exception/InvalidDefinitionTest.php">
-    <RedundantCondition occurrences="1">
+    <RedundantCondition occurrences="2">
+      <code>assertInstanceOf</code>
       <code>assertInstanceOf</code>
     </RedundantCondition>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>assertInstanceOf</code>
       <code>assertInstanceOf</code>
     </RedundantConditionGivenDocblockType>
   </file>

--- a/src/Definitions.php
+++ b/src/Definitions.php
@@ -62,8 +62,12 @@ final class Definitions
                 continue;
             }
 
-            if (!$reflection->isInstantiable()) {
+            if ($reflection->isAbstract()) {
                 continue;
+            }
+
+            if (!$reflection->isInstantiable()) {
+                throw Exception\InvalidDefinition::canNotBeInstantiated($className);
             }
 
             try {

--- a/src/Exception/InvalidDefinition.php
+++ b/src/Exception/InvalidDefinition.php
@@ -15,6 +15,14 @@ namespace Ergebnis\FactoryBot\Exception;
 
 final class InvalidDefinition extends \RuntimeException implements Exception
 {
+    public static function canNotBeInstantiated(string $className): self
+    {
+        return new self(\sprintf(
+            'Definition "%s" can not be instantiated.',
+            $className
+        ));
+    }
+
     public static function throwsExceptionDuringInstantiation(string $className, \Exception $exception): self
     {
         return new self(

--- a/test/Fixture/Definitions/ImplementsDefinitionButCanNotBeInstantiated/OrganizationDefinition.php
+++ b/test/Fixture/Definitions/ImplementsDefinitionButCanNotBeInstantiated/OrganizationDefinition.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Fixture\Definitions\ImplementsDefinitionButHasPrivateConstructor;
+namespace Ergebnis\FactoryBot\Test\Fixture\Definitions\ImplementsDefinitionButCanNotBeInstantiated;
 
 use Ergebnis\FactoryBot\Definition;
 use Ergebnis\FactoryBot\FixtureFactory;

--- a/test/Fixture/Definitions/ImplementsDefinitionButCanNotBeInstantiated/RepositoryDefinition.php
+++ b/test/Fixture/Definitions/ImplementsDefinitionButCanNotBeInstantiated/RepositoryDefinition.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Fixture\Definitions\ImplementsDefinitionButHasPrivateConstructor;
+namespace Ergebnis\FactoryBot\Test\Fixture\Definitions\ImplementsDefinitionButCanNotBeInstantiated;
 
 use Ergebnis\FactoryBot\Definition;
 use Ergebnis\FactoryBot\FixtureFactory;

--- a/test/Fixture/Definitions/ImplementsDefinitionButCanNotBeInstantiated/UserDefinition.php
+++ b/test/Fixture/Definitions/ImplementsDefinitionButCanNotBeInstantiated/UserDefinition.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Fixture\Definitions\ImplementsDefinitionButHasPrivateConstructor;
+namespace Ergebnis\FactoryBot\Test\Fixture\Definitions\ImplementsDefinitionButCanNotBeInstantiated;
 
 use Ergebnis\FactoryBot\Definition;
 use Ergebnis\FactoryBot\FixtureFactory;

--- a/test/Unit/DefinitionsTest.php
+++ b/test/Unit/DefinitionsTest.php
@@ -80,29 +80,24 @@ final class DefinitionsTest extends AbstractTestCase
         self::assertArrayHasKey(Fixture\FixtureFactory\Entity\User::class, $registeredDefinitions);
     }
 
-    public function testInIgnoresDefinitionsThatHavePrivateConstructors(): void
+    public function testInThrowsInvalidDefinitionExceptionWhenDefinitionCanNotBeInstantiated(): void
     {
-        $fixtureFactory = new FixtureFactory(
-            self::entityManager(),
-            self::faker()
-        );
+        $this->expectException(Exception\InvalidDefinition::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Definition "%s" can not be instantiated.',
+            Fixture\Definitions\ImplementsDefinitionButCanNotBeInstantiated\RepositoryDefinition::class
+        ));
 
-        $definitions = Definitions::in(__DIR__ . '/../Fixture/Definitions/ImplementsDefinitionButHasPrivateConstructor');
-
-        $definitions->registerWith($fixtureFactory);
-
-        $registeredDefinitions = $fixtureFactory->definitions();
-
-        self::assertCount(2, $registeredDefinitions);
-        self::assertContainsOnly(EntityDefinition::class, $registeredDefinitions);
-        self::assertArrayHasKey(Fixture\FixtureFactory\Entity\Organization::class, $registeredDefinitions);
-        self::assertArrayNotHasKey(Fixture\FixtureFactory\Entity\Repository::class, $registeredDefinitions);
-        self::assertArrayHasKey(Fixture\FixtureFactory\Entity\User::class, $registeredDefinitions);
+        Definitions::in(__DIR__ . '/../Fixture/Definitions/ImplementsDefinitionButCanNotBeInstantiated');
     }
 
     public function testInThrowsInvalidDefinitionExceptionWhenExceptionIsThrownDuringInstantiationOfDefinition(): void
     {
         $this->expectException(Exception\InvalidDefinition::class);
+        $this->expectExceptionMessage(\sprintf(
+            'An exception was thrown while trying to instantiate definition "%s".',
+            Fixture\Definitions\ImplementsDefinitionButThrowsExceptionDuringConstruction\RepositoryDefinition::class
+        ));
 
         Definitions::in(__DIR__ . '/../Fixture/Definitions/ImplementsDefinitionButThrowsExceptionDuringConstruction');
     }

--- a/test/Unit/Exception/InvalidDefinitionTest.php
+++ b/test/Unit/Exception/InvalidDefinitionTest.php
@@ -26,6 +26,24 @@ final class InvalidDefinitionTest extends Framework\TestCase
 {
     use Helper;
 
+    public function testCanNotBeInstantiatedReturnsException(): void
+    {
+        $className = self::faker()->word;
+
+        $exception = Exception\InvalidDefinition::canNotBeInstantiated($className);
+
+        self::assertInstanceOf(Exception\InvalidDefinition::class, $exception);
+        self::assertInstanceOf(\RuntimeException::class, $exception);
+        self::assertInstanceOf(Exception\Exception::class, $exception);
+
+        $message = \sprintf(
+            'Definition "%s" can not be instantiated.',
+            $className
+        );
+
+        self::assertSame($message, $exception->getMessage());
+    }
+
     public function testThrowsExceptionDuringInstantiationReturnsException(): void
     {
         $className = self::faker()->word;
@@ -36,14 +54,15 @@ final class InvalidDefinitionTest extends Framework\TestCase
             $previousException
         );
 
+        self::assertInstanceOf(Exception\InvalidDefinition::class, $exception);
+        self::assertInstanceOf(\RuntimeException::class, $exception);
+        self::assertInstanceOf(Exception\Exception::class, $exception);
+
         $message = \sprintf(
             'An exception was thrown while trying to instantiate definition "%s".',
             $className
         );
 
-        self::assertInstanceOf(Exception\InvalidDefinition::class, $exception);
-        self::assertInstanceOf(\RuntimeException::class, $exception);
-        self::assertInstanceOf(Exception\Exception::class, $exception);
         self::assertSame($message, $exception->getMessage());
         self::assertSame(0, $exception->getCode());
         self::assertSame($previousException, $exception->getPrevious());


### PR DESCRIPTION
This PR

* [x] throws an `InvalidDefinition` exception when a concrete definition can not be instantiated