### PR TITLE
Fix: Do not export example/

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 /.github/               export-ignore
 /config/                export-ignore
+/example/               export-ignore
 /test/                  export-ignore
 /tools/                 export-ignore
 /.editorconfig          export-ignore


### PR DESCRIPTION
This PR

* [x] stops exporting the `example/` directory