### PR TITLE
Fix: Signature of closure

### DIFF
--- a/test/Unit/FieldDefinitionTest.php
+++ b/test/Unit/FieldDefinitionTest.php
@@ -18,6 +18,7 @@ use Ergebnis\FactoryBot\Exception;
 use Ergebnis\FactoryBot\FieldDefinition;
 use Ergebnis\FactoryBot\FixtureFactory;
 use Example\Entity;
+use Faker\Generator;
 
 /**
  * @internal
@@ -38,7 +39,7 @@ final class FieldDefinitionTest extends AbstractTestCase
 {
     public function testClosureReturnsRequiredClosure(): void
     {
-        $closure = static function (FixtureFactory $fixtureFactory): Entity\User {
+        $closure = static function (Generator $faker, FixtureFactory $fixtureFactory): Entity\User {
             /** @var Entity\User $user */
             $user = $fixtureFactory->createOne(Entity\User::class);
 
@@ -56,7 +57,7 @@ final class FieldDefinitionTest extends AbstractTestCase
 
     public function testOptionalClosureReturnsOptionalClosure(): void
     {
-        $closure = static function (FixtureFactory $fixtureFactory): Entity\User {
+        $closure = static function (Generator $faker, FixtureFactory $fixtureFactory): Entity\User {
             /** @var Entity\User $user */
             $user = $fixtureFactory->createOne(Entity\User::class);
 

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -503,7 +503,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         $fixtureFactory->define(Entity\CodeOfConduct::class);
 
         $fixtureFactory->define(Entity\Repository::class, [
-            'codeOfConduct' => FieldDefinition::optionalClosure(static function (FixtureFactory $fixtureFactory): Entity\CodeOfConduct {
+            'codeOfConduct' => FieldDefinition::optionalClosure(static function (Generator $faker, FixtureFactory $fixtureFactory): Entity\CodeOfConduct {
                 return $fixtureFactory->createOne(Entity\CodeOfConduct::class);
             }),
         ]);


### PR DESCRIPTION
This PR

* [x] fixes the signatures of closures used in optional field definitions that are not invoked in tests