### PR TITLE
Fix: Exclude fakerphp/faker from dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,9 @@ updates:
       - dependency-name: "doctrine/orm"
         versions:
           - ">= 0"
+      - dependency-name: "fakerphp/faker"
+        versions:
+          - ">= 0"
     labels:
       - "dependency"
     open-pull-requests-limit: 10


### PR DESCRIPTION
This PR

* [x] excludes `fakerphp/faker` from dependabot updates