### PR TITLE
Fix: Require ramsey/uuid with patch version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "phpstan/phpstan-strict-rules": "~0.12.2",
     "phpunit/phpunit": "^8.5.8",
     "psalm/plugin-phpunit": "~0.10.1",
-    "ramsey/uuid": "^4.0",
+    "ramsey/uuid": "^4.0.1",
     "vimeo/psalm": "^3.12.2"
   },
   "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "468ff502ffe553fd9f2a90a87de2d02f",
+    "content-hash": "fa544b1f6263cf775750c0d12ec6b913",
     "packages": [
         {
             "name": "doctrine/annotations",


### PR DESCRIPTION
This PR

* [x] requires `ramsey/uuid` with patch version