### PR TITLE
Fix: Do not configure deprecated fixer

### DIFF
--- a/.php-cs-fixer.fixture.php
+++ b/.php-cs-fixer.fixture.php
@@ -28,7 +28,7 @@ $license->save();
 
 $config = PhpCsFixer\Config\Factory::fromRuleSet(new PhpCsFixer\Config\RuleSet\Php73($license->header()), [
     'mb_str_functions' => false,
-    'psr4' => false,
+    'psr_autoloading' => false,
 ]);
 
 $config->getFinder()->in(__DIR__ . '/test/Fixture/DefinitionProvider/CanNotBeAutoloaded');


### PR DESCRIPTION
This pull request

* [x] disables the `psr_autoloading` instead of the deprecated `psr4` fixer

Follows #578.