### PR TITLE
Fix: Require at least doctrine/collections:^1.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`0.3.2...main`][0.3.2...main].
 ### Changed
 
 * Required at least `doctrine/annotations:^1.10.3` ([#494]), by [@localheinz]
+* Required at least `doctrine/collections:^1.6.5` ([#495]), by [@localheinz]
 
 ### Fixed
 
@@ -230,5 +231,6 @@ For a full diff see [`fa9c564...0.1.0`][fa9c564...0.1.0].
 [#459]: https://github.com/ergebnis/factory-bot/pull/459
 [#493]: https://github.com/ergebnis/factory-bot/pull/493
 [#494]: https://github.com/ergebnis/factory-bot/pull/494
+[#495]: https://github.com/ergebnis/factory-bot/pull/495
 
 [@localheinz]: https://github.com/localheinz

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "require": {
     "php": "^7.3",
     "doctrine/annotations": "^1.10.3",
-    "doctrine/collections": "^1.0.0",
+    "doctrine/collections": "^1.6.5",
     "doctrine/orm": "^2.6.3",
     "ergebnis/classy": "^1.1.0",
     "fakerphp/faker": "^1.11.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3659c4182a1fd791cb6d1d176dccd0f0",
+    "content-hash": "3e71e5e3ff751559776212ad34877c5d",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -234,33 +234,28 @@
         },
         {
             "name": "doctrine/collections",
-            "version": "1.6.4",
+            "version": "1.6.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/collections.git",
-                "reference": "6b1e4b2b66f6d6e49983cebfe23a21b7ccc5b0d7"
+                "reference": "55f8b799269a1a472457bd1a41b4f379d4cfba4a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/collections/zipball/6b1e4b2b66f6d6e49983cebfe23a21b7ccc5b0d7",
-                "reference": "6b1e4b2b66f6d6e49983cebfe23a21b7ccc5b0d7",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/55f8b799269a1a472457bd1a41b4f379d4cfba4a",
+                "reference": "55f8b799269a1a472457bd1a41b4f379d4cfba4a",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
+                "php": "^7.1.3 || ^8.0"
             },
             "require-dev": {
                 "doctrine/coding-standard": "^6.0",
                 "phpstan/phpstan-shim": "^0.9.2",
                 "phpunit/phpunit": "^7.0",
-                "vimeo/psalm": "^3.2.2"
+                "vimeo/psalm": "^3.8.1"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.6.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Doctrine\\Common\\Collections\\": "lib/Doctrine/Common/Collections"
@@ -300,7 +295,11 @@
                 "iterators",
                 "php"
             ],
-            "time": "2019-11-13T13:07:11+00:00"
+            "support": {
+                "issues": "https://github.com/doctrine/collections/issues",
+                "source": "https://github.com/doctrine/collections/tree/1.6.7"
+            },
+            "time": "2020-07-27T17:53:49+00:00"
         },
         {
             "name": "doctrine/common",


### PR DESCRIPTION
This PR

* [x] requires at least `doctrine/collections:^1.6.5`

Related to #481.
