### PR TITLE
Fix: Add missing covers annotation

### DIFF
--- a/test/Integration/FixtureFactoryTest.php
+++ b/test/Integration/FixtureFactoryTest.php
@@ -23,10 +23,12 @@ use Ergebnis\FactoryBot\Test\Fixture;
  *
  * @covers \Ergebnis\FactoryBot\FixtureFactory
  *
+ * @uses \Ergebnis\FactoryBot\Count
  * @uses \Ergebnis\FactoryBot\EntityDefinition
  * @uses \Ergebnis\FactoryBot\FieldDefinition
- * @uses \Ergebnis\FactoryBot\FieldDefinition\Reference
  * @uses \Ergebnis\FactoryBot\FieldDefinition\Closure
+ * @uses \Ergebnis\FactoryBot\FieldDefinition\Reference
+ * @uses \Ergebnis\FactoryBot\FieldDefinition\Sequence
  * @uses \Ergebnis\FactoryBot\FieldDefinition\Value
  */
 final class FixtureFactoryTest extends AbstractTestCase


### PR DESCRIPTION
This PR

* [x] adds missing `@covers` annotations

Follows #310.