### PR TITLE
Fix: Ignore `doctrine/dbal`

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,6 +14,9 @@ updates:
       - dependency-name: "doctrine/collections"
         versions:
           - ">= 0"
+      - dependency-name: "doctrine/dbal"
+        versions:
+          - ">= 0"
       - dependency-name: "doctrine/orm"
         versions:
           - ">= 0"


### PR DESCRIPTION
This pull request

* [x] ignores `doctrine/dbal` when updating dependencies