### PR TITLE
Fix: Throw InvalidDefinition exception when definition can not be autoloaded

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -10,7 +10,7 @@ on: # yamllint disable-line rule:truthy
 
 env:
   MIN_COVERED_MSI: 99
-  MIN_MSI: 98
+  MIN_MSI: 99
   PHP_EXTENSIONS: "mbstring"
 
 jobs:
@@ -86,6 +86,9 @@ jobs:
 
       - name: "Run friendsofphp/php-cs-fixer"
         run: "vendor/bin/php-cs-fixer fix --config=.php_cs --diff --diff-format=udiff --dry-run --verbose"
+
+      - name: "Run friendsofphp/php-cs-fixer on fixtures"
+        run: "vendor/bin/php-cs-fixer fix --config=.php_cs.fixture --diff --diff-format=udiff --dry-run --verbose"
 
   dependency-analysis:
     name: "Dependency Analysis"

--- a/.php_cs.fixture
+++ b/.php_cs.fixture
@@ -28,19 +28,11 @@ $license->save();
 
 $config = PhpCsFixer\Config\Factory::fromRuleSet(new PhpCsFixer\Config\RuleSet\Php71($license->header()), [
     'mb_str_functions' => false,
+    'psr4' => false,
 ]);
 
-$config->getFinder()
-    ->ignoreDotFiles(false)
-    ->in(__DIR__)
-    ->exclude([
-        '.build/',
-        '.github/',
-        '.notes/',
-        '/test/Fixture/Definitions/CanNotBeAutoloaded/',
-    ])
-    ->name('.php_cs');
+$config->getFinder()->in(__DIR__ . '/test/Fixture/Definitions/CanNotBeAutoloaded');
 
-$config->setCacheFile(__DIR__ . '/.build/php-cs-fixer/.php_cs.cache');
+$config->setCacheFile(__DIR__ . '/.build/php-cs-fixer/.php_cs.fixture.cache');
 
 return $config;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For a full diff see [`0.1.0...main`][0.1.0...main].
 ### Fixed
 
 * Started throwing an `InvalidDefinition` exception when a definition is concrete but cannot be instantiated ([#301]), by [@localheinz]
+* Started throwing an `InvalidDefinition` exception when a definition cannot be autoloaded ([#302]), by [@localheinz]
 
 ## [`0.1.0`][0.1.0]
 
@@ -144,5 +145,6 @@ For a full diff see [`fa9c564...0.1.0`][fa9c564...0.1.0].
 [#287]: https://github.com/ergebnis/factory-bot/pull/287
 [#300]: https://github.com/ergebnis/factory-bot/pull/300
 [#301]: https://github.com/ergebnis/factory-bot/pull/301
+[#302]: https://github.com/ergebnis/factory-bot/pull/302
 
 [@localheinz]: https://github.com/localheinz

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 MIN_COVERED_MSI:=99
-MIN_MSI:=98
+MIN_MSI:=99
 
 .PHONY: it
 it: coding-standards static-code-analysis tests ## Runs the coding-standards, static-code-analysis, and tests targets
@@ -15,6 +15,7 @@ coding-standards: vendor ## Normalizes composer.json with ergebnis/composer-norm
 	yamllint -c .yamllint.yaml --strict .
 	mkdir -p .build/php-cs-fixer
 	vendor/bin/php-cs-fixer fix --config=.php_cs --diff --diff-format=udiff --verbose
+	vendor/bin/php-cs-fixer fix --config=.php_cs.fixture --diff --diff-format=udiff --verbose
 
 .PHONY: dependency-analysis
 dependency-analysis: vendor ## Runs a dependency analysis with maglnet/composer-require-checker

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -197,17 +197,17 @@ parameters:
 
 		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\InvalidDefinition' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidDefinition will always evaluate to true\\.$#"
-			count: 2
+			count: 3
 			path: test/Unit/Exception/InvalidDefinitionTest.php
 
 		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'RuntimeException' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidDefinition will always evaluate to true\\.$#"
-			count: 2
+			count: 3
 			path: test/Unit/Exception/InvalidDefinitionTest.php
 
 		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Exception\\\\\\\\Exception' and Ergebnis\\\\FactoryBot\\\\Exception\\\\InvalidDefinition will always evaluate to true\\.$#"
-			count: 2
+			count: 3
 			path: test/Unit/Exception/InvalidDefinitionTest.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -109,11 +109,13 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="test/Unit/Exception/InvalidDefinitionTest.php">
-    <RedundantCondition occurrences="2">
+    <RedundantCondition occurrences="3">
+      <code>assertInstanceOf</code>
       <code>assertInstanceOf</code>
       <code>assertInstanceOf</code>
     </RedundantCondition>
-    <RedundantConditionGivenDocblockType occurrences="2">
+    <RedundantConditionGivenDocblockType occurrences="3">
+      <code>assertInstanceOf</code>
       <code>assertInstanceOf</code>
       <code>assertInstanceOf</code>
     </RedundantConditionGivenDocblockType>

--- a/src/Definitions.php
+++ b/src/Definitions.php
@@ -55,7 +55,7 @@ final class Definitions
             try {
                 $reflection = new \ReflectionClass($className);
             } catch (\ReflectionException $exception) {
-                continue;
+                throw Exception\InvalidDefinition::canNotBeAutoloaded($className);
             }
 
             if (!$reflection->implementsInterface(Definition::class)) {

--- a/src/Exception/InvalidDefinition.php
+++ b/src/Exception/InvalidDefinition.php
@@ -15,6 +15,14 @@ namespace Ergebnis\FactoryBot\Exception;
 
 final class InvalidDefinition extends \RuntimeException implements Exception
 {
+    public static function canNotBeAutoloaded(string $className): self
+    {
+        return new self(\sprintf(
+            'Definition "%s" can not be autoloaded.',
+            $className
+        ));
+    }
+
     public static function canNotBeInstantiated(string $className): self
     {
         return new self(\sprintf(

--- a/test/Fixture/Definitions/CanNotBeAutoloaded/OrganizationDefinition.php
+++ b/test/Fixture/Definitions/CanNotBeAutoloaded/OrganizationDefinition.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/factory-bot
+ */
+
+namespace Ergebnis\FactoryBot\Test\Fixture\Definitions\CanNotBeAutoloaded;
+
+use Ergebnis\FactoryBot\Definition;
+use Ergebnis\FactoryBot\FixtureFactory;
+use Ergebnis\FactoryBot\Test\Fixture;
+
+final class OrganizationDefinition implements Definition
+{
+    public function accept(FixtureFactory $fixtureFactory): void
+    {
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
+    }
+}

--- a/test/Fixture/Definitions/CanNotBeAutoloaded/RepositoryDefinition.php
+++ b/test/Fixture/Definitions/CanNotBeAutoloaded/RepositoryDefinition.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/factory-bot
+ */
+
+namespace Ergebnis\FactoryBot\Test\Fixture\Definitions\CanNotBeAutoloaded;
+
+use Ergebnis\FactoryBot\Definition;
+use Ergebnis\FactoryBot\FixtureFactory;
+use Ergebnis\FactoryBot\Test\Fixture;
+
+final class RepositoryDefinitionButCanNotBeAutoloaded implements Definition
+{
+    public function accept(FixtureFactory $fixtureFactory): void
+    {
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class);
+    }
+}

--- a/test/Fixture/Definitions/CanNotBeAutoloaded/UserDefinition.php
+++ b/test/Fixture/Definitions/CanNotBeAutoloaded/UserDefinition.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/factory-bot
+ */
+
+namespace Ergebnis\FactoryBot\Test\Fixture\Definitions\CanNotBeAutoloaded;
+
+use Ergebnis\FactoryBot\Definition;
+use Ergebnis\FactoryBot\FixtureFactory;
+use Ergebnis\FactoryBot\Test\Fixture;
+
+final class UserDefinition implements Definition
+{
+    public function accept(FixtureFactory $fixtureFactory): void
+    {
+        $fixtureFactory->define(Fixture\FixtureFactory\Entity\User::class);
+    }
+}

--- a/test/Unit/DefinitionsTest.php
+++ b/test/Unit/DefinitionsTest.php
@@ -40,7 +40,18 @@ final class DefinitionsTest extends AbstractTestCase
         Definitions::in(__DIR__ . '/../Fixture/Definitions/NonExistentDirectory');
     }
 
-    public function testInIgnoresClassesWhichDoNotImplementProviderInterface(): void
+    public function testInThrowsInvalidDefinitionExceptionWhenDefinitionCanNotBeAutoloaded(): void
+    {
+        $this->expectException(Exception\InvalidDefinition::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Definition "%s" can not be autoloaded.',
+            Fixture\Definitions\CanNotBeAutoloaded\RepositoryDefinitionButCanNotBeAutoloaded::class
+        ));
+
+        Definitions::in(__DIR__ . '/../Fixture/Definitions/CanNotBeAutoloaded');
+    }
+
+    public function testInIgnoresClassesWhichDoNotImplementDefinitionInterface(): void
     {
         $fixtureFactory = new FixtureFactory(
             self::entityManager(),

--- a/test/Unit/Exception/InvalidDefinitionTest.php
+++ b/test/Unit/Exception/InvalidDefinitionTest.php
@@ -26,6 +26,24 @@ final class InvalidDefinitionTest extends Framework\TestCase
 {
     use Helper;
 
+    public function testCanNotBeAutoloadedReturnsException(): void
+    {
+        $className = self::faker()->word;
+
+        $exception = Exception\InvalidDefinition::canNotBeAutoloaded($className);
+
+        self::assertInstanceOf(Exception\InvalidDefinition::class, $exception);
+        self::assertInstanceOf(\RuntimeException::class, $exception);
+        self::assertInstanceOf(Exception\Exception::class, $exception);
+
+        $message = \sprintf(
+            'Definition "%s" can not be autoloaded.',
+            $className
+        );
+
+        self::assertSame($message, $exception->getMessage());
+    }
+
     public function testCanNotBeInstantiatedReturnsException(): void
     {
         $className = self::faker()->word;


### PR DESCRIPTION
This PR

* [x] throws an `InvalidDefinition` exception when a potential definition can not be autoloaded