### PR TITLE
Fix: Move perfectly valid examples into examples directory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 /.github/               export-ignore
 /config/                export-ignore
+/example/               export-ignore
 /test/                  export-ignore
 /tools/                 export-ignore
 /.editorconfig          export-ignore

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,9 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "Ergebnis\\FactoryBot\\Test\\": "test/"
+      "Ergebnis\\FactoryBot\\Test\\": "test/",
+      "Example\\": "example/src/",
+      "Example\\Test\\": "example/test/"
     }
   },
   "support": {

--- a/example/src/Entity/Avatar.php
+++ b/example/src/Entity/Avatar.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Fixture\FixtureFactory\Entity;
+namespace Example\Entity;
 
 use Doctrine\ORM;
 

--- a/example/src/Entity/CodeOfConduct.php
+++ b/example/src/Entity/CodeOfConduct.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Fixture\FixtureFactory\Entity;
+namespace Example\Entity;
 
 use Doctrine\ORM;
 

--- a/example/src/Entity/Organization.php
+++ b/example/src/Entity/Organization.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Fixture\FixtureFactory\Entity;
+namespace Example\Entity;
 
 use Doctrine\Common;
 use Doctrine\ORM;
@@ -53,7 +53,7 @@ class Organization
 
     /**
      * @ORM\Mapping\OneToMany(
-     *     targetEntity="Ergebnis\FactoryBot\Test\Fixture\FixtureFactory\Entity\Repository",
+     *     targetEntity="Example\Entity\Repository",
      *     mappedBy="organization"
      * )
      *
@@ -63,7 +63,7 @@ class Organization
 
     /**
      * @ORM\Mapping\ManyToMany(
-     *     targetEntity="Ergebnis\FactoryBot\Test\Fixture\FixtureFactory\Entity\User",
+     *     targetEntity="Example\Entity\User",
      *     inversedBy="organizations"
      * )
      *

--- a/example/src/Entity/Project.php
+++ b/example/src/Entity/Project.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Fixture\FixtureFactory\Entity;
+namespace Example\Entity;
 
 use Doctrine\ORM;
 
@@ -41,7 +41,7 @@ class Project
     private $name;
 
     /**
-     * @ORM\Mapping\ManyToOne(targetEntity="Ergebnis\FactoryBot\Test\Fixture\FixtureFactory\Entity\Repository")
+     * @ORM\Mapping\ManyToOne(targetEntity="Example\Entity\Repository")
      * @ORM\Mapping\JoinColumn(
      *     name="repository_id",
      *     referencedColumnName="id",

--- a/example/src/Entity/Repository.php
+++ b/example/src/Entity/Repository.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Fixture\FixtureFactory\Entity;
+namespace Example\Entity;
 
 use Doctrine\ORM;
 
@@ -45,7 +45,7 @@ class Repository
 
     /**
      * @ORM\Mapping\ManyToOne(
-     *     targetEntity="Ergebnis\FactoryBot\Test\Fixture\FixtureFactory\Entity\Organization",
+     *     targetEntity="Example\Entity\Organization",
      *     inversedBy="repositories"
      * )
      * @ORM\Mapping\JoinColumn(
@@ -59,7 +59,7 @@ class Repository
     private $organization;
 
     /**
-     * @ORM\Mapping\ManyToOne(targetEntity="Ergebnis\FactoryBot\Test\Fixture\FixtureFactory\Entity\Repository")
+     * @ORM\Mapping\ManyToOne(targetEntity="Example\Entity\Repository")
      * @ORM\Mapping\JoinColumn(
      *     name="template_id",
      *     referencedColumnName="id"
@@ -70,7 +70,7 @@ class Repository
     private $template;
 
     /**
-     * @ORM\Mapping\ManyToOne(targetEntity="Ergebnis\FactoryBot\Test\Fixture\FixtureFactory\Entity\CodeOfConduct")
+     * @ORM\Mapping\ManyToOne(targetEntity="Example\Entity\CodeOfConduct")
      * @ORM\Mapping\JoinColumn(
      *     name="code_of_conduct_key",
      *     referencedColumnName="key"

--- a/example/src/Entity/User.php
+++ b/example/src/Entity/User.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Fixture\FixtureFactory\Entity;
+namespace Example\Entity;
 
 use Doctrine\Common;
 use Doctrine\ORM;
@@ -57,7 +57,7 @@ class User
 
     /**
      * @ORM\Mapping\Embedded(
-     *     class="Ergebnis\FactoryBot\Test\Fixture\FixtureFactory\Entity\Avatar",
+     *     class="Example\Entity\Avatar",
      *     columnPrefix="avatar"
      * )
      *
@@ -67,7 +67,7 @@ class User
 
     /**
      * @ORM\Mapping\ManyToMany(
-     *     targetEntity="Ergebnis\FactoryBot\Test\Fixture\FixtureFactory\Entity\Organization",
+     *     targetEntity="Example\Entity\Organization",
      *     mappedBy="members"
      * )
      *

--- a/example/test/Fixture/Entity/OrganizationDefinitionProvider.php
+++ b/example/test/Fixture/Entity/OrganizationDefinitionProvider.php
@@ -11,16 +11,16 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Fixture\DefinitionProvider\ImplementsDefinitionProvider;
+namespace Example\Test\Fixture\Entity;
 
 use Ergebnis\FactoryBot\EntityDefinitionProvider;
 use Ergebnis\FactoryBot\FixtureFactory;
-use Ergebnis\FactoryBot\Test\Fixture;
+use Example\Entity;
 
-final class UserDefinitionProvider implements EntityDefinitionProvider
+final class OrganizationDefinitionProvider implements EntityDefinitionProvider
 {
     public function accept(FixtureFactory $fixtureFactory): void
     {
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\User::class);
+        $fixtureFactory->define(Entity\Organization::class);
     }
 }

--- a/example/test/Fixture/Entity/RepositoryDefinitionProvider.php
+++ b/example/test/Fixture/Entity/RepositoryDefinitionProvider.php
@@ -11,16 +11,16 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Fixture\DefinitionProvider\ImplementsDefinitionProvider;
+namespace Example\Test\Fixture\Entity;
 
 use Ergebnis\FactoryBot\EntityDefinitionProvider;
 use Ergebnis\FactoryBot\FixtureFactory;
-use Ergebnis\FactoryBot\Test\Fixture;
+use Example\Entity;
 
-final class OrganizationDefinitionProvider implements EntityDefinitionProvider
+final class RepositoryDefinitionProvider implements EntityDefinitionProvider
 {
     public function accept(FixtureFactory $fixtureFactory): void
     {
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
+        $fixtureFactory->define(Entity\Repository::class);
     }
 }

--- a/example/test/Fixture/Entity/UserDefinitionProvider.php
+++ b/example/test/Fixture/Entity/UserDefinitionProvider.php
@@ -11,16 +11,16 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/factory-bot
  */
 
-namespace Ergebnis\FactoryBot\Test\Fixture\DefinitionProvider\ImplementsDefinitionProvider;
+namespace Example\Test\Fixture\Entity;
 
 use Ergebnis\FactoryBot\EntityDefinitionProvider;
 use Ergebnis\FactoryBot\FixtureFactory;
-use Ergebnis\FactoryBot\Test\Fixture;
+use Example\Entity;
 
-final class RepositoryDefinitionProvider implements EntityDefinitionProvider
+final class UserDefinitionProvider implements EntityDefinitionProvider
 {
     public function accept(FixtureFactory $fixtureFactory): void
     {
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class);
+        $fixtureFactory->define(Entity\User::class);
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,91 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Method Example\\\\Entity\\\\Organization\\:\\:id\\(\\) has a nullable return type declaration\\.$#"
+			count: 1
+			path: example/src/Entity/Organization.php
+
+		-
+			message: "#^Method Example\\\\Entity\\\\Organization\\:\\:name\\(\\) has a nullable return type declaration\\.$#"
+			count: 1
+			path: example/src/Entity/Organization.php
+
+		-
+			message: "#^Method Example\\\\Entity\\\\Project\\:\\:id\\(\\) has a nullable return type declaration\\.$#"
+			count: 1
+			path: example/src/Entity/Project.php
+
+		-
+			message: "#^Constructor in Example\\\\Entity\\\\Repository has parameter \\$codeOfConduct with default value\\.$#"
+			count: 1
+			path: example/src/Entity/Repository.php
+
+		-
+			message: "#^Constructor in Example\\\\Entity\\\\Repository has parameter \\$template with default value\\.$#"
+			count: 1
+			path: example/src/Entity/Repository.php
+
+		-
+			message: "#^Method Example\\\\Entity\\\\Repository\\:\\:__construct\\(\\) has parameter \\$codeOfConduct with a nullable type declaration\\.$#"
+			count: 1
+			path: example/src/Entity/Repository.php
+
+		-
+			message: "#^Method Example\\\\Entity\\\\Repository\\:\\:__construct\\(\\) has parameter \\$codeOfConduct with null as default value\\.$#"
+			count: 1
+			path: example/src/Entity/Repository.php
+
+		-
+			message: "#^Method Example\\\\Entity\\\\Repository\\:\\:__construct\\(\\) has parameter \\$template with a nullable type declaration\\.$#"
+			count: 1
+			path: example/src/Entity/Repository.php
+
+		-
+			message: "#^Method Example\\\\Entity\\\\Repository\\:\\:__construct\\(\\) has parameter \\$template with null as default value\\.$#"
+			count: 1
+			path: example/src/Entity/Repository.php
+
+		-
+			message: "#^Method Example\\\\Entity\\\\Repository\\:\\:id\\(\\) has a nullable return type declaration\\.$#"
+			count: 1
+			path: example/src/Entity/Repository.php
+
+		-
+			message: "#^Method Example\\\\Entity\\\\Repository\\:\\:template\\(\\) has a nullable return type declaration\\.$#"
+			count: 1
+			path: example/src/Entity/Repository.php
+
+		-
+			message: "#^Method Example\\\\Entity\\\\Repository\\:\\:codeOfConduct\\(\\) has a nullable return type declaration\\.$#"
+			count: 1
+			path: example/src/Entity/Repository.php
+
+		-
+			message: "#^Constructor in Example\\\\Entity\\\\User has parameter \\$location with default value\\.$#"
+			count: 1
+			path: example/src/Entity/User.php
+
+		-
+			message: "#^Method Example\\\\Entity\\\\User\\:\\:__construct\\(\\) has parameter \\$location with a nullable type declaration\\.$#"
+			count: 1
+			path: example/src/Entity/User.php
+
+		-
+			message: "#^Method Example\\\\Entity\\\\User\\:\\:__construct\\(\\) has parameter \\$location with null as default value\\.$#"
+			count: 1
+			path: example/src/Entity/User.php
+
+		-
+			message: "#^Method Example\\\\Entity\\\\User\\:\\:id\\(\\) has a nullable return type declaration\\.$#"
+			count: 1
+			path: example/src/Entity/User.php
+
+		-
+			message: "#^Method Example\\\\Entity\\\\User\\:\\:location\\(\\) has a nullable return type declaration\\.$#"
+			count: 1
+			path: example/src/Entity/User.php
+
+		-
 			message: "#^Instanceof between Ergebnis\\\\FactoryBot\\\\FieldDefinition\\\\Resolvable and Ergebnis\\\\FactoryBot\\\\FieldDefinition\\\\Resolvable will always evaluate to true\\.$#"
 			count: 1
 			path: src/EntityDefinition.php
@@ -49,91 +134,6 @@ parameters:
 			message: "#^Method Ergebnis\\\\FactoryBot\\\\Test\\\\Double\\\\Faker\\\\TrueGenerator\\:\\:numberBetween\\(\\) has parameter \\$min with no typehint specified\\.$#"
 			count: 1
 			path: test/Double/Faker/TrueGenerator.php
-
-		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\Organization\\:\\:id\\(\\) has a nullable return type declaration\\.$#"
-			count: 1
-			path: test/Fixture/FixtureFactory/Entity/Organization.php
-
-		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\Organization\\:\\:name\\(\\) has a nullable return type declaration\\.$#"
-			count: 1
-			path: test/Fixture/FixtureFactory/Entity/Organization.php
-
-		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\Project\\:\\:id\\(\\) has a nullable return type declaration\\.$#"
-			count: 1
-			path: test/Fixture/FixtureFactory/Entity/Project.php
-
-		-
-			message: "#^Constructor in Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\Repository has parameter \\$codeOfConduct with default value\\.$#"
-			count: 1
-			path: test/Fixture/FixtureFactory/Entity/Repository.php
-
-		-
-			message: "#^Constructor in Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\Repository has parameter \\$template with default value\\.$#"
-			count: 1
-			path: test/Fixture/FixtureFactory/Entity/Repository.php
-
-		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\Repository\\:\\:__construct\\(\\) has parameter \\$codeOfConduct with a nullable type declaration\\.$#"
-			count: 1
-			path: test/Fixture/FixtureFactory/Entity/Repository.php
-
-		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\Repository\\:\\:__construct\\(\\) has parameter \\$codeOfConduct with null as default value\\.$#"
-			count: 1
-			path: test/Fixture/FixtureFactory/Entity/Repository.php
-
-		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\Repository\\:\\:__construct\\(\\) has parameter \\$template with a nullable type declaration\\.$#"
-			count: 1
-			path: test/Fixture/FixtureFactory/Entity/Repository.php
-
-		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\Repository\\:\\:__construct\\(\\) has parameter \\$template with null as default value\\.$#"
-			count: 1
-			path: test/Fixture/FixtureFactory/Entity/Repository.php
-
-		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\Repository\\:\\:id\\(\\) has a nullable return type declaration\\.$#"
-			count: 1
-			path: test/Fixture/FixtureFactory/Entity/Repository.php
-
-		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\Repository\\:\\:template\\(\\) has a nullable return type declaration\\.$#"
-			count: 1
-			path: test/Fixture/FixtureFactory/Entity/Repository.php
-
-		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\Repository\\:\\:codeOfConduct\\(\\) has a nullable return type declaration\\.$#"
-			count: 1
-			path: test/Fixture/FixtureFactory/Entity/Repository.php
-
-		-
-			message: "#^Constructor in Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\User has parameter \\$location with default value\\.$#"
-			count: 1
-			path: test/Fixture/FixtureFactory/Entity/User.php
-
-		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\User\\:\\:__construct\\(\\) has parameter \\$location with a nullable type declaration\\.$#"
-			count: 1
-			path: test/Fixture/FixtureFactory/Entity/User.php
-
-		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\User\\:\\:__construct\\(\\) has parameter \\$location with null as default value\\.$#"
-			count: 1
-			path: test/Fixture/FixtureFactory/Entity/User.php
-
-		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\User\\:\\:id\\(\\) has a nullable return type declaration\\.$#"
-			count: 1
-			path: test/Fixture/FixtureFactory/Entity/User.php
-
-		-
-			message: "#^Method Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\User\\:\\:location\\(\\) has a nullable return type declaration\\.$#"
-			count: 1
-			path: test/Fixture/FixtureFactory/Entity/User.php
 
 		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Count' and Ergebnis\\\\FactoryBot\\\\Count will always evaluate to true\\.$#"
@@ -321,12 +321,12 @@ parameters:
 			path: test/Unit/Exception/InvalidSequenceTest.php
 
 		-
-			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Test\\\\\\\\Fixture\\\\\\\\FixtureFactory\\\\\\\\Entity\\\\\\\\User' and Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\User will always evaluate to true\\.$#"
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Example\\\\\\\\Entity\\\\\\\\User' and Example\\\\Entity\\\\User will always evaluate to true\\.$#"
 			count: 1
 			path: test/Unit/FieldDefinition/ReferenceTest.php
 
 		-
-			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertIsArray\\(\\) with array\\<int, Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\User\\> will always evaluate to true\\.$#"
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertIsArray\\(\\) with array\\<int, Example\\\\Entity\\\\User\\> will always evaluate to true\\.$#"
 			count: 1
 			path: test/Unit/FieldDefinition/ReferencesTest.php
 
@@ -336,27 +336,27 @@ parameters:
 			path: test/Unit/FixtureFactoryTest.php
 
 		-
-			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Test\\\\\\\\Fixture\\\\\\\\FixtureFactory\\\\\\\\Entity\\\\\\\\Organization' and Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\Organization will always evaluate to true\\.$#"
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Example\\\\\\\\Entity\\\\\\\\Organization' and Example\\\\Entity\\\\Organization will always evaluate to true\\.$#"
 			count: 2
 			path: test/Unit/FixtureFactoryTest.php
 
 		-
-			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Test\\\\\\\\Fixture\\\\\\\\FixtureFactory\\\\\\\\Entity\\\\\\\\Repository' and Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\Repository will always evaluate to true\\.$#"
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Example\\\\\\\\Entity\\\\\\\\Repository' and Example\\\\Entity\\\\Repository will always evaluate to true\\.$#"
 			count: 2
 			path: test/Unit/FixtureFactoryTest.php
 
 		-
-			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Test\\\\\\\\Fixture\\\\\\\\FixtureFactory\\\\\\\\Entity\\\\\\\\User' and Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\User will always evaluate to true\\.$#"
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Example\\\\\\\\Entity\\\\\\\\User' and Example\\\\Entity\\\\User will always evaluate to true\\.$#"
 			count: 2
 			path: test/Unit/FixtureFactoryTest.php
 
 		-
-			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNotNull\\(\\) with Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\Organization will always evaluate to true\\.$#"
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNotNull\\(\\) with Example\\\\Entity\\\\Organization will always evaluate to true\\.$#"
 			count: 2
 			path: test/Unit/FixtureFactoryTest.php
 
 		-
-			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Ergebnis\\\\\\\\FactoryBot\\\\\\\\Test\\\\\\\\Fixture\\\\\\\\FixtureFactory\\\\\\\\Entity\\\\\\\\Project' and Ergebnis\\\\FactoryBot\\\\Test\\\\Fixture\\\\FixtureFactory\\\\Entity\\\\Project will always evaluate to true\\.$#"
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Example\\\\\\\\Entity\\\\\\\\Project' and Example\\\\Entity\\\\Project will always evaluate to true\\.$#"
 			count: 1
 			path: test/Unit/FixtureFactoryTest.php
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,6 +16,7 @@ parameters:
 	inferPrivatePropertyTypeFromConstructor: true
 	level: max
 	paths:
+		- example/
 		- src/
 		- test/
 	tmpDir: .build/phpstan/

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="3.12.2@7c7ebd068f8acaba211d4a2c707c4ba90874fa26">
+  <file src="example/src/Entity/Organization.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$id</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="example/src/Entity/Project.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$id</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="example/src/Entity/Repository.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$id</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="example/src/Entity/User.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$id</code>
+    </PropertyNotSetInConstructor>
+  </file>
   <file src="src/EntityDefinition.php">
     <DocblockTypeContradiction occurrences="1">
       <code>return !$fieldDefinition instanceof FieldDefinition\Resolvable;</code>
@@ -42,26 +62,6 @@
       <code>$min</code>
       <code>$max</code>
     </MixedArgument>
-  </file>
-  <file src="test/Fixture/FixtureFactory/Entity/Organization.php">
-    <PropertyNotSetInConstructor occurrences="1">
-      <code>$id</code>
-    </PropertyNotSetInConstructor>
-  </file>
-  <file src="test/Fixture/FixtureFactory/Entity/Project.php">
-    <PropertyNotSetInConstructor occurrences="1">
-      <code>$id</code>
-    </PropertyNotSetInConstructor>
-  </file>
-  <file src="test/Fixture/FixtureFactory/Entity/Repository.php">
-    <PropertyNotSetInConstructor occurrences="1">
-      <code>$id</code>
-    </PropertyNotSetInConstructor>
-  </file>
-  <file src="test/Fixture/FixtureFactory/Entity/User.php">
-    <PropertyNotSetInConstructor occurrences="1">
-      <code>$id</code>
-    </PropertyNotSetInConstructor>
   </file>
   <file src="test/Integration/FixtureFactoryTest.php">
     <InternalMethod occurrences="1">

--- a/psalm.xml
+++ b/psalm.xml
@@ -17,6 +17,7 @@
     </plugins>
 
     <projectFiles>
+        <directory name="example/" />
         <directory name="src/" />
         <directory name="test/" />
         <ignoreFiles>

--- a/test/Fixture/DefinitionProvider/CanNotBeAutoloaded/OrganizationDefinitionProvider.php
+++ b/test/Fixture/DefinitionProvider/CanNotBeAutoloaded/OrganizationDefinitionProvider.php
@@ -15,12 +15,12 @@ namespace Ergebnis\FactoryBot\Test\Fixture\DefinitionProvider\CanNotBeAutoloaded
 
 use Ergebnis\FactoryBot\EntityDefinitionProvider;
 use Ergebnis\FactoryBot\FixtureFactory;
-use Ergebnis\FactoryBot\Test\Fixture;
+use Example\Entity;
 
 final class OrganizationDefinitionProvider implements EntityDefinitionProvider
 {
     public function accept(FixtureFactory $fixtureFactory): void
     {
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
+        $fixtureFactory->define(Entity\Organization::class);
     }
 }

--- a/test/Fixture/DefinitionProvider/CanNotBeAutoloaded/RepositoryDefinitionProvider.php
+++ b/test/Fixture/DefinitionProvider/CanNotBeAutoloaded/RepositoryDefinitionProvider.php
@@ -15,12 +15,12 @@ namespace Ergebnis\FactoryBot\Test\Fixture\DefinitionProvider\CanNotBeAutoloaded
 
 use Ergebnis\FactoryBot\EntityDefinitionProvider;
 use Ergebnis\FactoryBot\FixtureFactory;
-use Ergebnis\FactoryBot\Test\Fixture;
+use Example\Entity;
 
 final class RepositoryDefinitionProviderButCanNotBeAutoloaded implements EntityDefinitionProvider
 {
     public function accept(FixtureFactory $fixtureFactory): void
     {
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class);
+        $fixtureFactory->define(Entity\Repository::class);
     }
 }

--- a/test/Fixture/DefinitionProvider/CanNotBeAutoloaded/UserDefinitionProvider.php
+++ b/test/Fixture/DefinitionProvider/CanNotBeAutoloaded/UserDefinitionProvider.php
@@ -15,12 +15,12 @@ namespace Ergebnis\FactoryBot\Test\Fixture\DefinitionProvider\CanNotBeAutoloaded
 
 use Ergebnis\FactoryBot\EntityDefinitionProvider;
 use Ergebnis\FactoryBot\FixtureFactory;
-use Ergebnis\FactoryBot\Test\Fixture;
+use Example\Entity;
 
 final class UserDefinitionProvider implements EntityDefinitionProvider
 {
     public function accept(FixtureFactory $fixtureFactory): void
     {
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\User::class);
+        $fixtureFactory->define(Entity\User::class);
     }
 }

--- a/test/Fixture/DefinitionProvider/DoesNotImplementDefinitionProvider/OrganizationDefinitionProvider.php
+++ b/test/Fixture/DefinitionProvider/DoesNotImplementDefinitionProvider/OrganizationDefinitionProvider.php
@@ -15,12 +15,12 @@ namespace Ergebnis\FactoryBot\Test\Fixture\DefinitionProvider\DoesNotImplementDe
 
 use Ergebnis\FactoryBot\EntityDefinitionProvider;
 use Ergebnis\FactoryBot\FixtureFactory;
-use Ergebnis\FactoryBot\Test\Fixture;
+use Example\Entity;
 
 final class OrganizationDefinitionProvider implements EntityDefinitionProvider
 {
     public function accept(FixtureFactory $fixtureFactory): void
     {
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
+        $fixtureFactory->define(Entity\Organization::class);
     }
 }

--- a/test/Fixture/DefinitionProvider/DoesNotImplementDefinitionProvider/RepositoryDefinition.php
+++ b/test/Fixture/DefinitionProvider/DoesNotImplementDefinitionProvider/RepositoryDefinition.php
@@ -14,12 +14,12 @@ declare(strict_types=1);
 namespace Ergebnis\FactoryBot\Test\Fixture\DefinitionProvider\DoesNotImplementDefinitionProvider;
 
 use Ergebnis\FactoryBot\FixtureFactory;
-use Ergebnis\FactoryBot\Test\Fixture;
+use Example\Entity;
 
 final class RepositoryDefinition
 {
     public function accept(FixtureFactory $fixtureFactory): void
     {
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class);
+        $fixtureFactory->define(Entity\Repository::class);
     }
 }

--- a/test/Fixture/DefinitionProvider/DoesNotImplementDefinitionProvider/UserDefinitionProvider.php
+++ b/test/Fixture/DefinitionProvider/DoesNotImplementDefinitionProvider/UserDefinitionProvider.php
@@ -15,12 +15,12 @@ namespace Ergebnis\FactoryBot\Test\Fixture\DefinitionProvider\DoesNotImplementDe
 
 use Ergebnis\FactoryBot\EntityDefinitionProvider;
 use Ergebnis\FactoryBot\FixtureFactory;
-use Ergebnis\FactoryBot\Test\Fixture;
+use Example\Entity;
 
 final class UserDefinitionProvider implements EntityDefinitionProvider
 {
     public function accept(FixtureFactory $fixtureFactory): void
     {
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\User::class);
+        $fixtureFactory->define(Entity\User::class);
     }
 }

--- a/test/Fixture/DefinitionProvider/ImplementsDefinitionProviderButCanNotBeInstantiated/OrganizationDefinitionProvider.php
+++ b/test/Fixture/DefinitionProvider/ImplementsDefinitionProviderButCanNotBeInstantiated/OrganizationDefinitionProvider.php
@@ -15,12 +15,12 @@ namespace Ergebnis\FactoryBot\Test\Fixture\DefinitionProvider\ImplementsDefiniti
 
 use Ergebnis\FactoryBot\EntityDefinitionProvider;
 use Ergebnis\FactoryBot\FixtureFactory;
-use Ergebnis\FactoryBot\Test\Fixture;
+use Example\Entity;
 
 final class OrganizationDefinitionProvider implements EntityDefinitionProvider
 {
     public function accept(FixtureFactory $fixtureFactory): void
     {
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
+        $fixtureFactory->define(Entity\Organization::class);
     }
 }

--- a/test/Fixture/DefinitionProvider/ImplementsDefinitionProviderButCanNotBeInstantiated/RepositoryDefinitionProvider.php
+++ b/test/Fixture/DefinitionProvider/ImplementsDefinitionProviderButCanNotBeInstantiated/RepositoryDefinitionProvider.php
@@ -15,7 +15,7 @@ namespace Ergebnis\FactoryBot\Test\Fixture\DefinitionProvider\ImplementsDefiniti
 
 use Ergebnis\FactoryBot\EntityDefinitionProvider;
 use Ergebnis\FactoryBot\FixtureFactory;
-use Ergebnis\FactoryBot\Test\Fixture;
+use Example\Entity;
 
 final class RepositoryDefinitionProvider implements EntityDefinitionProvider
 {
@@ -25,6 +25,6 @@ final class RepositoryDefinitionProvider implements EntityDefinitionProvider
 
     public function accept(FixtureFactory $fixtureFactory): void
     {
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class);
+        $fixtureFactory->define(Entity\Repository::class);
     }
 }

--- a/test/Fixture/DefinitionProvider/ImplementsDefinitionProviderButCanNotBeInstantiated/UserDefinitionProvider.php
+++ b/test/Fixture/DefinitionProvider/ImplementsDefinitionProviderButCanNotBeInstantiated/UserDefinitionProvider.php
@@ -15,12 +15,12 @@ namespace Ergebnis\FactoryBot\Test\Fixture\DefinitionProvider\ImplementsDefiniti
 
 use Ergebnis\FactoryBot\EntityDefinitionProvider;
 use Ergebnis\FactoryBot\FixtureFactory;
-use Ergebnis\FactoryBot\Test\Fixture;
+use Example\Entity;
 
 final class UserDefinitionProvider implements EntityDefinitionProvider
 {
     public function accept(FixtureFactory $fixtureFactory): void
     {
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\User::class);
+        $fixtureFactory->define(Entity\User::class);
     }
 }

--- a/test/Fixture/DefinitionProvider/ImplementsDefinitionProviderButIsAbstract/OrganizationDefinitionProvider.php
+++ b/test/Fixture/DefinitionProvider/ImplementsDefinitionProviderButIsAbstract/OrganizationDefinitionProvider.php
@@ -15,12 +15,12 @@ namespace Ergebnis\FactoryBot\Test\Fixture\DefinitionProvider\ImplementsDefiniti
 
 use Ergebnis\FactoryBot\EntityDefinitionProvider;
 use Ergebnis\FactoryBot\FixtureFactory;
-use Ergebnis\FactoryBot\Test\Fixture;
+use Example\Entity;
 
 final class OrganizationDefinitionProvider implements EntityDefinitionProvider
 {
     public function accept(FixtureFactory $fixtureFactory): void
     {
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
+        $fixtureFactory->define(Entity\Organization::class);
     }
 }

--- a/test/Fixture/DefinitionProvider/ImplementsDefinitionProviderButIsAbstract/RepositoryDefinitionProvider.php
+++ b/test/Fixture/DefinitionProvider/ImplementsDefinitionProviderButIsAbstract/RepositoryDefinitionProvider.php
@@ -15,12 +15,12 @@ namespace Ergebnis\FactoryBot\Test\Fixture\DefinitionProvider\ImplementsDefiniti
 
 use Ergebnis\FactoryBot\EntityDefinitionProvider;
 use Ergebnis\FactoryBot\FixtureFactory;
-use Ergebnis\FactoryBot\Test\Fixture;
+use Example\Entity;
 
 abstract class RepositoryDefinitionProvider implements EntityDefinitionProvider
 {
     final public function accept(FixtureFactory $fixtureFactory): void
     {
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class);
+        $fixtureFactory->define(Entity\Repository::class);
     }
 }

--- a/test/Fixture/DefinitionProvider/ImplementsDefinitionProviderButIsAbstract/UserDefinitionProvider.php
+++ b/test/Fixture/DefinitionProvider/ImplementsDefinitionProviderButIsAbstract/UserDefinitionProvider.php
@@ -15,12 +15,12 @@ namespace Ergebnis\FactoryBot\Test\Fixture\DefinitionProvider\ImplementsDefiniti
 
 use Ergebnis\FactoryBot\EntityDefinitionProvider;
 use Ergebnis\FactoryBot\FixtureFactory;
-use Ergebnis\FactoryBot\Test\Fixture;
+use Example\Entity;
 
 final class UserDefinitionProvider implements EntityDefinitionProvider
 {
     public function accept(FixtureFactory $fixtureFactory): void
     {
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\User::class);
+        $fixtureFactory->define(Entity\User::class);
     }
 }

--- a/test/Fixture/DefinitionProvider/ImplementsDefinitionProviderButThrowsExceptionDuringInstantiation/OrganizationDefinitionProvider.php
+++ b/test/Fixture/DefinitionProvider/ImplementsDefinitionProviderButThrowsExceptionDuringInstantiation/OrganizationDefinitionProvider.php
@@ -15,12 +15,12 @@ namespace Ergebnis\FactoryBot\Test\Fixture\DefinitionProvider\ImplementsDefiniti
 
 use Ergebnis\FactoryBot\EntityDefinitionProvider;
 use Ergebnis\FactoryBot\FixtureFactory;
-use Ergebnis\FactoryBot\Test\Fixture;
+use Example\Entity;
 
 final class OrganizationDefinitionProvider implements EntityDefinitionProvider
 {
     public function accept(FixtureFactory $fixtureFactory): void
     {
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
+        $fixtureFactory->define(Entity\Organization::class);
     }
 }

--- a/test/Fixture/DefinitionProvider/ImplementsDefinitionProviderButThrowsExceptionDuringInstantiation/RepositoryDefinitionProvider.php
+++ b/test/Fixture/DefinitionProvider/ImplementsDefinitionProviderButThrowsExceptionDuringInstantiation/RepositoryDefinitionProvider.php
@@ -15,7 +15,7 @@ namespace Ergebnis\FactoryBot\Test\Fixture\DefinitionProvider\ImplementsDefiniti
 
 use Ergebnis\FactoryBot\EntityDefinitionProvider;
 use Ergebnis\FactoryBot\FixtureFactory;
-use Ergebnis\FactoryBot\Test\Fixture;
+use Example\Entity;
 
 final class RepositoryDefinitionProvider implements EntityDefinitionProvider
 {
@@ -26,6 +26,6 @@ final class RepositoryDefinitionProvider implements EntityDefinitionProvider
 
     public function accept(FixtureFactory $fixtureFactory): void
     {
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class);
+        $fixtureFactory->define(Entity\Repository::class);
     }
 }

--- a/test/Fixture/DefinitionProvider/ImplementsDefinitionProviderButThrowsExceptionDuringInstantiation/UserDefinitionProvider.php
+++ b/test/Fixture/DefinitionProvider/ImplementsDefinitionProviderButThrowsExceptionDuringInstantiation/UserDefinitionProvider.php
@@ -15,12 +15,12 @@ namespace Ergebnis\FactoryBot\Test\Fixture\DefinitionProvider\ImplementsDefiniti
 
 use Ergebnis\FactoryBot\EntityDefinitionProvider;
 use Ergebnis\FactoryBot\FixtureFactory;
-use Ergebnis\FactoryBot\Test\Fixture;
+use Example\Entity;
 
 final class UserDefinitionProvider implements EntityDefinitionProvider
 {
     public function accept(FixtureFactory $fixtureFactory): void
     {
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\User::class);
+        $fixtureFactory->define(Entity\User::class);
     }
 }

--- a/test/Integration/FixtureFactoryTest.php
+++ b/test/Integration/FixtureFactoryTest.php
@@ -16,7 +16,7 @@ namespace Ergebnis\FactoryBot\Test\Integration;
 use Ergebnis\FactoryBot\Count;
 use Ergebnis\FactoryBot\FieldDefinition;
 use Ergebnis\FactoryBot\FixtureFactory;
-use Ergebnis\FactoryBot\Test\Fixture;
+use Example\Entity;
 
 /**
  * @internal
@@ -45,16 +45,16 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         $name = $faker->word;
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
+        $fixtureFactory->define(Entity\Organization::class, [
             'name' => $name,
         ]);
 
-        $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class);
+        $fixtureFactory->createOne(Entity\Organization::class);
 
         $entityManager->flush();
         $entityManager->clear();
 
-        $organization = $entityManager->getRepository(Fixture\FixtureFactory\Entity\Organization::class)->findOneBy([
+        $organization = $entityManager->getRepository(Entity\Organization::class)->findOneBy([
             'name' => $name,
         ]);
 
@@ -73,22 +73,22 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         $name = $faker->word;
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
+        $fixtureFactory->define(Entity\Organization::class, [
             'name' => $name,
         ]);
 
         $fixtureFactory->persistAfterCreate();
 
-        $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class);
+        $fixtureFactory->createOne(Entity\Organization::class);
 
         $entityManager->flush();
         $entityManager->clear();
 
-        $organization = $entityManager->getRepository(Fixture\FixtureFactory\Entity\Organization::class)->findOneBy([
+        $organization = $entityManager->getRepository(Entity\Organization::class)->findOneBy([
             'name' => $name,
         ]);
 
-        self::assertInstanceOf(Fixture\FixtureFactory\Entity\Organization::class, $organization);
+        self::assertInstanceOf(Entity\Organization::class, $organization);
     }
 
     public function testCreateOneDoesNotPersistEntityWhenPersistAfterCreateHasBeenDisabled(): void
@@ -103,19 +103,19 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         $name = $faker->word;
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
+        $fixtureFactory->define(Entity\Organization::class, [
             'name' => $name,
         ]);
 
         $fixtureFactory->persistAfterCreate();
         $fixtureFactory->doNotPersistAfterCreate();
 
-        $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class);
+        $fixtureFactory->createOne(Entity\Organization::class);
 
         $entityManager->flush();
         $entityManager->clear();
 
-        $organization = $entityManager->getRepository(Fixture\FixtureFactory\Entity\Organization::class)->findOneBy([
+        $organization = $entityManager->getRepository(Entity\Organization::class)->findOneBy([
             'name' => $name,
         ]);
 
@@ -132,20 +132,20 @@ final class FixtureFactoryTest extends AbstractTestCase
             $faker
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Avatar::class, [
+        $fixtureFactory->define(Entity\Avatar::class, [
             'url' => FieldDefinition::closure(static function () use ($faker): string {
                 return $faker->imageUrl();
             }),
         ]);
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\User::class, [
-            'avatar' => FieldDefinition::reference(Fixture\FixtureFactory\Entity\Avatar::class),
+        $fixtureFactory->define(Entity\User::class, [
+            'avatar' => FieldDefinition::reference(Entity\Avatar::class),
             'login' => $faker->userName,
         ]);
 
         $fixtureFactory->persistAfterCreate();
 
-        $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\User::class);
+        $fixtureFactory->createOne(Entity\User::class);
 
         $entityManager->flush();
 
@@ -161,19 +161,19 @@ final class FixtureFactoryTest extends AbstractTestCase
             self::faker()
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
+        $fixtureFactory->define(Entity\Organization::class, [
             'name' => FieldDefinition::sequence('name-%d'),
         ]);
 
         $fixtureFactory->createMany(
-            Fixture\FixtureFactory\Entity\Organization::class,
+            Entity\Organization::class,
             Count::exact(5)
         );
 
         $entityManager->flush();
         $entityManager->clear();
 
-        $organizations = $entityManager->getRepository(Fixture\FixtureFactory\Entity\Organization::class)->findAll();
+        $organizations = $entityManager->getRepository(Entity\Organization::class)->findAll();
 
         self::assertEmpty($organizations);
     }
@@ -188,7 +188,7 @@ final class FixtureFactoryTest extends AbstractTestCase
             $faker
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
+        $fixtureFactory->define(Entity\Organization::class, [
             'name' => FieldDefinition::sequence('name-%d'),
         ]);
 
@@ -197,14 +197,14 @@ final class FixtureFactoryTest extends AbstractTestCase
         $value = $faker->numberBetween(1, 5);
 
         $fixtureFactory->createMany(
-            Fixture\FixtureFactory\Entity\Organization::class,
+            Entity\Organization::class,
             Count::exact($value)
         );
 
         $entityManager->flush();
         $entityManager->clear();
 
-        $organizations = $entityManager->getRepository(Fixture\FixtureFactory\Entity\Organization::class)->findAll();
+        $organizations = $entityManager->getRepository(Entity\Organization::class)->findAll();
 
         self::assertCount($value, $organizations);
     }
@@ -219,7 +219,7 @@ final class FixtureFactoryTest extends AbstractTestCase
             $faker
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
+        $fixtureFactory->define(Entity\Organization::class, [
             'name' => FieldDefinition::sequence('name-%d'),
         ]);
 
@@ -229,14 +229,14 @@ final class FixtureFactoryTest extends AbstractTestCase
         $value = $faker->numberBetween(1, 5);
 
         $fixtureFactory->createMany(
-            Fixture\FixtureFactory\Entity\Organization::class,
+            Entity\Organization::class,
             Count::exact($value)
         );
 
         $entityManager->flush();
         $entityManager->clear();
 
-        $organizations = $entityManager->getRepository(Fixture\FixtureFactory\Entity\Organization::class)->findAll();
+        $organizations = $entityManager->getRepository(Entity\Organization::class)->findAll();
 
         self::assertEmpty($organizations);
     }

--- a/test/Unit/FieldDefinition/ClosureTest.php
+++ b/test/Unit/FieldDefinition/ClosureTest.php
@@ -15,8 +15,8 @@ namespace Ergebnis\FactoryBot\Test\Unit\FieldDefinition;
 
 use Ergebnis\FactoryBot\FieldDefinition\Closure;
 use Ergebnis\FactoryBot\FixtureFactory;
-use Ergebnis\FactoryBot\Test\Fixture;
 use Ergebnis\FactoryBot\Test\Unit\AbstractTestCase;
+use Example\Entity;
 use Faker\Generator;
 
 /**
@@ -40,10 +40,10 @@ final class ClosureTest extends AbstractTestCase
             $faker
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\User::class);
+        $fixtureFactory->define(Entity\User::class);
 
-        $closure = static function (Generator $faker, FixtureFactory $fixtureFactory): Fixture\FixtureFactory\Entity\User {
-            return $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\User::class);
+        $closure = static function (Generator $faker, FixtureFactory $fixtureFactory): Entity\User {
+            return $fixtureFactory->createOne(Entity\User::class);
         };
 
         $fieldDefinition = new Closure($closure);
@@ -53,6 +53,6 @@ final class ClosureTest extends AbstractTestCase
             $fixtureFactory
         );
 
-        self::assertInstanceOf(Fixture\FixtureFactory\Entity\User::class, $resolved);
+        self::assertInstanceOf(Entity\User::class, $resolved);
     }
 }

--- a/test/Unit/FieldDefinition/OptionalTest.php
+++ b/test/Unit/FieldDefinition/OptionalTest.php
@@ -16,8 +16,8 @@ namespace Ergebnis\FactoryBot\Test\Unit\FieldDefinition;
 use Ergebnis\FactoryBot\FieldDefinition\Optional;
 use Ergebnis\FactoryBot\FieldDefinition\Resolvable;
 use Ergebnis\FactoryBot\FixtureFactory;
-use Ergebnis\FactoryBot\Test\Fixture;
 use Ergebnis\FactoryBot\Test\Unit\AbstractTestCase;
+use Example\Entity;
 use Faker\Generator;
 
 /**
@@ -41,12 +41,12 @@ final class OptionalTest extends AbstractTestCase
             $faker
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\User::class);
+        $fixtureFactory->define(Entity\User::class);
 
         $resolvable = new class() implements Resolvable {
             public function resolve(Generator $faker, FixtureFactory $fixtureFactory)
             {
-                return $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\User::class);
+                return $fixtureFactory->createOne(Entity\User::class);
             }
         };
 
@@ -57,6 +57,6 @@ final class OptionalTest extends AbstractTestCase
             $fixtureFactory
         );
 
-        self::assertInstanceOf(Fixture\FixtureFactory\Entity\User::class, $resolved);
+        self::assertInstanceOf(Entity\User::class, $resolved);
     }
 }

--- a/test/Unit/FieldDefinition/ReferenceTest.php
+++ b/test/Unit/FieldDefinition/ReferenceTest.php
@@ -15,8 +15,8 @@ namespace Ergebnis\FactoryBot\Test\Unit\FieldDefinition;
 
 use Ergebnis\FactoryBot\FieldDefinition\Reference;
 use Ergebnis\FactoryBot\FixtureFactory;
-use Ergebnis\FactoryBot\Test\Fixture;
 use Ergebnis\FactoryBot\Test\Unit\AbstractTestCase;
+use Example\Entity;
 
 /**
  * @internal
@@ -32,7 +32,7 @@ final class ReferenceTest extends AbstractTestCase
 {
     public function testResolvesToObjectCreatedByFixtureFactory(): void
     {
-        $className = Fixture\FixtureFactory\Entity\User::class;
+        $className = Entity\User::class;
 
         $faker = self::faker();
 

--- a/test/Unit/FieldDefinition/ReferencesTest.php
+++ b/test/Unit/FieldDefinition/ReferencesTest.php
@@ -16,8 +16,8 @@ namespace Ergebnis\FactoryBot\Test\Unit\FieldDefinition;
 use Ergebnis\FactoryBot\Count;
 use Ergebnis\FactoryBot\FieldDefinition\References;
 use Ergebnis\FactoryBot\FixtureFactory;
-use Ergebnis\FactoryBot\Test\Fixture;
 use Ergebnis\FactoryBot\Test\Unit\AbstractTestCase;
+use Example\Entity;
 
 /**
  * @internal
@@ -40,7 +40,7 @@ final class ReferencesTest extends AbstractTestCase
      */
     public function testResolvesToArrayOfObjectsCreatedByFixtureFactory(int $value): void
     {
-        $className = Fixture\FixtureFactory\Entity\User::class;
+        $className = Entity\User::class;
         $faker = self::faker();
 
         $fixtureFactory = new FixtureFactory(

--- a/test/Unit/FieldDefinitionTest.php
+++ b/test/Unit/FieldDefinitionTest.php
@@ -17,7 +17,7 @@ use Ergebnis\FactoryBot\Count;
 use Ergebnis\FactoryBot\Exception;
 use Ergebnis\FactoryBot\FieldDefinition;
 use Ergebnis\FactoryBot\FixtureFactory;
-use Ergebnis\FactoryBot\Test\Fixture;
+use Example\Entity;
 
 /**
  * @internal
@@ -38,9 +38,9 @@ final class FieldDefinitionTest extends AbstractTestCase
 {
     public function testClosureReturnsRequiredClosure(): void
     {
-        $closure = static function (FixtureFactory $fixtureFactory): Fixture\FixtureFactory\Entity\User {
-            /** @var Fixture\FixtureFactory\Entity\User $user */
-            $user = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\User::class);
+        $closure = static function (FixtureFactory $fixtureFactory): Entity\User {
+            /** @var Entity\User $user */
+            $user = $fixtureFactory->createOne(Entity\User::class);
 
             $user->renameTo(self::faker()->userName);
 
@@ -56,9 +56,9 @@ final class FieldDefinitionTest extends AbstractTestCase
 
     public function testOptionalClosureReturnsOptionalClosure(): void
     {
-        $closure = static function (FixtureFactory $fixtureFactory): Fixture\FixtureFactory\Entity\User {
-            /** @var Fixture\FixtureFactory\Entity\User $user */
-            $user = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\User::class);
+        $closure = static function (FixtureFactory $fixtureFactory): Entity\User {
+            /** @var Entity\User $user */
+            $user = $fixtureFactory->createOne(Entity\User::class);
 
             $user->renameTo(self::faker()->userName);
 
@@ -74,7 +74,7 @@ final class FieldDefinitionTest extends AbstractTestCase
 
     public function testReferenceReturnsRequiredReference(): void
     {
-        $className = Fixture\FixtureFactory\Entity\User::class;
+        $className = Entity\User::class;
 
         $fieldDefinition = FieldDefinition::reference($className);
 
@@ -85,7 +85,7 @@ final class FieldDefinitionTest extends AbstractTestCase
 
     public function testOptionalReferenceReturnsOptionalReference(): void
     {
-        $className = Fixture\FixtureFactory\Entity\User::class;
+        $className = Entity\User::class;
 
         $fieldDefinition = FieldDefinition::optionalReference($className);
 
@@ -101,7 +101,7 @@ final class FieldDefinitionTest extends AbstractTestCase
      */
     public function testReferencesReturnsRequiredReferencesWhenCountIsSpecified(int $value): void
     {
-        $className = Fixture\FixtureFactory\Entity\User::class;
+        $className = Entity\User::class;
 
         $fieldDefinition = FieldDefinition::references(
             $className,

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -19,6 +19,7 @@ use Ergebnis\FactoryBot\FieldDefinition;
 use Ergebnis\FactoryBot\FixtureFactory;
 use Ergebnis\FactoryBot\Test\Double;
 use Ergebnis\FactoryBot\Test\Fixture;
+use Example\Entity;
 use Faker\Generator;
 
 /**
@@ -63,11 +64,11 @@ final class FixtureFactoryTest extends AbstractTestCase
             self::faker()
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
+        $fixtureFactory->define(Entity\Organization::class);
 
         $this->expectException(Exception\EntityDefinitionAlreadyRegistered::class);
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
+        $fixtureFactory->define(Entity\Organization::class);
     }
 
     public function testDefineThrowsClassNotFoundExceptionWhenClassDoesNotExist(): void
@@ -109,8 +110,8 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         $this->expectException(Exception\InvalidFieldNames::class);
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\User::class, [
-            'avatar' => new Fixture\FixtureFactory\Entity\Avatar(),
+        $fixtureFactory->define(Entity\User::class, [
+            'avatar' => new Entity\Avatar(),
             'email' => $faker->email,
             'phone' => $faker->phoneNumber,
         ]);
@@ -153,12 +154,12 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         $fixtureFactory->load(__DIR__ . '/../Fixture/DefinitionProvider/DoesNotImplementDefinitionProvider');
 
-        $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class);
-        $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\User::class);
+        $fixtureFactory->createOne(Entity\Organization::class);
+        $fixtureFactory->createOne(Entity\User::class);
 
         $this->expectException(Exception\EntityDefinitionNotRegistered::class);
 
-        $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Repository::class);
+        $fixtureFactory->createOne(Entity\Repository::class);
     }
 
     public function testLoadIgnoresClassesWhichImplementDefinitionProviderInterfaceButAreAbstract(): void
@@ -170,12 +171,12 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         $fixtureFactory->load(__DIR__ . '/../Fixture/DefinitionProvider/ImplementsDefinitionProviderButIsAbstract');
 
-        $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class);
-        $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\User::class);
+        $fixtureFactory->createOne(Entity\Organization::class);
+        $fixtureFactory->createOne(Entity\User::class);
 
         $this->expectException(Exception\EntityDefinitionNotRegistered::class);
 
-        $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Repository::class);
+        $fixtureFactory->createOne(Entity\Repository::class);
     }
 
     public function testLoadThrowsInvalidDefinitionExceptionWhenClassImplementsDefinitionProviderInterfaceButCanNotBeInstantiated(): void
@@ -217,15 +218,15 @@ final class FixtureFactoryTest extends AbstractTestCase
             self::faker()
         );
 
-        $fixtureFactory->load(__DIR__ . '/../Fixture/DefinitionProvider/ImplementsDefinitionProvider');
+        $fixtureFactory->load(__DIR__ . '/../../example/test/Fixture/Entity');
 
-        $organization = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class);
-        $repository = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Repository::class);
-        $user = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\User::class);
+        $organization = $fixtureFactory->createOne(Entity\Organization::class);
+        $repository = $fixtureFactory->createOne(Entity\Repository::class);
+        $user = $fixtureFactory->createOne(Entity\User::class);
 
-        self::assertInstanceOf(Fixture\FixtureFactory\Entity\Organization::class, $organization);
-        self::assertInstanceOf(Fixture\FixtureFactory\Entity\Repository::class, $repository);
-        self::assertInstanceOf(Fixture\FixtureFactory\Entity\User::class, $user);
+        self::assertInstanceOf(Entity\Organization::class, $organization);
+        self::assertInstanceOf(Entity\Repository::class, $repository);
+        self::assertInstanceOf(Entity\User::class, $user);
     }
 
     public function testCreateOneThrowsEntityDefinitionNotRegisteredWhenEntityDefinitionHasNotBeenRegistered(): void
@@ -251,13 +252,13 @@ final class FixtureFactoryTest extends AbstractTestCase
             $faker
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
+        $fixtureFactory->define(Entity\Organization::class, [
             'name' => $faker->word,
         ]);
 
         $this->expectException(Exception\InvalidFieldNames::class);
 
-        $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class, [
+        $fixtureFactory->createOne(Entity\Organization::class, [
             'flavour' => 'strawberry',
         ]);
     }
@@ -273,19 +274,19 @@ final class FixtureFactoryTest extends AbstractTestCase
             $faker
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Avatar::class, [
+        $fixtureFactory->define(Entity\Avatar::class, [
             'url' => $url,
         ]);
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\User::class, [
-            'avatar' => FieldDefinition::reference(Fixture\FixtureFactory\Entity\Avatar::class),
+        $fixtureFactory->define(Entity\User::class, [
+            'avatar' => FieldDefinition::reference(Entity\Avatar::class),
         ]);
 
-        $user = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\User::class);
+        $user = $fixtureFactory->createOne(Entity\User::class);
 
-        self::assertInstanceOf(Fixture\FixtureFactory\Entity\User::class, $user);
+        self::assertInstanceOf(Entity\User::class, $user);
 
-        /** @var Fixture\FixtureFactory\Entity\User $user */
+        /** @var Entity\User $user */
         $avatar = $user->avatar();
 
         self::assertSame($url, $avatar->url());
@@ -302,7 +303,7 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         $this->expectException(Exception\InvalidFieldNames::class);
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\User::class, [
+        $fixtureFactory->define(Entity\User::class, [
             'login' => $faker->userName,
             'avatar.url' => $faker->imageUrl(),
             'avatar.width' => $faker->numberBetween(100, 250),
@@ -319,11 +320,11 @@ final class FixtureFactoryTest extends AbstractTestCase
             $faker
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\User::class);
+        $fixtureFactory->define(Entity\User::class);
 
         $this->expectException(Exception\InvalidFieldNames::class);
 
-        $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\User::class, [
+        $fixtureFactory->createOne(Entity\User::class, [
             'login' => $faker->userName,
             'avatar.url' => $faker->imageUrl(),
             'avatar.width' => $faker->numberBetween(100, 250),
@@ -342,12 +343,12 @@ final class FixtureFactoryTest extends AbstractTestCase
             $faker
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
+        $fixtureFactory->define(Entity\Organization::class, [
             'name' => $name,
         ]);
 
-        /** @var Fixture\FixtureFactory\Entity\Organization $organization */
-        $organization = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class);
+        /** @var Entity\Organization $organization */
+        $organization = $fixtureFactory->createOne(Entity\Organization::class);
 
         self::assertSame($name, $organization->name());
     }
@@ -361,7 +362,7 @@ final class FixtureFactoryTest extends AbstractTestCase
             self::faker()
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
+        $fixtureFactory->define(Entity\Organization::class, [
             'name' => static function () use (&$name): string {
                 return \sprintf(
                     'the-%s-organization',
@@ -370,13 +371,13 @@ final class FixtureFactoryTest extends AbstractTestCase
             },
         ]);
 
-        /** @var Fixture\FixtureFactory\Entity\Organization $organizationOne */
-        $organizationOne = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class);
+        /** @var Entity\Organization $organizationOne */
+        $organizationOne = $fixtureFactory->createOne(Entity\Organization::class);
 
         $name = 'bar';
 
-        /** @var Fixture\FixtureFactory\Entity\Organization $organizationTwo */
-        $organizationTwo = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class);
+        /** @var Entity\Organization $organizationTwo */
+        $organizationTwo = $fixtureFactory->createOne(Entity\Organization::class);
 
         self::assertSame('the-foo-organization', $organizationOne->name());
         self::assertSame('the-bar-organization', $organizationTwo->name());
@@ -389,10 +390,10 @@ final class FixtureFactoryTest extends AbstractTestCase
             self::faker()
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
+        $fixtureFactory->define(Entity\Organization::class);
 
-        /** @var Fixture\FixtureFactory\Entity\Organization $organization */
-        $organization = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class);
+        /** @var Entity\Organization $organization */
+        $organization = $fixtureFactory->createOne(Entity\Organization::class);
 
         self::assertNull($organization->name());
     }
@@ -404,10 +405,10 @@ final class FixtureFactoryTest extends AbstractTestCase
             self::faker()
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
+        $fixtureFactory->define(Entity\Organization::class);
 
-        /** @var Fixture\FixtureFactory\Entity\Organization $organization */
-        $organization = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class);
+        /** @var Entity\Organization $organization */
+        $organization = $fixtureFactory->createOne(Entity\Organization::class);
 
         self::assertFalse($organization->isVerified());
     }
@@ -419,10 +420,10 @@ final class FixtureFactoryTest extends AbstractTestCase
             self::faker()
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, []);
+        $fixtureFactory->define(Entity\Organization::class, []);
 
-        /** @var Fixture\FixtureFactory\Entity\Organization $organization */
-        $organization = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class);
+        /** @var Entity\Organization $organization */
+        $organization = $fixtureFactory->createOne(Entity\Organization::class);
 
         self::assertFalse($organization->constructorWasCalled());
     }
@@ -436,12 +437,12 @@ final class FixtureFactoryTest extends AbstractTestCase
             $faker
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
+        $fixtureFactory->define(Entity\Organization::class, [
             'name' => $faker->word,
         ]);
 
-        /** @var Fixture\FixtureFactory\Entity\Organization $organization */
-        $organization = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class);
+        /** @var Entity\Organization $organization */
+        $organization = $fixtureFactory->createOne(Entity\Organization::class);
 
         self::assertEmpty($organization->repositories());
     }
@@ -455,20 +456,20 @@ final class FixtureFactoryTest extends AbstractTestCase
             $faker
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
+        $fixtureFactory->define(Entity\Organization::class);
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
-            'organization' => FieldDefinition::reference(Fixture\FixtureFactory\Entity\Organization::class),
+        $fixtureFactory->define(Entity\Repository::class, [
+            'organization' => FieldDefinition::reference(Entity\Organization::class),
         ]);
 
-        /** @var Fixture\FixtureFactory\Entity\Repository $repositoryOne */
-        $repositoryOne = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Repository::class);
+        /** @var Entity\Repository $repositoryOne */
+        $repositoryOne = $fixtureFactory->createOne(Entity\Repository::class);
 
-        /** @var Fixture\FixtureFactory\Entity\Repository $repositoryTwo */
-        $repositoryTwo = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Repository::class);
+        /** @var Entity\Repository $repositoryTwo */
+        $repositoryTwo = $fixtureFactory->createOne(Entity\Repository::class);
 
-        /** @var Fixture\FixtureFactory\Entity\Organization $organization */
-        $organization = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class, [
+        /** @var Entity\Organization $organization */
+        $organization = $fixtureFactory->createOne(Entity\Organization::class, [
             'name' => $faker->word,
             'repositories' => [
                 $repositoryOne,
@@ -487,14 +488,14 @@ final class FixtureFactoryTest extends AbstractTestCase
             self::faker()
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
+        $fixtureFactory->define(Entity\Organization::class);
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
-            'organization' => FieldDefinition::reference(Fixture\FixtureFactory\Entity\Organization::class),
+        $fixtureFactory->define(Entity\Repository::class, [
+            'organization' => FieldDefinition::reference(Entity\Organization::class),
         ]);
 
-        /** @var Fixture\FixtureFactory\Entity\Repository $repository */
-        $repository = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Repository::class);
+        /** @var Entity\Repository $repository */
+        $repository = $fixtureFactory->createOne(Entity\Repository::class);
 
         $organization = $repository->organization();
 
@@ -508,16 +509,16 @@ final class FixtureFactoryTest extends AbstractTestCase
             new Double\Faker\FalseGenerator()
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\CodeOfConduct::class);
+        $fixtureFactory->define(Entity\CodeOfConduct::class);
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
-            'codeOfConduct' => FieldDefinition::optionalClosure(static function (FixtureFactory $fixtureFactory): Fixture\FixtureFactory\Entity\CodeOfConduct {
-                return $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\CodeOfConduct::class);
+        $fixtureFactory->define(Entity\Repository::class, [
+            'codeOfConduct' => FieldDefinition::optionalClosure(static function (FixtureFactory $fixtureFactory): Entity\CodeOfConduct {
+                return $fixtureFactory->createOne(Entity\CodeOfConduct::class);
             }),
         ]);
 
-        /** @var Fixture\FixtureFactory\Entity\Repository $repository */
-        $repository = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Repository::class);
+        /** @var Entity\Repository $repository */
+        $repository = $fixtureFactory->createOne(Entity\Repository::class);
 
         self::assertNull($repository->codeOfConduct());
     }
@@ -529,18 +530,18 @@ final class FixtureFactoryTest extends AbstractTestCase
             new Double\Faker\TrueGenerator()
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\CodeOfConduct::class);
+        $fixtureFactory->define(Entity\CodeOfConduct::class);
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
-            'codeOfConduct' => FieldDefinition::optionalClosure(static function (Generator $faker, FixtureFactory $fixtureFactory): Fixture\FixtureFactory\Entity\CodeOfConduct {
-                return $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\CodeOfConduct::class);
+        $fixtureFactory->define(Entity\Repository::class, [
+            'codeOfConduct' => FieldDefinition::optionalClosure(static function (Generator $faker, FixtureFactory $fixtureFactory): Entity\CodeOfConduct {
+                return $fixtureFactory->createOne(Entity\CodeOfConduct::class);
             }),
         ]);
 
-        /** @var Fixture\FixtureFactory\Entity\Repository $repository */
-        $repository = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Repository::class);
+        /** @var Entity\Repository $repository */
+        $repository = $fixtureFactory->createOne(Entity\Repository::class);
 
-        self::assertInstanceOf(Fixture\FixtureFactory\Entity\CodeOfConduct::class, $repository->codeOfConduct());
+        self::assertInstanceOf(Entity\CodeOfConduct::class, $repository->codeOfConduct());
     }
 
     public function testCreateOneResolvesRequiredClosureToResultOfClosureInvokedWithFakerAndFixtureFactoryWhenFakerReturnsFalse(): void
@@ -550,18 +551,18 @@ final class FixtureFactoryTest extends AbstractTestCase
             new Double\Faker\FalseGenerator()
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\CodeOfConduct::class);
+        $fixtureFactory->define(Entity\CodeOfConduct::class);
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
-            'codeOfConduct' => FieldDefinition::closure(static function (Generator $faker, FixtureFactory $fixtureFactory): Fixture\FixtureFactory\Entity\CodeOfConduct {
-                return $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\CodeOfConduct::class);
+        $fixtureFactory->define(Entity\Repository::class, [
+            'codeOfConduct' => FieldDefinition::closure(static function (Generator $faker, FixtureFactory $fixtureFactory): Entity\CodeOfConduct {
+                return $fixtureFactory->createOne(Entity\CodeOfConduct::class);
             }),
         ]);
 
-        /** @var Fixture\FixtureFactory\Entity\Repository $repository */
-        $repository = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Repository::class);
+        /** @var Entity\Repository $repository */
+        $repository = $fixtureFactory->createOne(Entity\Repository::class);
 
-        self::assertInstanceOf(Fixture\FixtureFactory\Entity\CodeOfConduct::class, $repository->codeOfConduct());
+        self::assertInstanceOf(Entity\CodeOfConduct::class, $repository->codeOfConduct());
     }
 
     public function testCreateOneResolvesRequiredClosureToResultOfClosureInvokedWithFakerAndFixtureFactoryWhenFakerReturnsTrue(): void
@@ -571,18 +572,18 @@ final class FixtureFactoryTest extends AbstractTestCase
             new Double\Faker\TrueGenerator()
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\CodeOfConduct::class);
+        $fixtureFactory->define(Entity\CodeOfConduct::class);
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
-            'codeOfConduct' => FieldDefinition::closure(static function (Generator $faker, FixtureFactory $fixtureFactory): Fixture\FixtureFactory\Entity\CodeOfConduct {
-                return $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\CodeOfConduct::class);
+        $fixtureFactory->define(Entity\Repository::class, [
+            'codeOfConduct' => FieldDefinition::closure(static function (Generator $faker, FixtureFactory $fixtureFactory): Entity\CodeOfConduct {
+                return $fixtureFactory->createOne(Entity\CodeOfConduct::class);
             }),
         ]);
 
-        /** @var Fixture\FixtureFactory\Entity\Repository $repository */
-        $repository = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Repository::class);
+        /** @var Entity\Repository $repository */
+        $repository = $fixtureFactory->createOne(Entity\Repository::class);
 
-        self::assertInstanceOf(Fixture\FixtureFactory\Entity\CodeOfConduct::class, $repository->codeOfConduct());
+        self::assertInstanceOf(Entity\CodeOfConduct::class, $repository->codeOfConduct());
     }
 
     public function testCreateOneResolvesOptionalReferenceToNullWhenFakerReturnsFalse(): void
@@ -592,14 +593,14 @@ final class FixtureFactoryTest extends AbstractTestCase
             new Double\Faker\FalseGenerator()
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\CodeOfConduct::class);
+        $fixtureFactory->define(Entity\CodeOfConduct::class);
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
-            'codeOfConduct' => FieldDefinition::optionalReference(Fixture\FixtureFactory\Entity\CodeOfConduct::class),
+        $fixtureFactory->define(Entity\Repository::class, [
+            'codeOfConduct' => FieldDefinition::optionalReference(Entity\CodeOfConduct::class),
         ]);
 
-        /** @var Fixture\FixtureFactory\Entity\Repository $repository */
-        $repository = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Repository::class);
+        /** @var Entity\Repository $repository */
+        $repository = $fixtureFactory->createOne(Entity\Repository::class);
 
         self::assertNull($repository->codeOfConduct());
     }
@@ -611,16 +612,16 @@ final class FixtureFactoryTest extends AbstractTestCase
             new Double\Faker\TrueGenerator()
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\CodeOfConduct::class);
+        $fixtureFactory->define(Entity\CodeOfConduct::class);
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
-            'codeOfConduct' => FieldDefinition::optionalReference(Fixture\FixtureFactory\Entity\CodeOfConduct::class),
+        $fixtureFactory->define(Entity\Repository::class, [
+            'codeOfConduct' => FieldDefinition::optionalReference(Entity\CodeOfConduct::class),
         ]);
 
-        /** @var Fixture\FixtureFactory\Entity\Repository $repository */
-        $repository = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Repository::class);
+        /** @var Entity\Repository $repository */
+        $repository = $fixtureFactory->createOne(Entity\Repository::class);
 
-        self::assertInstanceOf(Fixture\FixtureFactory\Entity\CodeOfConduct::class, $repository->codeOfConduct());
+        self::assertInstanceOf(Entity\CodeOfConduct::class, $repository->codeOfConduct());
     }
 
     public function testCreateOneResolvesRequiredReferenceToEntityWhenFakerReturnsFalse(): void
@@ -630,16 +631,16 @@ final class FixtureFactoryTest extends AbstractTestCase
             new Double\Faker\FalseGenerator()
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\CodeOfConduct::class);
+        $fixtureFactory->define(Entity\CodeOfConduct::class);
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
-            'codeOfConduct' => FieldDefinition::reference(Fixture\FixtureFactory\Entity\CodeOfConduct::class),
+        $fixtureFactory->define(Entity\Repository::class, [
+            'codeOfConduct' => FieldDefinition::reference(Entity\CodeOfConduct::class),
         ]);
 
-        /** @var Fixture\FixtureFactory\Entity\Repository $repository */
-        $repository = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Repository::class);
+        /** @var Entity\Repository $repository */
+        $repository = $fixtureFactory->createOne(Entity\Repository::class);
 
-        self::assertInstanceOf(Fixture\FixtureFactory\Entity\CodeOfConduct::class, $repository->codeOfConduct());
+        self::assertInstanceOf(Entity\CodeOfConduct::class, $repository->codeOfConduct());
     }
 
     public function testCreateOneResolvesRequiredReferenceToEntityWhenFakerReturnsTrue(): void
@@ -649,16 +650,16 @@ final class FixtureFactoryTest extends AbstractTestCase
             new Double\Faker\TrueGenerator()
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\CodeOfConduct::class);
+        $fixtureFactory->define(Entity\CodeOfConduct::class);
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
-            'codeOfConduct' => FieldDefinition::reference(Fixture\FixtureFactory\Entity\CodeOfConduct::class),
+        $fixtureFactory->define(Entity\Repository::class, [
+            'codeOfConduct' => FieldDefinition::reference(Entity\CodeOfConduct::class),
         ]);
 
-        /** @var Fixture\FixtureFactory\Entity\Repository $repository */
-        $repository = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Repository::class);
+        /** @var Entity\Repository $repository */
+        $repository = $fixtureFactory->createOne(Entity\Repository::class);
 
-        self::assertInstanceOf(Fixture\FixtureFactory\Entity\CodeOfConduct::class, $repository->codeOfConduct());
+        self::assertInstanceOf(Entity\CodeOfConduct::class, $repository->codeOfConduct());
     }
 
     /**
@@ -673,21 +674,21 @@ final class FixtureFactoryTest extends AbstractTestCase
             new Double\Faker\FalseGenerator()
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
+        $fixtureFactory->define(Entity\Organization::class, [
             'repositories' => FieldDefinition::references(
-                Fixture\FixtureFactory\Entity\Repository::class,
+                Entity\Repository::class,
                 Count::exact($value)
             ),
         ]);
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
+        $fixtureFactory->define(Entity\Repository::class, [
             'name' => self::faker()->word,
         ]);
 
-        /** @var Fixture\FixtureFactory\Entity\Organization $organization */
-        $organization = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class);
+        /** @var Entity\Organization $organization */
+        $organization = $fixtureFactory->createOne(Entity\Organization::class);
 
-        self::assertContainsOnly(Fixture\FixtureFactory\Entity\Repository::class, $organization->repositories());
+        self::assertContainsOnly(Entity\Repository::class, $organization->repositories());
         self::assertCount($value, $organization->repositories());
     }
 
@@ -703,23 +704,23 @@ final class FixtureFactoryTest extends AbstractTestCase
             new Double\Faker\TrueGenerator()
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
+        $fixtureFactory->define(Entity\Organization::class, [
             'repositories' => FieldDefinition::references(
-                Fixture\FixtureFactory\Entity\Repository::class,
+                Entity\Repository::class,
                 Count::exact($value)
             ),
         ]);
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
+        $fixtureFactory->define(Entity\Repository::class, [
             'name' => self::faker()->word,
         ]);
 
-        /** @var Fixture\FixtureFactory\Entity\Organization $organization */
-        $organization = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class);
+        /** @var Entity\Organization $organization */
+        $organization = $fixtureFactory->createOne(Entity\Organization::class);
 
         $repositories = $organization->repositories();
 
-        self::assertContainsOnly(Fixture\FixtureFactory\Entity\Repository::class, $repositories);
+        self::assertContainsOnly(Entity\Repository::class, $repositories);
         self::assertCount($value, $repositories);
     }
 
@@ -735,9 +736,9 @@ final class FixtureFactoryTest extends AbstractTestCase
             new Double\Faker\FalseGenerator()
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
+        $fixtureFactory->define(Entity\Organization::class, [
             'repositories' => FieldDefinition::references(
-                Fixture\FixtureFactory\Entity\Repository::class,
+                Entity\Repository::class,
                 Count::between(
                     $minimum,
                     $maximum
@@ -745,14 +746,14 @@ final class FixtureFactoryTest extends AbstractTestCase
             ),
         ]);
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
+        $fixtureFactory->define(Entity\Repository::class, [
             'name' => self::faker()->word,
         ]);
 
-        /** @var Fixture\FixtureFactory\Entity\Organization $organization */
-        $organization = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class);
+        /** @var Entity\Organization $organization */
+        $organization = $fixtureFactory->createOne(Entity\Organization::class);
 
-        self::assertContainsOnly(Fixture\FixtureFactory\Entity\Repository::class, $organization->repositories());
+        self::assertContainsOnly(Entity\Repository::class, $organization->repositories());
         self::assertGreaterThanOrEqual($minimum, \count($organization->repositories()));
         self::assertLessThanOrEqual($maximum, \count($organization->repositories()));
     }
@@ -769,9 +770,9 @@ final class FixtureFactoryTest extends AbstractTestCase
             new Double\Faker\TrueGenerator()
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
+        $fixtureFactory->define(Entity\Organization::class, [
             'repositories' => FieldDefinition::references(
-                Fixture\FixtureFactory\Entity\Repository::class,
+                Entity\Repository::class,
                 Count::between(
                     $minimum,
                     $maximum
@@ -779,14 +780,14 @@ final class FixtureFactoryTest extends AbstractTestCase
             ),
         ]);
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
+        $fixtureFactory->define(Entity\Repository::class, [
             'name' => self::faker()->word,
         ]);
 
-        /** @var Fixture\FixtureFactory\Entity\Organization $organization */
-        $organization = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class);
+        /** @var Entity\Organization $organization */
+        $organization = $fixtureFactory->createOne(Entity\Organization::class);
 
-        self::assertContainsOnly(Fixture\FixtureFactory\Entity\Repository::class, $organization->repositories());
+        self::assertContainsOnly(Entity\Repository::class, $organization->repositories());
         self::assertGreaterThanOrEqual($minimum, \count($organization->repositories()));
         self::assertLessThanOrEqual($maximum, \count($organization->repositories()));
     }
@@ -798,12 +799,12 @@ final class FixtureFactoryTest extends AbstractTestCase
             new Double\Faker\FalseGenerator()
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\User::class, [
+        $fixtureFactory->define(Entity\User::class, [
             'location' => FieldDefinition::optionalSequence('City (%d)'),
         ]);
 
-        /** @var Fixture\FixtureFactory\Entity\User $user */
-        $user = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\User::class);
+        /** @var Entity\User $user */
+        $user = $fixtureFactory->createOne(Entity\User::class);
 
         self::assertNull($user->location());
     }
@@ -816,11 +817,11 @@ final class FixtureFactoryTest extends AbstractTestCase
         );
 
         $fixtureFactory->define(
-            Fixture\FixtureFactory\Entity\User::class,
+            Entity\User::class,
             [
                 'location' => FieldDefinition::optionalSequence('City (%d)'),
             ],
-            static function (Fixture\FixtureFactory\Entity\User $user, array $fieldValues): void {
+            static function (Entity\User $user, array $fieldValues): void {
                 $fieldName = 'location';
 
                 self::assertArrayHasKey($fieldName, $fieldValues, \sprintf(
@@ -830,8 +831,8 @@ final class FixtureFactoryTest extends AbstractTestCase
             }
         );
 
-        /** @var Fixture\FixtureFactory\Entity\User $user */
-        $user = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\User::class);
+        /** @var Entity\User $user */
+        $user = $fixtureFactory->createOne(Entity\User::class);
 
         self::assertNull($user->location());
     }
@@ -843,18 +844,18 @@ final class FixtureFactoryTest extends AbstractTestCase
             new Double\Faker\TrueGenerator()
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\User::class, [
+        $fixtureFactory->define(Entity\User::class, [
             'location' => FieldDefinition::optionalSequence('City (%d)'),
         ]);
 
-        /** @var Fixture\FixtureFactory\Entity\User $userOne */
-        $userOne = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\User::class);
+        /** @var Entity\User $userOne */
+        $userOne = $fixtureFactory->createOne(Entity\User::class);
 
-        /** @var Fixture\FixtureFactory\Entity\User $userTwo */
-        $userTwo = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\User::class);
+        /** @var Entity\User $userTwo */
+        $userTwo = $fixtureFactory->createOne(Entity\User::class);
 
-        /** @var Fixture\FixtureFactory\Entity\User $userThree */
-        $userThree = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\User::class);
+        /** @var Entity\User $userThree */
+        $userThree = $fixtureFactory->createOne(Entity\User::class);
 
         self::assertSame('City (1)', $userOne->location());
         self::assertSame('City (2)', $userTwo->location());
@@ -868,18 +869,18 @@ final class FixtureFactoryTest extends AbstractTestCase
             new Double\Faker\FalseGenerator()
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\User::class, [
+        $fixtureFactory->define(Entity\User::class, [
             'location' => FieldDefinition::sequence('City (%d)'),
         ]);
 
-        /** @var Fixture\FixtureFactory\Entity\User $userOne */
-        $userOne = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\User::class);
+        /** @var Entity\User $userOne */
+        $userOne = $fixtureFactory->createOne(Entity\User::class);
 
-        /** @var Fixture\FixtureFactory\Entity\User $userTwo */
-        $userTwo = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\User::class);
+        /** @var Entity\User $userTwo */
+        $userTwo = $fixtureFactory->createOne(Entity\User::class);
 
-        /** @var Fixture\FixtureFactory\Entity\User $userThree */
-        $userThree = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\User::class);
+        /** @var Entity\User $userThree */
+        $userThree = $fixtureFactory->createOne(Entity\User::class);
 
         self::assertSame('City (1)', $userOne->location());
         self::assertSame('City (2)', $userTwo->location());
@@ -893,18 +894,18 @@ final class FixtureFactoryTest extends AbstractTestCase
             new Double\Faker\TrueGenerator()
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\User::class, [
+        $fixtureFactory->define(Entity\User::class, [
             'location' => FieldDefinition::sequence('City (%d)'),
         ]);
 
-        /** @var Fixture\FixtureFactory\Entity\User $userOne */
-        $userOne = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\User::class);
+        /** @var Entity\User $userOne */
+        $userOne = $fixtureFactory->createOne(Entity\User::class);
 
-        /** @var Fixture\FixtureFactory\Entity\User $userTwo */
-        $userTwo = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\User::class);
+        /** @var Entity\User $userTwo */
+        $userTwo = $fixtureFactory->createOne(Entity\User::class);
 
-        /** @var Fixture\FixtureFactory\Entity\User $userThree */
-        $userThree = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\User::class);
+        /** @var Entity\User $userThree */
+        $userThree = $fixtureFactory->createOne(Entity\User::class);
 
         self::assertSame('City (1)', $userOne->location());
         self::assertSame('City (2)', $userTwo->location());
@@ -920,14 +921,14 @@ final class FixtureFactoryTest extends AbstractTestCase
             $faker
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
+        $fixtureFactory->define(Entity\Organization::class, [
             'name' => $faker->unique()->word,
         ]);
 
         $name = $faker->unique()->word;
 
-        /** @var Fixture\FixtureFactory\Entity\Organization $organization */
-        $organization = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class, [
+        /** @var Entity\Organization $organization */
+        $organization = $fixtureFactory->createOne(Entity\Organization::class, [
             'name' => $name,
         ]);
 
@@ -943,14 +944,14 @@ final class FixtureFactoryTest extends AbstractTestCase
             $faker
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
+        $fixtureFactory->define(Entity\Organization::class, [
             'name' => $faker->unique()->word,
         ]);
 
         $name = $faker->unique()->word;
 
-        /** @var Fixture\FixtureFactory\Entity\Organization $organization */
-        $organization = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class, [
+        /** @var Entity\Organization $organization */
+        $organization = $fixtureFactory->createOne(Entity\Organization::class, [
             'name' => FieldDefinition::value($name),
         ]);
 
@@ -964,15 +965,15 @@ final class FixtureFactoryTest extends AbstractTestCase
             self::faker()
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
+        $fixtureFactory->define(Entity\Repository::class, [
             'template' => FieldDefinition::references(
-                Fixture\FixtureFactory\Entity\Repository::class,
+                Entity\Repository::class,
                 Count::between(0, 5)
             ),
         ]);
 
-        /** @var Fixture\FixtureFactory\Entity\Repository $repository */
-        $repository = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Repository::class, [
+        /** @var Entity\Repository $repository */
+        $repository = $fixtureFactory->createOne(Entity\Repository::class, [
             'template' => null,
         ]);
 
@@ -986,15 +987,15 @@ final class FixtureFactoryTest extends AbstractTestCase
             self::faker()
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
+        $fixtureFactory->define(Entity\Repository::class, [
             'template' => FieldDefinition::references(
-                Fixture\FixtureFactory\Entity\Repository::class,
+                Entity\Repository::class,
                 Count::between(0, 5)
             ),
         ]);
 
-        /** @var Fixture\FixtureFactory\Entity\Repository $repository */
-        $repository = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Repository::class, [
+        /** @var Entity\Repository $repository */
+        $repository = $fixtureFactory->createOne(Entity\Repository::class, [
             'template' => FieldDefinition::value(null),
         ]);
 
@@ -1015,28 +1016,28 @@ final class FixtureFactoryTest extends AbstractTestCase
             $faker
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
+        $fixtureFactory->define(Entity\Organization::class, [
             'repositories' => FieldDefinition::references(
-                Fixture\FixtureFactory\Entity\Repository::class,
+                Entity\Repository::class,
                 Count::between(0, 5)
             ),
         ]);
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
+        $fixtureFactory->define(Entity\Repository::class, [
             'name' => $faker->word,
         ]);
 
-        /** @var Fixture\FixtureFactory\Entity\Organization $organization */
-        $organization = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class, [
+        /** @var Entity\Organization $organization */
+        $organization = $fixtureFactory->createOne(Entity\Organization::class, [
             'repositories' => $fixtureFactory->createMany(
-                Fixture\FixtureFactory\Entity\Repository::class,
+                Entity\Repository::class,
                 Count::exact($value)
             ),
         ]);
 
         $repositories = $organization->repositories();
 
-        self::assertContainsOnly(Fixture\FixtureFactory\Entity\Repository::class, $repositories);
+        self::assertContainsOnly(Entity\Repository::class, $repositories);
         self::assertCount($value, $repositories);
     }
 
@@ -1054,28 +1055,28 @@ final class FixtureFactoryTest extends AbstractTestCase
             $faker
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class, [
+        $fixtureFactory->define(Entity\Organization::class, [
             'repositories' => FieldDefinition::references(
-                Fixture\FixtureFactory\Entity\Repository::class,
+                Entity\Repository::class,
                 Count::between(0, 5)
             ),
         ]);
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
+        $fixtureFactory->define(Entity\Repository::class, [
             'name' => $faker->word,
         ]);
 
-        /** @var Fixture\FixtureFactory\Entity\Organization $organization */
-        $organization = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class, [
+        /** @var Entity\Organization $organization */
+        $organization = $fixtureFactory->createOne(Entity\Organization::class, [
             'repositories' => FieldDefinition::references(
-                Fixture\FixtureFactory\Entity\Repository::class,
+                Entity\Repository::class,
                 Count::exact($value)
             ),
         ]);
 
         $repositories = $organization->repositories();
 
-        self::assertContainsOnly(Fixture\FixtureFactory\Entity\Repository::class, $repositories);
+        self::assertContainsOnly(Entity\Repository::class, $repositories);
         self::assertCount($value, $repositories);
     }
 
@@ -1091,11 +1092,11 @@ final class FixtureFactoryTest extends AbstractTestCase
         );
 
         $fixtureFactory->define(
-            Fixture\FixtureFactory\Entity\Organization::class,
+            Entity\Organization::class,
             [
                 'name' => $name,
             ],
-            static function (Fixture\FixtureFactory\Entity\Organization $organization, array $fieldValues, Generator $faker): void {
+            static function (Entity\Organization $organization, array $fieldValues, Generator $faker): void {
                 $name = \sprintf(
                     '%s-%s-%d',
                     $organization->name(),
@@ -1107,8 +1108,8 @@ final class FixtureFactoryTest extends AbstractTestCase
             }
         );
 
-        /** @var Fixture\FixtureFactory\Entity\Organization $organization */
-        $organization = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Organization::class);
+        /** @var Entity\Organization $organization */
+        $organization = $fixtureFactory->createOne(Entity\Organization::class);
 
         $expectedPattern = \sprintf(
             '/^%s-%s-\d{2}$/',
@@ -1131,18 +1132,18 @@ final class FixtureFactoryTest extends AbstractTestCase
             $faker
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
+        $fixtureFactory->define(Entity\Organization::class);
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
+        $fixtureFactory->define(Entity\Repository::class, [
             'name' => $faker->word,
-            'organization' => FieldDefinition::reference(Fixture\FixtureFactory\Entity\Organization::class),
+            'organization' => FieldDefinition::reference(Entity\Organization::class),
         ]);
 
-        /** @var Fixture\FixtureFactory\Entity\Repository $repositoryOne */
-        $repositoryOne = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Repository::class);
+        /** @var Entity\Repository $repositoryOne */
+        $repositoryOne = $fixtureFactory->createOne(Entity\Repository::class);
 
-        /** @var Fixture\FixtureFactory\Entity\Repository $repositoryTwo */
-        $repositoryTwo = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Repository::class);
+        /** @var Entity\Repository $repositoryTwo */
+        $repositoryTwo = $fixtureFactory->createOne(Entity\Repository::class);
 
         $organizationOne = $repositoryOne->organization();
         $organizationTwo = $repositoryTwo->organization();
@@ -1159,28 +1160,28 @@ final class FixtureFactoryTest extends AbstractTestCase
             self::faker()
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
+        $fixtureFactory->define(Entity\Organization::class);
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Repository::class, [
-            'organization' => FieldDefinition::reference(Fixture\FixtureFactory\Entity\Organization::class),
+        $fixtureFactory->define(Entity\Repository::class, [
+            'organization' => FieldDefinition::reference(Entity\Organization::class),
         ]);
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Project::class, [
-            'repository' => FieldDefinition::reference(Fixture\FixtureFactory\Entity\Repository::class),
+        $fixtureFactory->define(Entity\Project::class, [
+            'repository' => FieldDefinition::reference(Entity\Repository::class),
         ]);
 
-        $project = $fixtureFactory->createOne(Fixture\FixtureFactory\Entity\Project::class);
+        $project = $fixtureFactory->createOne(Entity\Project::class);
 
-        self::assertInstanceOf(Fixture\FixtureFactory\Entity\Project::class, $project);
+        self::assertInstanceOf(Entity\Project::class, $project);
 
-        /** @var Fixture\FixtureFactory\Entity\Project $project */
+        /** @var Entity\Project $project */
         $repository = $project->repository();
 
-        self::assertInstanceOf(Fixture\FixtureFactory\Entity\Repository::class, $repository);
+        self::assertInstanceOf(Entity\Repository::class, $repository);
 
         $organization = $repository->organization();
 
-        self::assertInstanceOf(Fixture\FixtureFactory\Entity\Organization::class, $organization);
+        self::assertInstanceOf(Entity\Organization::class, $organization);
     }
 
     /**
@@ -1195,10 +1196,10 @@ final class FixtureFactoryTest extends AbstractTestCase
             self::faker()
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
+        $fixtureFactory->define(Entity\Organization::class);
 
         $entities = $fixtureFactory->createMany(
-            Fixture\FixtureFactory\Entity\Organization::class,
+            Entity\Organization::class,
             Count::exact($value)
         );
 
@@ -1217,10 +1218,10 @@ final class FixtureFactoryTest extends AbstractTestCase
             $faker
         );
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
+        $fixtureFactory->define(Entity\Organization::class);
 
         $entities = $fixtureFactory->createMany(
-            Fixture\FixtureFactory\Entity\Organization::class,
+            Entity\Organization::class,
             Count::between(
                 $minimum,
                 $maximum
@@ -1242,10 +1243,10 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         $value = $faker->numberBetween(1, 5);
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
+        $fixtureFactory->define(Entity\Organization::class);
 
         $entities = $fixtureFactory->createMany(
-            Fixture\FixtureFactory\Entity\Organization::class,
+            Entity\Organization::class,
             Count::exact($value),
             [
                 'isVerified' => true,
@@ -1254,7 +1255,7 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         self::assertCount($value, $entities);
 
-        $verifiedEntities = \array_filter($entities, static function (Fixture\FixtureFactory\Entity\Organization $organization): bool {
+        $verifiedEntities = \array_filter($entities, static function (Entity\Organization $organization): bool {
             return $organization->isVerified();
         });
 
@@ -1272,10 +1273,10 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         $value = $faker->numberBetween(1, 5);
 
-        $fixtureFactory->define(Fixture\FixtureFactory\Entity\Organization::class);
+        $fixtureFactory->define(Entity\Organization::class);
 
         $entities = $fixtureFactory->createMany(
-            Fixture\FixtureFactory\Entity\Organization::class,
+            Entity\Organization::class,
             Count::exact($value),
             [
                 'isVerified' => FieldDefinition::value(true),
@@ -1284,7 +1285,7 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         self::assertCount($value, $entities);
 
-        $verifiedEntities = \array_filter($entities, static function (Fixture\FixtureFactory\Entity\Organization $organization): bool {
+        $verifiedEntities = \array_filter($entities, static function (Entity\Organization $organization): bool {
             return $organization->isVerified();
         });
 

--- a/test/Util/Doctrine/ORM/EntityManagerFactory.php
+++ b/test/Util/Doctrine/ORM/EntityManagerFactory.php
@@ -21,7 +21,7 @@ final class EntityManagerFactory
     {
         $configuration = ORM\Tools\Setup::createAnnotationMetadataConfiguration(
             [
-                __DIR__ . '/../../../Fixture/FixtureFactory/Entity',
+                __DIR__ . '/../../../../example/src/Entity',
             ],
             true,
             null,


### PR DESCRIPTION
This PR

* [x] moves perfectly valid examples into the `examples/` directory