### PR TITLE
Fix: Remove unused method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ For a full diff see [`0.1.0...main`][0.1.0...main].
 * Started throwing an `InvalidDefinition` exception when a definition is concrete but cannot be instantiated ([#301]), by [@localheinz]
 * Started throwing an `InvalidDefinition` exception when a definition cannot be autoloaded ([#302]), by [@localheinz]
 
+### Removed
+
+* Removed `FixtureFactory::definitions()` ([#321]), by [@localheinz]
+
 ## [`0.1.0`][0.1.0]
 
 For a full diff see [`fa9c564...0.1.0`][fa9c564...0.1.0].
@@ -154,5 +158,6 @@ For a full diff see [`fa9c564...0.1.0`][fa9c564...0.1.0].
 [#311]: https://github.com/ergebnis/factory-bot/pull/311
 [#312]: https://github.com/ergebnis/factory-bot/pull/312
 [#314]: https://github.com/ergebnis/factory-bot/pull/314
+[#321]: https://github.com/ergebnis/factory-bot/pull/321
 
 [@localheinz]: https://github.com/localheinz

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -326,14 +326,6 @@ final class FixtureFactory
     }
 
     /**
-     * @return array<string, EntityDefinition>
-     */
-    public function definitions(): array
-    {
-        return $this->entityDefinitions;
-    }
-
-    /**
      * @param array<string, \Closure|FieldDefinition\Resolvable|mixed> $fieldDefinitions
      *
      * @return array<string, FieldDefinition\Resolvable>

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -47,16 +47,6 @@ use Faker\Generator;
  */
 final class FixtureFactoryTest extends AbstractTestCase
 {
-    public function testDefaults(): void
-    {
-        $fixtureFactory = new FixtureFactory(
-            self::entityManager(),
-            self::faker()
-        );
-
-        self::assertCount(0, $fixtureFactory->definitions());
-    }
-
     public function testDefineThrowsEntityDefinitionAlreadyRegisteredExceptionWhenDefinitionHasAlreadyBeenProvidedForEntity(): void
     {
         $fixtureFactory = new FixtureFactory(


### PR DESCRIPTION
This PR

* [x] removes an unused method

Follows #313.