### PR TITLE
Fix: Require at least doctrine/annotations:^1.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`0.3.2...main`][0.3.2...main].
 
+### Changed
+
+* Required at least `doctrine/annotations:^1.10.3` ([#494]), by [@localheinz]
+
 ### Fixed
 
 * Dropped support for PHP 7.2 ([#493]), by [@localheinz]
@@ -225,5 +229,6 @@ For a full diff see [`fa9c564...0.1.0`][fa9c564...0.1.0].
 [#375]: https://github.com/ergebnis/factory-bot/pull/375
 [#459]: https://github.com/ergebnis/factory-bot/pull/459
 [#493]: https://github.com/ergebnis/factory-bot/pull/493
+[#494]: https://github.com/ergebnis/factory-bot/pull/494
 
 [@localheinz]: https://github.com/localheinz

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   ],
   "require": {
     "php": "^7.3",
-    "doctrine/annotations": "^1.7.0",
+    "doctrine/annotations": "^1.10.3",
     "doctrine/collections": "^1.0.0",
     "doctrine/orm": "^2.6.3",
     "ergebnis/classy": "^1.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "272bf9fd120b45622f7e5b12c6214299",
+    "content-hash": "3659c4182a1fd791cb6d1d176dccd0f0",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -77,30 +77,33 @@
         },
         {
             "name": "doctrine/annotations",
-            "version": "v1.8.0",
+            "version": "1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "904dca4eb10715b92569fbcd79e201d5c349b6bc"
+                "reference": "ce77a7ba1770462cd705a91a151b6c3746f9c6ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/904dca4eb10715b92569fbcd79e201d5c349b6bc",
-                "reference": "904dca4eb10715b92569fbcd79e201d5c349b6bc",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/ce77a7ba1770462cd705a91a151b6c3746f9c6ad",
+                "reference": "ce77a7ba1770462cd705a91a151b6c3746f9c6ad",
                 "shasum": ""
             },
             "require": {
                 "doctrine/lexer": "1.*",
-                "php": "^7.1"
+                "ext-tokenizer": "*",
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
                 "doctrine/cache": "1.*",
-                "phpunit/phpunit": "^7.5"
+                "doctrine/coding-standard": "^6.0 || ^8.1",
+                "phpstan/phpstan": "^0.12.20",
+                "phpunit/phpunit": "^7.5 || ^9.1.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7.x-dev"
+                    "dev-master": "1.11.x-dev"
                 }
             },
             "autoload": {
@@ -135,13 +138,17 @@
                 }
             ],
             "description": "Docblock Annotations Parser",
-            "homepage": "http://www.doctrine-project.org",
+            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
             "keywords": [
                 "annotations",
                 "docblock",
                 "parser"
             ],
-            "time": "2019-10-01T18:55:10+00:00"
+            "support": {
+                "issues": "https://github.com/doctrine/annotations/issues",
+                "source": "https://github.com/doctrine/annotations/tree/1.11.1"
+            },
+            "time": "2020-10-26T10:28:16+00:00"
         },
         {
             "name": "doctrine/cache",


### PR DESCRIPTION
This PR

* [x] requires at least `doctrine/annotations:^1.10.3`

Related to #481.