### PR TITLE
Enhancement: Implement WithOptionalStrategy

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -9,8 +9,8 @@ on: # yamllint disable-line rule:truthy
       - "main"
 
 env:
-  MIN_COVERED_MSI: 99
-  MIN_MSI: 99
+  MIN_COVERED_MSI: 98
+  MIN_MSI: 98
   PHP_EXTENSIONS: "mbstring"
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`0.2.1...main`][0.2.1...main].
 
+### Added
+
+* Implemented a `WithOptionalStrategy` ([#365]), by [@localheinz]
+
 ### Changed
 
 * Moved resolution of `Count` to `FixtureFactory` ([#351]), by [@localheinz]
@@ -183,5 +187,6 @@ For a full diff see [`fa9c564...0.1.0`][fa9c564...0.1.0].
 [#338]: https://github.com/ergebnis/factory-bot/pull/338
 [#351]: https://github.com/ergebnis/factory-bot/pull/351
 [#353]: https://github.com/ergebnis/factory-bot/pull/353
+[#365]: https://github.com/ergebnis/factory-bot/pull/365
 
 [@localheinz]: https://github.com/localheinz

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-MIN_COVERED_MSI:=99
-MIN_MSI:=99
+MIN_COVERED_MSI:=98
+MIN_MSI:=98
 
 .PHONY: it
 it: coding-standards static-code-analysis tests tests-example ## Runs the coding-standards, static-code-analysis, tests, and tests-example targets

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ $closure = static function (Generator $faker, FactoryBot\FixtureFactory $fixture
 };
 ```
 
-The fixture factory will resolve the field definition to `null` or to the return value of invoking the closure with the instance of `Faker\Generator` composed into the fixture factory.
+A fixture factory using the [`DefaultStrategy`](#defaultstrategy) will resolve the field definition to `null` or to the return value of invoking the closure with the instance of `Faker\Generator` composed into the fixture factory.
 
 ```php
 <?php
@@ -330,11 +330,35 @@ $user = $fixtureFactory->createOne(Entity\User::class);
 var_dump($user->location()); // null or a random city
 ```
 
+A fixture factory using the [`WithOptionalStrategy`](#withoptionalstrategy) will resolve the field definition to the return value of invoking the closure with the instance of `Faker\Generator` composed into the fixture factory.
+
+```php
+<?php
+
+use Ergebnis\FactoryBot;
+use Example\Entity;
+use Faker\Generator;
+
+/** @var FactoryBot\FixtureFactory $fixtureFactory */
+$fixtureFactory->define(Entity\User::class, [
+    'location' => FactoryBot\FieldDefinition::optionalClosure(static function (Generator $faker): string {
+        return $faker->city;
+    }),
+]);
+
+$withOptionalFixtureFactory = $fixtureFactory->withOptional();
+
+/** @var Entity\User $user */
+$user = $withOptionalFixtureFactory->createOne(Entity\User::class);
+
+var_dump($user->location()); // a random city
+```
+
 ##### `FieldDefinition::reference()`
 
 `FieldDefinition::reference()` accepts the class name of an entity or embeddable.
 
-The fixture factory will resolve the field definition to an instance of the entity or embeddable class populated through the fixture factory.
+Every fixture factory will resolve the field definition to an instance of the entity or embeddable class populated through the fixture factory.
 
 ```php
 <?php
@@ -359,7 +383,7 @@ var_dump($user->avatar()); // an instance of Entity\Avatar
 
 `FieldDefinition::optionalReference()` accepts the class name of an entity or embeddable.
 
-The fixture factory will resolve the field definition to `null` or to an instance of the entity or embeddable class populated through the fixture factory.
+A fixture factory using the [`DefaultStrategy`](#defaultstrategy)] will resolve the field definition to `null` or to an instance of the entity or embeddable class populated through the fixture factory.
 
 ```php
 <?php
@@ -376,6 +400,27 @@ $fixtureFactory->define(Entity\Repository::class, [
 $repository = $fixtureFactory->createOne(Entity\Repository::class);
 
 var_dump($repository->template()); // null or an instance of Entity\Repository
+```
+
+A fixture factory using the [`WithOptionalStrategy`](#withoptionalstrategy)] will resolve the field definition to an instance of the entity or embeddable class populated through the fixture factory.
+
+```php
+<?php
+
+use Ergebnis\FactoryBot;
+use Example\Entity;
+
+/** @var FactoryBot\FixtureFactory $fixtureFactory */
+$fixtureFactory->define(Entity\Repository::class, [
+    'template' => FactoryBot\FieldDefinition::optionalReference(Entity\Repository::class),
+]);
+
+$withOptionalFixtureFactory = $fixtureFactory->withOptional();
+
+/** @var Entity\Repository $repository */
+$repository = $withOptionalFixtureFactory->createOne(Entity\Repository::class);
+
+var_dump($repository->template()); // an instance of Entity\Repository
 ```
 
 :exclamation: When resolving the reference, the fixture factory needs to be aware of the referenced entity or embeddable.
@@ -401,7 +446,7 @@ $otherCount = FactoryBot\Count::between(
 
 :bulb: When you create the count from minimum and maximum values, the fixture factory will resolve its actual value before creating references. This way, you can have variation in the number of references - any number between the minimum and maximum can be assumed.
 
-The fixture factory will resolve the field definition to an array of instances of the entity or embeddable class populated through the fixture factory.
+A fixture factory using the [`DefaultStrategy`](#defaultstrategy) will resolve the field definition to an array of instances of the entity or embeddable class populated through the fixture factory. Depending on the value of `$count`, the array might be empty.
 
 ```php
 <?php
@@ -428,13 +473,42 @@ var_dump($organization->members());      // array with 5 instances of Entity\Use
 var_dump($organization->repositories()); // array with 0-20 instances of Entity\Repository
 ```
 
+A fixture factory using the [`WithOptionalStrategy`](#withoptionalstrategy) will resolve the field definition to an array of instances of the entity or embeddable class populated through the fixture factory. The array will contain at least one reference.
+
+```php
+<?php
+
+use Ergebnis\FactoryBot;
+use Example\Entity;
+
+/** @var FactoryBot\FixtureFactory $fixtureFactory */
+$fixtureFactory->define(Entity\Organization::class, [
+    'members' => FactoryBot\FieldDefinition::references(
+        Entity\User::class,
+        FactoryBot\Count::exact(5)
+    ),
+    'repositories' => FactoryBot\FieldDefinition::references(
+        Entity\Repository::class,
+        FactoryBot\Count::between(0, 20)
+    ),
+]);
+
+$withOptionalFixtureFactory = $fixtureFactory->withOptional();
+
+/** @var Entity\Organization $organization */
+$organization = $withOptionalFixtureFactory->createOne(Entity\Organization::class);
+
+var_dump($organization->members());      // array with 5 instances of Entity\User
+var_dump($organization->repositories()); // array with 1-20 instances of Entity\Repository
+```
+
 :exclamation: When resolving the references, the fixture factory needs to be aware of the referenced entity or embeddable.
 
 ##### `FieldDefinition::sequence()`
 
 `FieldDefinition::sequence()` accepts a string containing the `%d` placeholder at least once and an optional initial number (defaults to `1`).
 
-The fixture factory will resolve the field definition by replacing all occurrences of the placeholder `%d` in the string with the sequential number's current value. The sequential number will then be incremented by `1` for the next run.
+Every fixture factory will resolve the field definition by replacing all occurrences of the placeholder `%d` in the string with the sequential number's current value. The sequential number will then be incremented by `1` for the next run.
 
 ```php
 <?php
@@ -464,7 +538,7 @@ var_dump($userTwo->login()); // 'user-2'
 
 `FieldDefinition::optionalSequence()` accepts a string containing the `%d` placeholder at least once and an optional initial number (defaults to `1`).
 
-The fixture factory will resolve the field definition to `null` or by replacing all occurrences of the placeholder `%d` in the string with the sequential number's current value. The sequential number will then be incremented by `1` for the next run.
+A fixture factory using the [`DefaultStrategy`](#defaultstrategy) will resolve the field definition to `null` or by replacing all occurrences of the placeholder `%d` in the string with the sequential number's current value. The sequential number will then be incremented by `1` for the next run.
 
 ```php
 <?php
@@ -488,6 +562,34 @@ $userTwo = $fixtureFactory->createOne(Entity\User::class);
 
 var_dump($userOne->location()); // null or 'City 1'
 var_dump($userTwo->location()); // null or 'City 1' or 'City 2'
+```
+
+A fixture factory using the [`WithOptionalStrategy`](#withoptionalstrategy) will resolve the field definition by replacing all occurrences of the placeholder `%d` in the string with the sequential number's current value. The sequential number will then be incremented by `1` for the next run.
+
+```php
+<?php
+
+use Ergebnis\FactoryBot;
+use Example\Entity;
+
+/** @var FactoryBot\FixtureFactory $fixtureFactory */
+$fixtureFactory->define(Entity\User::class, [
+    'location' => FactoryBot\FieldDefinition::optionalSequence(
+        'City %d',
+        1
+    ),
+]);
+
+$withOptionalFixtureFactory = $fixtureFactory->withOptional();
+
+/** @var Entity\User $userOne */
+$userOne = $withOptionalFixtureFactory->createOne(Entity\User::class);
+
+/** @var Entity\User $userTwo */
+$userTwo = $withOptionalFixtureFactory->createOne(Entity\User::class);
+
+var_dump($userOne->location()); // 'City 1'
+var_dump($userTwo->location()); // 'City 2'
 ```
 
 ##### `FieldDefinition::value()`
@@ -536,7 +638,7 @@ var_dump($user->login()); // 'localheinz'
 
 `FieldDefinition::optionalValue()` accepts an arbitrary value.
 
-The fixture factory will resolve the field definition to `null` or the value.
+A fixture factory using the [`DefaultStrategy`](#defaultstrategy) will resolve the field definition to `null` or the value.
 
 ```php
 <?php
@@ -553,6 +655,27 @@ $fixtureFactory->define(Entity\User::class, [
 $user = $fixtureFactory->create(Entity\User::class);
 
 var_dump($user->location()); // null or 'Berlin'
+```
+
+A fixture factory using the [`WithOptionalStrategy`](#withoptionalstrategy) will resolve the field definition to the value.
+
+```php
+<?php
+
+use Ergebnis\FactoryBot;
+use Example\Entity;
+
+/** @var FactoryBot\FixtureFactory $fixtureFactory */
+$fixtureFactory->define(Entity\User::class, [
+    'location' => FactoryBot\FieldDefinition::optionalValue('Berlin'),
+]);
+
+$withOptionalFixtureFactory = $fixtureFactory->withOptional();
+
+/** @var Entity\User $user */
+$user = $withOptionalFixtureFactory->create(Entity\User::class);
+
+var_dump($user->location()); // 'Berlin'
 ```
 
 ### Loading entity definitions
@@ -615,6 +738,41 @@ abstract class AbstractTestCase extends Framework\TestCase
 ### Creating entities
 
 Now that you have created (or loaded) entity definitions, you can create Doctrine entities populated with fake data.
+
+#### `DefaultStrategy`
+
+The fixture factory uses a `DefaultStrategy` for resolving field definitions.
+
+This strategy involves random behavior, and
+
+- [`FieldDefinition::optionalClosure()`](#fielddefinitionoptionalclosure) might be resolved to `null` a concrete value
+- [`FieldDefinition::optionalReference()`](#fielddefinitionoptionalreference) might be resolved to `null` or a concrete reference
+- [`FieldDefinition::optionalSequence()`](#fielddefinitionoptionalsequence) might be resolved to `null` or a concrete value
+- [`FieldDefinition::optionalValue()`](#fielddefinitionoptionalvalue) might be resolved to `null` or a concrete value
+- [`FieldDefinition::references()`](#fielddefinitionreferences) might be resolved to an empty `array` or an `array` of references
+
+:bulb: You might have a scenario where you have entity definitions that use optional field definitions, but would like to create an entity where these optional field definitions are resolved to concrete values or references. In this case you can use a fixture factory with the `WithOptionalStrategy`.
+
+#### `WithOptionalStrategy`
+
+To create a fixture factory using the `WithOptionalStrategy` out of an available fixture factory, invoke `withOptional()`:
+
+```php
+<?php
+
+use Ergebnis\FactoryBot;
+
+/** @var FactoryBot\FixtureFactory $fixtureFactory */
+$withOptionalFixtureFactory = $fixtureFactory->withOptional();
+```
+
+This strategy still involves random behavior, but
+
+- [`FieldDefinition::optionalClosure()`](#fielddefinitionoptionalclosure) will be resolved to a concrete value
+- [`FieldDefinition::optionalReference()`](#fielddefinitionoptionalreference) will be resolved to a concrete value
+- [`FieldDefinition::optionalSequence()`](#fielddefinitionoptionalsequence) will be resolved to a concrete value
+- [`FieldDefinition::optionalValue()`](#fielddefinitionoptionalvalue) will be resolved to a concrete value
+- [`FieldDefinition::references()`](#fielddefinitionreferences) will be resolved to a non-empty `array`
 
 #### `FixtureFactory::createOne()`
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -240,4 +240,12 @@
       <code>$expected</code>
     </MixedAssignment>
   </file>
+  <file src="test/Unit/Strategy/WithOptionalStrategyTest.php">
+    <MixedAssignment occurrences="4">
+      <code>$resolved</code>
+      <code>$expected</code>
+      <code>$resolved</code>
+      <code>$expected</code>
+    </MixedAssignment>
+  </file>
 </files>

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -313,6 +313,25 @@ final class FixtureFactory
     }
 
     /**
+     * Returns a fixture factory that utilizes the WithOptionalStrategy.
+     *
+     * With this strategy
+     *
+     * - an optional reference is always resolved
+     * - references resolve to an array containing at least one reference
+     *
+     * @return self
+     */
+    public function withOptional(): self
+    {
+        $instance = clone $this;
+
+        $instance->resolutionStrategy = new Strategy\WithOptionalStrategy();
+
+        return $instance;
+    }
+
+    /**
      * Enables persisting of entities after creation.
      */
     public function persistAfterCreate(): void

--- a/src/Strategy/WithOptionalStrategy.php
+++ b/src/Strategy/WithOptionalStrategy.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/factory-bot
+ */
+
+namespace Ergebnis\FactoryBot\Strategy;
+
+use Ergebnis\FactoryBot\Count;
+use Ergebnis\FactoryBot\FieldDefinition;
+use Ergebnis\FactoryBot\FixtureFactory;
+use Faker\Generator;
+
+/**
+ * @internal
+ */
+final class WithOptionalStrategy implements ResolutionStrategy
+{
+    public function resolveFieldValue(
+        Generator $faker,
+        FixtureFactory $fixtureFactory,
+        FieldDefinition\Resolvable $fieldDefinition
+    ) {
+        return $fieldDefinition->resolve(
+            $faker,
+            $fixtureFactory
+        );
+    }
+
+    public function resolveCount(Generator $faker, Count $count): int
+    {
+        if ($count->minimum() === $count->maximum()) {
+            return $count->minimum();
+        }
+
+        $resolved = $faker->numberBetween(
+            $count->minimum(),
+            $count->maximum()
+        );
+
+        if (0 === $resolved) {
+            return 1;
+        }
+
+        return $resolved;
+    }
+}

--- a/test/Unit/FixtureFactory/UsingWithOptionalStrategyTest.php
+++ b/test/Unit/FixtureFactory/UsingWithOptionalStrategyTest.php
@@ -1,0 +1,544 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/factory-bot
+ */
+
+namespace Ergebnis\FactoryBot\Test\Unit\FixtureFactory;
+
+use Ergebnis\FactoryBot\Count;
+use Ergebnis\FactoryBot\FieldDefinition;
+use Ergebnis\FactoryBot\FixtureFactory;
+use Ergebnis\FactoryBot\Test\Double;
+use Ergebnis\FactoryBot\Test\Unit;
+use Example\Entity;
+use Faker\Generator;
+
+/**
+ * @internal
+ *
+ * @covers \Ergebnis\FactoryBot\FixtureFactory
+ *
+ * @uses \Ergebnis\FactoryBot\Count
+ * @uses \Ergebnis\FactoryBot\EntityDefinition
+ * @uses \Ergebnis\FactoryBot\FieldDefinition
+ * @uses \Ergebnis\FactoryBot\FieldDefinition\Closure
+ * @uses \Ergebnis\FactoryBot\FieldDefinition\Optional
+ * @uses \Ergebnis\FactoryBot\FieldDefinition\Reference
+ * @uses \Ergebnis\FactoryBot\FieldDefinition\References
+ * @uses \Ergebnis\FactoryBot\FieldDefinition\Sequence
+ * @uses \Ergebnis\FactoryBot\FieldDefinition\Value
+ * @uses \Ergebnis\FactoryBot\Strategy\DefaultStrategy
+ * @uses \Ergebnis\FactoryBot\Strategy\WithOptionalStrategy
+ */
+final class UsingWithOptionalStrategyTest extends Unit\AbstractTestCase
+{
+    public function testCreateOneResolvesOptionalClosureToResultOfClosureInvokedWithFakerAndFixtureFactoryWhenFakerReturnsFalse(): void
+    {
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\FalseGenerator()
+        );
+
+        $fixtureFactory->define(Entity\CodeOfConduct::class);
+
+        $fixtureFactory->define(Entity\Repository::class, [
+            'codeOfConduct' => FieldDefinition::optionalClosure(static function (Generator $faker, FixtureFactory $fixtureFactory): Entity\CodeOfConduct {
+                return $fixtureFactory->createOne(Entity\CodeOfConduct::class);
+            }),
+        ]);
+
+        $withOptionalFixtureFactory = $fixtureFactory->withOptional();
+
+        /** @var Entity\Repository $repository */
+        $repository = $withOptionalFixtureFactory->createOne(Entity\Repository::class);
+
+        self::assertInstanceOf(Entity\CodeOfConduct::class, $repository->codeOfConduct());
+    }
+
+    public function testCreateOneResolvesOptionalClosureToResultOfClosureInvokedWithFakerAndFixtureFactoryWhenFakerReturnsTrue(): void
+    {
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\TrueGenerator()
+        );
+
+        $fixtureFactory->define(Entity\CodeOfConduct::class);
+
+        $fixtureFactory->define(Entity\Repository::class, [
+            'codeOfConduct' => FieldDefinition::optionalClosure(static function (Generator $faker, FixtureFactory $fixtureFactory): Entity\CodeOfConduct {
+                return $fixtureFactory->createOne(Entity\CodeOfConduct::class);
+            }),
+        ]);
+
+        $withOptionalFixtureFactory = $fixtureFactory->withOptional();
+
+        /** @var Entity\Repository $repository */
+        $repository = $withOptionalFixtureFactory->createOne(Entity\Repository::class);
+
+        self::assertInstanceOf(Entity\CodeOfConduct::class, $repository->codeOfConduct());
+    }
+
+    public function testCreateOneResolvesRequiredClosureToResultOfClosureInvokedWithFakerAndFixtureFactoryWhenFakerReturnsFalse(): void
+    {
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\FalseGenerator()
+        );
+
+        $fixtureFactory->define(Entity\CodeOfConduct::class);
+
+        $fixtureFactory->define(Entity\Repository::class, [
+            'codeOfConduct' => FieldDefinition::closure(static function (Generator $faker, FixtureFactory $fixtureFactory): Entity\CodeOfConduct {
+                return $fixtureFactory->createOne(Entity\CodeOfConduct::class);
+            }),
+        ]);
+
+        $withOptionalFixtureFactory = $fixtureFactory->withOptional();
+
+        /** @var Entity\Repository $repository */
+        $repository = $withOptionalFixtureFactory->createOne(Entity\Repository::class);
+
+        self::assertInstanceOf(Entity\CodeOfConduct::class, $repository->codeOfConduct());
+    }
+
+    public function testCreateOneResolvesRequiredClosureToResultOfClosureInvokedWithFakerAndFixtureFactoryWhenFakerReturnsTrue(): void
+    {
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\TrueGenerator()
+        );
+
+        $fixtureFactory->define(Entity\CodeOfConduct::class);
+
+        $fixtureFactory->define(Entity\Repository::class, [
+            'codeOfConduct' => FieldDefinition::closure(static function (Generator $faker, FixtureFactory $fixtureFactory): Entity\CodeOfConduct {
+                return $fixtureFactory->createOne(Entity\CodeOfConduct::class);
+            }),
+        ]);
+
+        $withOptionalFixtureFactory = $fixtureFactory->withOptional();
+
+        /** @var Entity\Repository $repository */
+        $repository = $withOptionalFixtureFactory->createOne(Entity\Repository::class);
+
+        self::assertInstanceOf(Entity\CodeOfConduct::class, $repository->codeOfConduct());
+    }
+
+    public function testCreateOneResolvesOptionalReferenceToEntityWhenFakerReturnsFalse(): void
+    {
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\FalseGenerator()
+        );
+
+        $fixtureFactory->define(Entity\CodeOfConduct::class);
+
+        $fixtureFactory->define(Entity\Repository::class, [
+            'codeOfConduct' => FieldDefinition::optionalReference(Entity\CodeOfConduct::class),
+        ]);
+
+        $withOptionalFixtureFactory = $fixtureFactory->withOptional();
+
+        /** @var Entity\Repository $repository */
+        $repository = $withOptionalFixtureFactory->createOne(Entity\Repository::class);
+
+        self::assertInstanceOf(Entity\CodeOfConduct::class, $repository->codeOfConduct());
+    }
+
+    public function testCreateOneResolvesOptionalReferenceToEntityWhenFakerReturnsTrue(): void
+    {
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\TrueGenerator()
+        );
+
+        $fixtureFactory->define(Entity\CodeOfConduct::class);
+
+        $fixtureFactory->define(Entity\Repository::class, [
+            'codeOfConduct' => FieldDefinition::optionalReference(Entity\CodeOfConduct::class),
+        ]);
+
+        $withOptionalFixtureFactory = $fixtureFactory->withOptional();
+
+        /** @var Entity\Repository $repository */
+        $repository = $withOptionalFixtureFactory->createOne(Entity\Repository::class);
+
+        self::assertInstanceOf(Entity\CodeOfConduct::class, $repository->codeOfConduct());
+    }
+
+    public function testCreateOneResolvesRequiredReferenceToEntityWhenFakerReturnsFalse(): void
+    {
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\FalseGenerator()
+        );
+
+        $fixtureFactory->define(Entity\CodeOfConduct::class);
+
+        $fixtureFactory->define(Entity\Repository::class, [
+            'codeOfConduct' => FieldDefinition::reference(Entity\CodeOfConduct::class),
+        ]);
+
+        $withOptionalFixtureFactory = $fixtureFactory->withOptional();
+
+        /** @var Entity\Repository $repository */
+        $repository = $withOptionalFixtureFactory->createOne(Entity\Repository::class);
+
+        self::assertInstanceOf(Entity\CodeOfConduct::class, $repository->codeOfConduct());
+    }
+
+    public function testCreateOneResolvesRequiredReferenceToEntityWhenFakerReturnsTrue(): void
+    {
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\TrueGenerator()
+        );
+
+        $fixtureFactory->define(Entity\CodeOfConduct::class);
+
+        $fixtureFactory->define(Entity\Repository::class, [
+            'codeOfConduct' => FieldDefinition::reference(Entity\CodeOfConduct::class),
+        ]);
+
+        $withOptionalFixtureFactory = $fixtureFactory->withOptional();
+
+        /** @var Entity\Repository $repository */
+        $repository = $withOptionalFixtureFactory->createOne(Entity\Repository::class);
+
+        self::assertInstanceOf(Entity\CodeOfConduct::class, $repository->codeOfConduct());
+    }
+
+    /**
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::greaterThanOrEqualToZero()
+     *
+     * @param int $value
+     */
+    public function testCreateOneResolvesRequiredReferencesToArrayCollectionOfEntitiesWhenFakerReturnsFalseAndCountIsExact(int $value): void
+    {
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\FalseGenerator()
+        );
+
+        $fixtureFactory->define(Entity\Organization::class, [
+            'repositories' => FieldDefinition::references(
+                Entity\Repository::class,
+                Count::exact($value)
+            ),
+        ]);
+
+        $fixtureFactory->define(Entity\Repository::class, [
+            'name' => self::faker()->word,
+        ]);
+
+        $withOptionalFixtureFactory = $fixtureFactory->withOptional();
+
+        /** @var Entity\Organization $organization */
+        $organization = $withOptionalFixtureFactory->createOne(Entity\Organization::class);
+
+        self::assertContainsOnly(Entity\Repository::class, $organization->repositories());
+        self::assertCount($value, $organization->repositories());
+    }
+
+    /**
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::greaterThanOrEqualToZero()
+     *
+     * @param int $value
+     */
+    public function testCreateOneResolvesRequiredReferencesToArrayCollectionOfEntitiesWhenFakerReturnsTrueAndCountIsExact(int $value): void
+    {
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\TrueGenerator()
+        );
+
+        $fixtureFactory->define(Entity\Organization::class, [
+            'repositories' => FieldDefinition::references(
+                Entity\Repository::class,
+                Count::exact($value)
+            ),
+        ]);
+
+        $fixtureFactory->define(Entity\Repository::class, [
+            'name' => self::faker()->word,
+        ]);
+
+        $withOptionalFixtureFactory = $fixtureFactory->withOptional();
+
+        /** @var Entity\Organization $organization */
+        $organization = $withOptionalFixtureFactory->createOne(Entity\Organization::class);
+
+        $repositories = $organization->repositories();
+
+        self::assertContainsOnly(Entity\Repository::class, $repositories);
+        self::assertCount($value, $repositories);
+    }
+
+    public function testCreateOneResolvesRequiredReferencesToArrayCollectionOfEntitiesWhenFakerReturnsFalseAndCountIsBetween(): void
+    {
+        $faker = self::faker();
+
+        $minimum = $faker->numberBetween(1, 5);
+        $maximum = $faker->numberBetween(10, 20);
+
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\FalseGenerator()
+        );
+
+        $fixtureFactory->define(Entity\Organization::class, [
+            'repositories' => FieldDefinition::references(
+                Entity\Repository::class,
+                Count::between(
+                    $minimum,
+                    $maximum
+                )
+            ),
+        ]);
+
+        $fixtureFactory->define(Entity\Repository::class, [
+            'name' => self::faker()->word,
+        ]);
+
+        $withOptionalFixtureFactory = $fixtureFactory->withOptional();
+
+        /** @var Entity\Organization $organization */
+        $organization = $withOptionalFixtureFactory->createOne(Entity\Organization::class);
+
+        self::assertContainsOnly(Entity\Repository::class, $organization->repositories());
+        self::assertGreaterThanOrEqual($minimum, \count($organization->repositories()));
+        self::assertLessThanOrEqual($maximum, \count($organization->repositories()));
+    }
+
+    public function testCreateOneResolvesRequiredReferencesToArrayCollectionOfEntitiesWhenFakerReturnsTrueAndCountIsBetween(): void
+    {
+        $faker = self::faker();
+
+        $minimum = $faker->numberBetween(1, 5);
+        $maximum = $faker->numberBetween(10, 20);
+
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\TrueGenerator()
+        );
+
+        $fixtureFactory->define(Entity\Organization::class, [
+            'repositories' => FieldDefinition::references(
+                Entity\Repository::class,
+                Count::between(
+                    $minimum,
+                    $maximum
+                )
+            ),
+        ]);
+
+        $fixtureFactory->define(Entity\Repository::class, [
+            'name' => self::faker()->word,
+        ]);
+
+        $withOptionalFixtureFactory = $fixtureFactory->withOptional();
+
+        /** @var Entity\Organization $organization */
+        $organization = $withOptionalFixtureFactory->createOne(Entity\Organization::class);
+
+        self::assertContainsOnly(Entity\Repository::class, $organization->repositories());
+        self::assertGreaterThanOrEqual($minimum, \count($organization->repositories()));
+        self::assertLessThanOrEqual($maximum, \count($organization->repositories()));
+    }
+
+    public function testCreateOneResolvesOptionalSequenceToToStringValueWhenPercentDPlaceholderIsPresentAndFakerReturnsFalse(): void
+    {
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\FalseGenerator()
+        );
+
+        $fixtureFactory->define(Entity\User::class, [
+            'location' => FieldDefinition::optionalSequence('City (%d)'),
+        ]);
+
+        $withOptionalFixtureFactory = $fixtureFactory->withOptional();
+
+        /** @var Entity\User $userOne */
+        $userOne = $withOptionalFixtureFactory->createOne(Entity\User::class);
+
+        /** @var Entity\User $userTwo */
+        $userTwo = $withOptionalFixtureFactory->createOne(Entity\User::class);
+
+        /** @var Entity\User $userThree */
+        $userThree = $withOptionalFixtureFactory->createOne(Entity\User::class);
+
+        self::assertSame('City (1)', $userOne->location());
+        self::assertSame('City (2)', $userTwo->location());
+        self::assertSame('City (3)', $userThree->location());
+    }
+
+    public function testCreateOneResolvesOptionalSequenceToStringValueWhenPercentDPlaceholderIsPresentAndFakerReturnsTrue(): void
+    {
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\TrueGenerator()
+        );
+
+        $fixtureFactory->define(Entity\User::class, [
+            'location' => FieldDefinition::optionalSequence('City (%d)'),
+        ]);
+
+        $withOptionalFixtureFactory = $fixtureFactory->withOptional();
+
+        /** @var Entity\User $userOne */
+        $userOne = $withOptionalFixtureFactory->createOne(Entity\User::class);
+
+        /** @var Entity\User $userTwo */
+        $userTwo = $withOptionalFixtureFactory->createOne(Entity\User::class);
+
+        /** @var Entity\User $userThree */
+        $userThree = $withOptionalFixtureFactory->createOne(Entity\User::class);
+
+        self::assertSame('City (1)', $userOne->location());
+        self::assertSame('City (2)', $userTwo->location());
+        self::assertSame('City (3)', $userThree->location());
+    }
+
+    public function testCreateOneResolvesRequiredSequenceToStringValueWhenPercentDPlaceholderIsPresentAndFakerReturnsFalse(): void
+    {
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\FalseGenerator()
+        );
+
+        $fixtureFactory->define(Entity\User::class, [
+            'location' => FieldDefinition::sequence('City (%d)'),
+        ]);
+
+        $withOptionalFixtureFactory = $fixtureFactory->withOptional();
+
+        /** @var Entity\User $userOne */
+        $userOne = $withOptionalFixtureFactory->createOne(Entity\User::class);
+
+        /** @var Entity\User $userTwo */
+        $userTwo = $withOptionalFixtureFactory->createOne(Entity\User::class);
+
+        /** @var Entity\User $userThree */
+        $userThree = $withOptionalFixtureFactory->createOne(Entity\User::class);
+
+        self::assertSame('City (1)', $userOne->location());
+        self::assertSame('City (2)', $userTwo->location());
+        self::assertSame('City (3)', $userThree->location());
+    }
+
+    public function testCreateOneResolvesRequiredSequenceToStringValueWhenPercentDPlaceholderIsPresentAndFakerReturnsTrue(): void
+    {
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\TrueGenerator()
+        );
+
+        $fixtureFactory->define(Entity\User::class, [
+            'location' => FieldDefinition::sequence('City (%d)'),
+        ]);
+
+        $withOptionalFixtureFactory = $fixtureFactory->withOptional();
+
+        /** @var Entity\User $userOne */
+        $userOne = $withOptionalFixtureFactory->createOne(Entity\User::class);
+
+        /** @var Entity\User $userTwo */
+        $userTwo = $withOptionalFixtureFactory->createOne(Entity\User::class);
+
+        /** @var Entity\User $userThree */
+        $userThree = $withOptionalFixtureFactory->createOne(Entity\User::class);
+
+        self::assertSame('City (1)', $userOne->location());
+        self::assertSame('City (2)', $userTwo->location());
+        self::assertSame('City (3)', $userThree->location());
+    }
+
+    /**
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::greaterThanOrEqualToZero()
+     *
+     * @param int $value
+     */
+    public function testCreateManyResolvesToArrayOfEntitiesWhenCountIsExact(int $value): void
+    {
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            self::faker()
+        );
+
+        $fixtureFactory->define(Entity\Organization::class);
+
+        $withOptionalFixtureFactory = $fixtureFactory->withOptional();
+
+        $entities = $withOptionalFixtureFactory->createMany(
+            Entity\Organization::class,
+            Count::exact($value)
+        );
+
+        self::assertCount($value, $entities);
+    }
+
+    public function testCreateManyResolvesToNonEmptyArrayOfEntitiesWhenCountIsBetweenMinimumIsZeroAndFakerReturnsMinimum(): void
+    {
+        $minimum = 0;
+        $maximum = 10;
+
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\MinimumGenerator()
+        );
+
+        $fixtureFactory->define(Entity\Organization::class);
+
+        $withOptionalFixtureFactory = $fixtureFactory->withOptional();
+
+        $entities = $withOptionalFixtureFactory->createMany(
+            Entity\Organization::class,
+            Count::between(
+                $minimum,
+                $maximum
+            )
+        );
+
+        self::assertCount(1, $entities);
+    }
+
+    /**
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::greaterThanOrEqualToZero()
+     *
+     * @param int $minimum
+     */
+    public function testCreateManyResolvesToNonEmptyArrayOfEntitiesWhenCountIsBetween(int $minimum): void
+    {
+        $maximum = $minimum + 10;
+
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            new Double\Faker\MinimumGenerator()
+        );
+
+        $fixtureFactory->define(Entity\Organization::class);
+
+        $withOptionalFixtureFactory = $fixtureFactory->withOptional();
+
+        $entities = $withOptionalFixtureFactory->createMany(
+            Entity\Organization::class,
+            Count::between(
+                $minimum,
+                $maximum
+            )
+        );
+
+        self::assertGreaterThanOrEqual(1, \count($entities));
+        self::assertGreaterThanOrEqual($minimum, \count($entities));
+        self::assertLessThanOrEqual($maximum, \count($entities));
+    }
+}

--- a/test/Unit/Strategy/WithOptionalStrategyTest.php
+++ b/test/Unit/Strategy/WithOptionalStrategyTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/factory-bot
+ */
+
+namespace Ergebnis\FactoryBot\Test\Unit\Strategy;
+
+use Ergebnis\FactoryBot\Count;
+use Ergebnis\FactoryBot\FieldDefinition;
+use Ergebnis\FactoryBot\FixtureFactory;
+use Ergebnis\FactoryBot\Strategy\WithOptionalStrategy;
+use Ergebnis\FactoryBot\Test\Double;
+use Ergebnis\FactoryBot\Test\Unit;
+
+/**
+ * @internal
+ *
+ * @covers \Ergebnis\FactoryBot\Strategy\WithOptionalStrategy
+ *
+ * @uses \Ergebnis\FactoryBot\Count
+ * @uses \Ergebnis\FactoryBot\FieldDefinition
+ * @uses \Ergebnis\FactoryBot\FieldDefinition\Optional
+ * @uses \Ergebnis\FactoryBot\FieldDefinition\Value
+ * @uses \Ergebnis\FactoryBot\FixtureFactory
+ */
+final class WithOptionalStrategyTest extends Unit\AbstractTestCase
+{
+    public function testResolveFieldValueResolvesOptionalFieldDefinitionWithFakerAndFixtureFactoryWhenFakerReturnsTrue(): void
+    {
+        $faker = self::faker();
+
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            $faker
+        );
+
+        $fieldDefinition = FieldDefinition::optionalValue($faker->sentence);
+
+        $strategy = new WithOptionalStrategy();
+
+        $resolved = $strategy->resolveFieldValue(
+            new Double\Faker\TrueGenerator(),
+            $fixtureFactory,
+            $fieldDefinition
+        );
+
+        $expected = $fieldDefinition->resolve(
+            $faker,
+            $fixtureFactory
+        );
+
+        self::assertSame($expected, $resolved);
+    }
+
+    public function testResolveFieldValueResolvesOptionalFieldDefinitionWithFakerAndFixtureFactoryWhenFakerReturnsFalse(): void
+    {
+        $faker = self::faker();
+
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            $faker
+        );
+
+        $fieldDefinition = FieldDefinition::optionalValue($faker->sentence);
+
+        $strategy = new WithOptionalStrategy();
+
+        $resolved = $strategy->resolveFieldValue(
+            new Double\Faker\FalseGenerator(),
+            $fixtureFactory,
+            $fieldDefinition
+        );
+
+        $expected = $fieldDefinition->resolve(
+            $faker,
+            $fixtureFactory
+        );
+
+        self::assertSame($expected, $resolved);
+    }
+
+    public function testResolveFieldValueResolvesFieldDefinitionWithFakerAndFixtureFactoryWhenFakerReturnsTrue(): void
+    {
+        $faker = self::faker();
+
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            $faker
+        );
+
+        $fieldDefinition = FieldDefinition::value($faker->sentence);
+
+        $strategy = new WithOptionalStrategy();
+
+        $resolved = $strategy->resolveFieldValue(
+            new Double\Faker\TrueGenerator(),
+            $fixtureFactory,
+            $fieldDefinition
+        );
+
+        $expected = $fieldDefinition->resolve(
+            $faker,
+            $fixtureFactory
+        );
+
+        self::assertSame($expected, $resolved);
+    }
+
+    public function testResolveFieldValueResolvesFieldDefinitionWithFakerAndFixtureFactoryWhenFakerReturnsFalse(): void
+    {
+        $faker = self::faker();
+
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            $faker
+        );
+
+        $fieldDefinition = FieldDefinition::value($faker->sentence);
+
+        $strategy = new WithOptionalStrategy();
+
+        $resolved = $strategy->resolveFieldValue(
+            new Double\Faker\FalseGenerator(),
+            $fixtureFactory,
+            $fieldDefinition
+        );
+
+        $expected = $fieldDefinition->resolve(
+            $faker,
+            $fixtureFactory
+        );
+
+        self::assertSame($expected, $resolved);
+    }
+
+    /**
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::greaterThanOrEqualToZero()
+     *
+     * @param int $value
+     */
+    public function testResolveCountResolvesCountWithFakerWhenCountIsExact(int $value): void
+    {
+        $faker = self::faker();
+
+        $strategy = new WithOptionalStrategy();
+
+        $resolved = $strategy->resolveCount(
+            $faker,
+            Count::exact($value)
+        );
+
+        self::assertSame($value, $resolved);
+    }
+
+    /**
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::greaterThanOrEqualToZero()
+     *
+     * @param int $minimum
+     */
+    public function testResolveCountResolvesCountWithFakerWhenCountIsBetweenAndFakerReturnsMinimum(int $minimum): void
+    {
+        $maximum = self::faker()->numberBetween($minimum + 1);
+
+        $strategy = new WithOptionalStrategy();
+
+        $resolved = $strategy->resolveCount(
+            new Double\Faker\MinimumGenerator(),
+            Count::between(
+                $minimum,
+                $maximum
+            )
+        );
+
+        $minimumGreaterThanZero = \max(
+            1,
+            $minimum
+        );
+
+        self::assertSame($minimumGreaterThanZero, $resolved);
+    }
+
+    /**
+     * @dataProvider \Ergebnis\FactoryBot\Test\DataProvider\IntProvider::greaterThanZero()
+     *
+     * @param int $maximum
+     */
+    public function testResolveCountResolvesCountWithFakerWhenCountIsBetweenAndFakerReturnsMaximum(int $maximum): void
+    {
+        $minimum = self::faker()->numberBetween(0, $maximum - 1);
+
+        $strategy = new WithOptionalStrategy();
+
+        $resolved = $strategy->resolveCount(
+            new Double\Faker\MaximumGenerator(),
+            Count::between(
+                $minimum,
+                $maximum
+            )
+        );
+
+        self::assertSame($maximum, $resolved);
+    }
+
+    public function testResolveCountResolvesCountWithFakerWhenCountIsBetween(): void
+    {
+        $faker = self::faker();
+
+        $minimum = $faker->numberBetween(1);
+        $maximum = $faker->numberBetween($minimum + 1);
+
+        $strategy = new WithOptionalStrategy();
+
+        $resolved = $strategy->resolveCount(
+            $faker,
+            Count::between(
+                $minimum,
+                $maximum
+            )
+        );
+
+        $minimumGreaterThanZero = \max(
+            1,
+            $minimum
+        );
+
+        self::assertGreaterThanOrEqual($minimumGreaterThanZero, $resolved);
+        self::assertLessThanOrEqual($maximum, $resolved);
+    }
+}


### PR DESCRIPTION
This PR

* [x] implements a `WithOptionalStrategy`

💁‍♂️ The fixture factory currently uses a `DefaultStrategy` for resolving field definitions.

This strategy involves random behavior, and

- `FieldDefinition::optionalClosure()` might be resolved to `null` a concrete value
- `FieldDefinition::optionalReference()` might be resolved to `null` or a concrete reference
- `FieldDefinition::optionalSequence()` might be resolved to `null` or a concrete value
- `FieldDefinition::optionalValue()` might be resolved to `null` or a concrete value
- `FieldDefinition::references()` might be resolved to an empty `array` or an `array` of references

You might have a scenario where you have entity definitions that use optional field definitions, but would like to create an entity where these optional field definitions are resolved to concrete values or references.  In this case you can use a fixture factory with the `WithOptionalStrategy`.

This strategy still involves random behavior, but

- `FieldDefinition::optionalClosure()` will be resolved to a concrete value
- `FieldDefinition::optionalReference()` will be resolved to a concrete value
- `FieldDefinition::optionalSequence()` will be resolved to a concrete value
- `FieldDefinition::optionalValue()` will be resolved to a concrete value
- `FieldDefinition::references()` will be resolved to a non-empty `array`
