### PR TITLE
Fix: Rename `.php_cs` to `.php-cs-fixer.php`

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -75,10 +75,10 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-php-cs-fixer-"
 
       - name: "Run friendsofphp/php-cs-fixer"
-        run: "vendor/bin/php-cs-fixer fix --config=.php_cs --diff --diff-format=udiff --dry-run --verbose"
+        run: "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --diff --diff-format=udiff --dry-run --verbose"
 
       - name: "Run friendsofphp/php-cs-fixer on fixtures"
-        run: "vendor/bin/php-cs-fixer fix --config=.php_cs.fixture --diff --diff-format=udiff --dry-run --verbose"
+        run: "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.fixture.php --diff --diff-format=udiff --dry-run --verbose"
 
   dependency-analysis:
     name: "Dependency Analysis"

--- a/.github/workflows/renew.yaml
+++ b/.github/workflows/renew.yaml
@@ -65,7 +65,7 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-php-cs-fixer-"
 
       - name: "Run friendsofphp/php-cs-fixer"
-        run: "vendor/bin/php-cs-fixer fix --config=.php_cs --diff --diff-format=udiff --verbose"
+        run: "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --diff --diff-format=udiff --verbose"
 
       - name: "Commit modified files"
         uses: "stefanzweifel/git-auto-commit-action@v4.11.0"

--- a/.php-cs-fixer.fixture.php
+++ b/.php-cs-fixer.fixture.php
@@ -33,6 +33,6 @@ $config = PhpCsFixer\Config\Factory::fromRuleSet(new PhpCsFixer\Config\RuleSet\P
 
 $config->getFinder()->in(__DIR__ . '/test/Fixture/DefinitionProvider/CanNotBeAutoloaded');
 
-$config->setCacheFile(__DIR__ . '/.build/php-cs-fixer/.php_cs.fixture.cache');
+$config->setCacheFile(__DIR__ . '/.build/php-cs-fixer/php-cs-fixer.fixture.cache');
 
 return $config;

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -39,7 +39,7 @@ $config->getFinder()
     ])
     ->ignoreDotFiles(false)
     ->in(__DIR__)
-    ->name('.php_cs');
+    ->name('.php-cs-fixer.php');
 
 $config->setCacheFile(__DIR__ . '/.build/php-cs-fixer/.php_cs.cache');
 

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ coding-standards: vendor ## Normalizes composer.json with ergebnis/composer-norm
 	composer normalize
 	yamllint -c .yamllint.yaml --strict .
 	mkdir -p .build/php-cs-fixer
-	vendor/bin/php-cs-fixer fix --config=.php_cs --diff --diff-format=udiff --verbose
-	vendor/bin/php-cs-fixer fix --config=.php_cs.fixture --diff --diff-format=udiff --verbose
+	vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --diff --diff-format=udiff --verbose
+	vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.fixture.php --diff --diff-format=udiff --verbose
 
 .PHONY: dependency-analysis
 dependency-analysis: vendor ## Runs a dependency analysis with maglnet/composer-require-checker


### PR DESCRIPTION
This pull request

* [x] renames `.php_cs` to `.php-cs-fixer.php`

Follows #578.