### PR TITLE
Allow field definitions to be overridden when using reference.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`0.4.0...main`][0.4.0...main].
 
+### Added
+
+- Allowed specifying field definition overrides when using `FieldDefinition::reference()` and `FieldDefinition::references()` ([#421]), by [@abenerd]
+
 ### Changed
 
 - Dropped support for PHP 7.3 ([#682]), by [@localheinz]
@@ -241,6 +245,7 @@ For a full diff see [`fa9c564...0.1.0`][fa9c564...0.1.0].
 [#369]: https://github.com/ergebnis/factory-bot/pull/369
 [#374]: https://github.com/ergebnis/factory-bot/pull/374
 [#375]: https://github.com/ergebnis/factory-bot/pull/375
+[#421]: https://github.com/ergebnis/factory-bot/pull/421
 [#459]: https://github.com/ergebnis/factory-bot/pull/459
 [#481]: https://github.com/ergebnis/factory-bot/pull/481
 [#493]: https://github.com/ergebnis/factory-bot/pull/493
@@ -250,4 +255,5 @@ For a full diff see [`fa9c564...0.1.0`][fa9c564...0.1.0].
 [#499]: https://github.com/ergebnis/factory-bot/pull/499
 [#682]: https://github.com/ergebnis/factory-bot/pull/682
 
+[@abenerd]: https://github.com/abenerd
 [@localheinz]: https://github.com/localheinz

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ var_dump($user->location()); // null
 
 ##### `FieldDefinition::reference()`
 
-`FieldDefinition::reference()` accepts the class name of an entity or embeddable.
+`FieldDefinition::reference()` accepts the class name of an entity or embeddable, and optionally an array of field definition overrides.
 
 Every fixture factory will resolve the field definition to an instance of the entity or embeddable class populated through the fixture factory.
 
@@ -404,11 +404,36 @@ $user = $fixtureFactory->createOne(Entity\User::class);
 var_dump($user->avatar()); // an instance of Entity\Avatar
 ```
 
+When field definition overrides are specified, they will be used to override exsting field definitions of the referenced entity.
+
+```php
+<?php
+
+use Ergebnis\FactoryBot;
+use Example\Entity;
+
+/** @var FactoryBot\FixtureFactory $fixtureFactory */
+$fixtureFactory->define(Entity\User::class, [
+    'avatar' => FactoryBot\FieldDefinition::reference(
+        Entity\Avatar::class,
+        [
+            'height' => 300,
+            'width' => 200,
+        ]
+    ),
+]);
+
+/** @var Entity\User $user */
+$user = $fixtureFactory->createOne(Entity\User::class);
+
+var_dump($user->avatar()); // an instance of Entity\Avatar with height set to 300 and width set to 200
+```
+
 :exclamation: When resolving the reference, the fixture factory needs to be aware of the referenced entity or embeddable.
 
 ##### `FieldDefinition::optionalReference()`
 
-`FieldDefinition::optionalReference()` accepts the class name of an entity or embeddable.
+`FieldDefinition::optionalReference()` accepts the class name of an entity or embeddable, and optionally an array of field definition overrides.
 
 A fixture factory using the [`Strategy\DefaultStrategy`](#strategydefaultstrategy) will resolve the field definition to `null` or an instance of the entity or embeddable class populated through the fixture factory.
 
@@ -475,7 +500,7 @@ var_dump($repository->template()); // null
 
 ##### `FieldDefinition::references()`
 
-`FieldDefinition::references()` accepts the class name of an entity or embeddable and the count of desired references.
+`FieldDefinition::references()` accepts the class name of an entity or embeddable, the count of desired references, and optionally an array of field definition overrides.
 
 You can create the count from an exact number, or minimum and maximum values.
 
@@ -510,7 +535,10 @@ $fixtureFactory->define(Entity\Organization::class, [
     ),
     'repositories' => FactoryBot\FieldDefinition::references(
         Entity\Repository::class,
-        FactoryBot\Count::between(0, 20)
+        FactoryBot\Count::between(0, 20),
+        [
+            'codeOfConduct' => null,
+        ]
     ),
 ]);
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -76,6 +76,16 @@ parameters:
 			path: src/EntityDefinition.php
 
 		-
+			message: "#^Constructor in Ergebnis\\\\FactoryBot\\\\FieldDefinition\\\\Reference has parameter \\$fieldDefinitionOverrides with default value\\.$#"
+			count: 1
+			path: src/FieldDefinition/Reference.php
+
+		-
+			message: "#^Constructor in Ergebnis\\\\FactoryBot\\\\FieldDefinition\\\\References has parameter \\$fieldDefinitionOverrides with default value\\.$#"
+			count: 1
+			path: src/FieldDefinition/References.php
+
+		-
 			message: "#^Dead catch \\- ReflectionException is never thrown in the try block\\.$#"
 			count: 1
 			path: src/FixtureFactory.php
@@ -352,12 +362,12 @@ parameters:
 
 		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Example\\\\\\\\Entity\\\\\\\\User' and Example\\\\Entity\\\\User will always evaluate to true\\.$#"
-			count: 1
+			count: 2
 			path: test/Unit/FieldDefinition/ReferenceTest.php
 
 		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertIsArray\\(\\) with array\\<int, Example\\\\Entity\\\\User\\> will always evaluate to true\\.$#"
-			count: 1
+			count: 2
 			path: test/Unit/FieldDefinition/ReferencesTest.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -136,7 +136,8 @@
     </UnusedClosureParam>
   </file>
   <file src="test/Unit/FieldDefinition/ReferencesTest.php">
-    <RedundantCondition occurrences="1">
+    <RedundantCondition occurrences="2">
+      <code>assertIsArray</code>
       <code>assertIsArray</code>
     </RedundantCondition>
   </file>

--- a/src/FieldDefinition.php
+++ b/src/FieldDefinition.php
@@ -27,44 +27,68 @@ final class FieldDefinition
 
     /**
      * @phpstan-param class-string<T> $className
+     * @phpstan-param array<string, \Closure|mixed|FieldDefinition\Resolvable> $fieldDefinitionOverrides
      * @phpstan-return FieldDefinition\Reference<T>
      * @phpstan-template T
      *
      * @psalm-param class-string<T> $className
+     * @psalm-param array<string, \Closure|mixed|FieldDefinition\Resolvable> $fieldDefinitionOverrides
      * @psalm-return FieldDefinition\Reference<T>
      * @psalm-template T
+     *
+     * @param array<string, \Closure|FieldDefinition\Resolvable|mixed> $fieldDefinitionOverrides
      */
-    public static function reference(string $className): FieldDefinition\Reference
-    {
-        return new FieldDefinition\Reference($className);
+    public static function reference(
+        string $className,
+        array $fieldDefinitionOverrides = []
+    ): FieldDefinition\Reference {
+        return new FieldDefinition\Reference(
+            $className,
+            $fieldDefinitionOverrides,
+        );
     }
 
     /**
      * @phpstan-param class-string $className
+     * @phpstan-param array<string, \Closure|mixed|FieldDefinition\Resolvable> $fieldDefinitionOverrides
      *
      * @psalm-param class-string $className
+     * @psalm-param array<string, \Closure|mixed|FieldDefinition\Resolvable> $fieldDefinitionOverrides
+     *
+     * @param array<string, \Closure|FieldDefinition\Resolvable|mixed> $fieldDefinitionOverrides
      */
-    public static function optionalReference(string $className): FieldDefinition\Optional
-    {
-        return new FieldDefinition\Optional(new FieldDefinition\Reference($className));
+    public static function optionalReference(
+        string $className,
+        array $fieldDefinitionOverrides = []
+    ): FieldDefinition\Optional {
+        return new FieldDefinition\Optional(new FieldDefinition\Reference(
+            $className,
+            $fieldDefinitionOverrides,
+        ));
     }
 
     /**
      * @phpstan-param class-string<T> $className
      * @phpstan-return FieldDefinition\References<T>
+     * @phpstan-param array<string, \Closure|mixed|FieldDefinition\Resolvable> $fieldDefinitionOverrides
      * @phpstan-template T
      *
      * @psalm-param class-string<T> $className
+     * @psalm-param array<string, \Closure|mixed|FieldDefinition\Resolvable> $fieldDefinitionOverrides
      * @psalm-return FieldDefinition\References<T>
      * @psalm-template T
+     *
+     * @param array<string, \Closure|FieldDefinition\Resolvable|mixed> $fieldDefinitionOverrides
      */
     public static function references(
         string $className,
-        Count $count
+        Count $count,
+        array $fieldDefinitionOverrides = []
     ): FieldDefinition\References {
         return new FieldDefinition\References(
             $className,
             $count,
+            $fieldDefinitionOverrides,
         );
     }
 

--- a/src/FieldDefinition/Reference.php
+++ b/src/FieldDefinition/Reference.php
@@ -33,13 +33,29 @@ final class Reference implements Resolvable
     private string $className;
 
     /**
+     * @phpstan-var array<string, \Closure|mixed|Resolvable>
+     *
+     * @psalm-var array<string, \Closure|mixed|Resolvable>
+     *
+     * @var array<string, \Closure|mixed|Resolvable>
+     */
+    private array $fieldDefinitionOverrides;
+
+    /**
      * @phpstan-param class-string<T> $className
+     * @phpstan-param array<string, \Closure|mixed|Resolvable> $fieldDefinitionOverrides
      *
      * @psalm-param class-string<T> $className
+     * @psalm-param array<string, \Closure|mixed|Resolvable> $fieldDefinitionOverrides
+     *
+     * @param array<string, \Closure|mixed|Resolvable> $fieldDefinitionOverrides
      */
-    public function __construct(string $className)
-    {
+    public function __construct(
+        string $className,
+        array $fieldDefinitionOverrides = []
+    ) {
         $this->className = $className;
+        $this->fieldDefinitionOverrides = $fieldDefinitionOverrides;
     }
 
     /**
@@ -53,6 +69,9 @@ final class Reference implements Resolvable
         Generator $faker,
         FixtureFactory $fixtureFactory
     ) {
-        return $fixtureFactory->createOne($this->className);
+        return $fixtureFactory->createOne(
+            $this->className,
+            $this->fieldDefinitionOverrides,
+        );
     }
 }

--- a/src/FieldDefinition/References.php
+++ b/src/FieldDefinition/References.php
@@ -35,16 +35,31 @@ final class References implements Resolvable
     private Count $count;
 
     /**
+     * @phpstan-var array<string, \Closure|mixed|Resolvable>
+     *
+     * @psalm-var array<string, \Closure|mixed|Resolvable>
+     *
+     * @var array<string, \Closure|mixed|Resolvable>
+     */
+    private array $fieldDefinitionOverrides;
+
+    /**
      * @phpstan-param class-string<T> $className
+     * @phpstan-param array<string, \Closure|mixed|Resolvable> $fieldDefinitionOverrides
      *
      * @psalm-param class-string<T> $className
+     * @psalm-param array<string, \Closure|mixed|Resolvable> $fieldDefinitionOverrides
+     *
+     * @param array<string, \Closure|mixed|Resolvable> $fieldDefinitionOverrides
      */
     public function __construct(
         string $className,
-        Count $count
+        Count $count,
+        array $fieldDefinitionOverrides = []
     ) {
         $this->className = $className;
         $this->count = $count;
+        $this->fieldDefinitionOverrides = $fieldDefinitionOverrides;
     }
 
     /**
@@ -61,6 +76,7 @@ final class References implements Resolvable
         return $fixtureFactory->createMany(
             $this->className,
             $this->count,
+            $this->fieldDefinitionOverrides,
         );
     }
 }

--- a/test/Unit/FieldDefinition/ReferenceTest.php
+++ b/test/Unit/FieldDefinition/ReferenceTest.php
@@ -53,4 +53,37 @@ final class ReferenceTest extends Test\Unit\AbstractTestCase
 
         self::assertInstanceOf($className, $resolved);
     }
+
+    public function testResolvesToObjectCreatedByFixtureFactoryWhenSpecifyingFieldDefinitionOverrides(): void
+    {
+        $className = Entity\User::class;
+
+        $faker = self::faker();
+
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            $faker,
+        );
+
+        $fixtureFactory->define($className, [
+            'login' => $faker->userName,
+        ]);
+
+        $overriddenLogin = $faker->userName;
+
+        $fieldDefinition = new FieldDefinition\Reference(
+            $className,
+            [
+                'login' => $overriddenLogin,
+            ],
+        );
+
+        $resolved = $fieldDefinition->resolve(
+            $faker,
+            $fixtureFactory,
+        );
+
+        self::assertInstanceOf($className, $resolved);
+        self::assertSame($overriddenLogin, $resolved->login());
+    }
 }

--- a/test/Unit/FieldDefinition/ReferencesTest.php
+++ b/test/Unit/FieldDefinition/ReferencesTest.php
@@ -63,4 +63,49 @@ final class ReferencesTest extends Test\Unit\AbstractTestCase
         self::assertCount($value, $resolved);
         self::assertContainsOnly($className, $resolved);
     }
+
+    public function testResolvesToArrayOfObjectsCreatedByFixtureFactoryWhenSpecifyingFieldDefinitionOverrides(): void
+    {
+        $className = Entity\User::class;
+
+        $faker = self::faker();
+
+        $fixtureFactory = new FixtureFactory(
+            self::entityManager(),
+            $faker,
+        );
+
+        $fixtureFactory->define($className, [
+            'login' => $faker->userName,
+        ]);
+
+        $overridenLogin = $faker->userName;
+
+        $fieldDefinition = new FieldDefinition\References(
+            $className,
+            Count::exact(3),
+            [
+                'login' => $overridenLogin,
+            ],
+        );
+
+        $resolved = $fieldDefinition->resolve(
+            $faker,
+            $fixtureFactory,
+        );
+
+        self::assertIsArray($resolved);
+        self::assertCount(3, $resolved);
+        self::assertContainsOnly($className, $resolved);
+
+        $logins = \array_unique(\array_map(static function (Entity\User $user): string {
+            return $user->login();
+        }, $resolved));
+
+        $expectedLogins = [
+            $overridenLogin,
+        ];
+
+        self::assertSame($expectedLogins, $logins);
+    }
 }

--- a/test/Unit/FieldDefinitionTest.php
+++ b/test/Unit/FieldDefinitionTest.php
@@ -84,6 +84,29 @@ final class FieldDefinitionTest extends AbstractTestCase
         self::assertEquals($expected, $fieldDefinition);
     }
 
+    public function testReferenceReturnsReferenceWhenFieldDefinitionOverridesAreSpecified(): void
+    {
+        $className = Entity\User::class;
+
+        $name = self::faker()->name();
+
+        $fieldDefinition = FieldDefinition::reference(
+            $className,
+            [
+                'name' => FieldDefinition::value($name),
+            ],
+        );
+
+        $expected = new FieldDefinition\Reference(
+            $className,
+            [
+                'name' => FieldDefinition::value($name),
+            ],
+        );
+
+        self::assertEquals($expected, $fieldDefinition);
+    }
+
     public function testOptionalReferenceReturnsOptionalReference(): void
     {
         $className = Entity\User::class;
@@ -91,6 +114,29 @@ final class FieldDefinitionTest extends AbstractTestCase
         $fieldDefinition = FieldDefinition::optionalReference($className);
 
         $expected = new FieldDefinition\Optional(new FieldDefinition\Reference($className));
+
+        self::assertEquals($expected, $fieldDefinition);
+    }
+
+    public function testOptionalReferenceReturnsOptionalReferenceWhenFieldDefinitionOverridesAreSpecified(): void
+    {
+        $className = Entity\User::class;
+
+        $name = self::faker()->name();
+
+        $fieldDefinition = FieldDefinition::optionalReference(
+            $className,
+            [
+                'name' => FieldDefinition::value($name),
+            ],
+        );
+
+        $expected = new FieldDefinition\Optional(new FieldDefinition\Reference(
+            $className,
+            [
+                'name' => FieldDefinition::value($name),
+            ],
+        ));
 
         self::assertEquals($expected, $fieldDefinition);
     }
@@ -110,6 +156,34 @@ final class FieldDefinitionTest extends AbstractTestCase
         $expected = new FieldDefinition\References(
             $className,
             Count::exact($value),
+        );
+
+        self::assertEquals($expected, $fieldDefinition);
+    }
+
+    public function testReferencesReturnsReferencesWhenFieldDefinitionOverridesAreSpecified(): void
+    {
+        $faker = self::faker();
+
+        $className = Entity\User::class;
+        $count = Count::exact($faker->numberBetween(1, 5));
+
+        $name = $faker->name();
+
+        $fieldDefinition = FieldDefinition::references(
+            $className,
+            $count,
+            [
+                'name' => FieldDefinition::value($name),
+            ],
+        );
+
+        $expected = new FieldDefinition\References(
+            $className,
+            $count,
+            [
+                'name' => FieldDefinition::value($name),
+            ],
         );
 
         self::assertEquals($expected, $fieldDefinition);


### PR DESCRIPTION
This PR allows users to override the default field definitions when referencing an entity in the FixtureFactory.

Resolves #418.
