### PR TITLE
Fix: Require at least doctrine/dbal:^2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ For a full diff see [`0.3.2...main`][0.3.2...main].
 
 * Required at least `doctrine/annotations:^1.10.3` ([#495]), by [@localheinz]
 * Required at least `doctrine/collections:^1.6.5` ([#496]), by [@localheinz]
-* Required at least `doctrine/orm:^2.8.0` ([#497]), by [@localheinz]
+* Required at least `doctrine/orm:^2.8.0` ([#498]), by [@localheinz]
+* Required at least `doctrine/dbal:^2.12.0` ([#499]), by [@localheinz]
 
 ### Fixed
 
@@ -233,6 +234,7 @@ For a full diff see [`fa9c564...0.1.0`][fa9c564...0.1.0].
 [#493]: https://github.com/ergebnis/factory-bot/pull/493
 [#495]: https://github.com/ergebnis/factory-bot/pull/495
 [#496]: https://github.com/ergebnis/factory-bot/pull/496
-[#497]: https://github.com/ergebnis/factory-bot/pull/497
+[#498]: https://github.com/ergebnis/factory-bot/pull/498
+[#499]: https://github.com/ergebnis/factory-bot/pull/499
 
 [@localheinz]: https://github.com/localheinz

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "php": "^7.3",
     "doctrine/annotations": "^1.10.3",
     "doctrine/collections": "^1.6.5",
+    "doctrine/dbal": "^2.12.0 || ^3.0.0",
     "doctrine/orm": "^2.8.0",
     "ergebnis/classy": "^1.1.0",
     "fakerphp/faker": "^1.11.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d6886f1e353aac9f9e99ebfb0b14c132",
+    "content-hash": "6a26f1a3979a8f16d7f479cf12cf09ef",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",


### PR DESCRIPTION
This PR

* [x] requires at least `doctrine/dbal:^2.12.0`

Related to #481.