### PR TITLE
Fix: Split persistOnGet()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`0.1.0...main`][0.1.0...main].
 
 * Renamed `InvalidDefinition::fromClassNameAndException()` to `InvalidDefinition::throwsExceptionDuringInstantiation()` ([#300]), by [@localheinz]
 * Renamed `Number` to `Count` ([#309]), by [@localheinz]
+* Split `FixtureFactory::persistOnGet()` into `FixtureFactory::persistAfterCreate()` and `FixtureFactory::doNotPersistAfterCreate()` ([#311]), by [@localheinz]
 
 ### Fixed
 
@@ -148,5 +149,6 @@ For a full diff see [`fa9c564...0.1.0`][fa9c564...0.1.0].
 [#301]: https://github.com/ergebnis/factory-bot/pull/301
 [#302]: https://github.com/ergebnis/factory-bot/pull/302
 [#309]: https://github.com/ergebnis/factory-bot/pull/309
+[#311]: https://github.com/ergebnis/factory-bot/pull/311
 
 [@localheinz]: https://github.com/localheinz

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -42,7 +42,7 @@ final class FixtureFactory
     /**
      * @var bool
      */
-    private $persist = false;
+    private $persistAfterCreate = false;
 
     public function __construct(ORM\EntityManagerInterface $entityManager, Generator $faker)
     {
@@ -218,7 +218,7 @@ final class FixtureFactory
             $this->faker
         );
 
-        if ($this->persist && false === $classMetadata->isEmbeddedClass) {
+        if ($this->persistAfterCreate && false === $classMetadata->isEmbeddedClass) {
             $this->entityManager->persist($entity);
         }
 
@@ -261,15 +261,19 @@ final class FixtureFactory
     }
 
     /**
-     * Sets whether `get()` should automatically persist the entity it creates.
-     * By default it does not. In any case, you still need to call
-     * flush() yourself.
-     *
-     * @param bool $enabled
+     * Enable persisting of entities after creation.
      */
-    public function persistOnGet(bool $enabled = true): void
+    public function persistAfterCreate(): void
     {
-        $this->persist = $enabled;
+        $this->persistAfterCreate = true;
+    }
+
+    /**
+     * Disable persisting of entities after creation.
+     */
+    public function doNotPersistAfterCreate(): void
+    {
+        $this->persistAfterCreate = false;
     }
 
     /**

--- a/test/Integration/FixtureFactoryTest.php
+++ b/test/Integration/FixtureFactoryTest.php
@@ -59,7 +59,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         self::assertNull($organization);
     }
 
-    public function testCreateOnePersistsEntityWhenPersistOnGetHasBeenEnabled(): void
+    public function testCreateOnePersistsEntityWhenPersistAfterCreateHasBeenEnabled(): void
     {
         $entityManager = self::entityManager();
         $faker = self::faker();
@@ -75,7 +75,7 @@ final class FixtureFactoryTest extends AbstractTestCase
             'name' => $name,
         ]);
 
-        $fixtureFactory->persistOnGet();
+        $fixtureFactory->persistAfterCreate();
 
         $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class);
 
@@ -89,7 +89,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         self::assertInstanceOf(Fixture\FixtureFactory\Entity\Organization::class, $organization);
     }
 
-    public function testCreateOneDoesNotPersistEntityWhenPersistOnGetHasBeenDisabled(): void
+    public function testCreateOneDoesNotPersistEntityWhenPersistAfterCreateHasBeenDisabled(): void
     {
         $entityManager = self::entityManager();
         $faker = self::faker();
@@ -105,8 +105,8 @@ final class FixtureFactoryTest extends AbstractTestCase
             'name' => $name,
         ]);
 
-        $fixtureFactory->persistOnGet();
-        $fixtureFactory->persistOnGet(false);
+        $fixtureFactory->persistAfterCreate();
+        $fixtureFactory->doNotPersistAfterCreate();
 
         $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class);
 
@@ -120,7 +120,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         self::assertNull($organization);
     }
 
-    public function testCreateOneDoesNotPersistEmbeddablesWhenPersistOnGetHasBeenEnabled(): void
+    public function testCreateOneDoesNotPersistEmbeddablesWhenPersistAfterCreateHasBeenEnabled(): void
     {
         $entityManager = self::entityManager();
         $faker = self::faker();
@@ -141,7 +141,7 @@ final class FixtureFactoryTest extends AbstractTestCase
             'login' => $faker->userName,
         ]);
 
-        $fixtureFactory->persistOnGet();
+        $fixtureFactory->persistAfterCreate();
 
         $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\User::class);
 
@@ -176,7 +176,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         self::assertEmpty($organizations);
     }
 
-    public function testCreateManyPersistsEntitiesWhenPersistOnGetHasBeenEnabled(): void
+    public function testCreateManyPersistsEntitiesWhenPersistAfterCreateHasBeenEnabled(): void
     {
         $entityManager = self::entityManager();
         $faker = self::faker();
@@ -190,7 +190,7 @@ final class FixtureFactoryTest extends AbstractTestCase
             'name' => FieldDefinition::sequence('name-%d'),
         ]);
 
-        $fixtureFactory->persistOnGet();
+        $fixtureFactory->persistAfterCreate();
 
         $value = $faker->numberBetween(1, 5);
 
@@ -207,7 +207,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         self::assertCount($value, $organizations);
     }
 
-    public function testCreateManyDoesNotPersistEntitiesWhenPersistOnGetHasBeenDisabled(): void
+    public function testCreateManyDoesNotPersistEntitiesWhenPersistAfterCreateHasBeenDisabled(): void
     {
         $entityManager = self::entityManager();
         $faker = self::faker();
@@ -221,8 +221,8 @@ final class FixtureFactoryTest extends AbstractTestCase
             'name' => FieldDefinition::sequence('name-%d'),
         ]);
 
-        $fixtureFactory->persistOnGet();
-        $fixtureFactory->persistOnGet(false);
+        $fixtureFactory->persistAfterCreate();
+        $fixtureFactory->doNotPersistAfterCreate();
 
         $value = $faker->numberBetween(1, 5);
 


### PR DESCRIPTION
This PR

* [x] splits `FixtureFactory::persistOnGet()` into  `FixtureFactory::persistAfterCreate()` and `FixtureFactory::doNotPersistAfterCreate()`