### PR TITLE
Fix: Populate template as optional reference

### DIFF
--- a/example/test/Fixture/Entity/RepositoryDefinitionProvider.php
+++ b/example/test/Fixture/Entity/RepositoryDefinitionProvider.php
@@ -30,6 +30,7 @@ final class RepositoryDefinitionProvider implements FactoryBot\EntityDefinitionP
                 return $faker->word;
             }),
             'organization' => FactoryBot\FieldDefinition::reference(Entity\Organization::class),
+            'template' => FactoryBot\FieldDefinition::optionalReference(Entity\Repository::class),
         ]);
     }
 }


### PR DESCRIPTION
This PR

* [x] populates the `template` field as optional reference to an `Entity\Repository`