### PR TITLE
Fix: Use `Collection` interface

### DIFF
--- a/example/src/Entity/Organization.php
+++ b/example/src/Entity/Organization.php
@@ -72,7 +72,7 @@ class Organization
      *     mappedBy="organization"
      * )
      *
-     * @var Common\Collections\ArrayCollection<int, Repository>
+     * @var Common\Collections\Collection<int, Repository>
      */
     private $repositories;
 
@@ -82,7 +82,7 @@ class Organization
      *     inversedBy="organizations"
      * )
      *
-     * @var Common\Collections\ArrayCollection<int, User>
+     * @var Common\Collections\Collection<int, User>
      */
     private $members;
 

--- a/example/src/Entity/User.php
+++ b/example/src/Entity/User.php
@@ -72,7 +72,7 @@ class User
      *     mappedBy="members"
      * )
      *
-     * @var Common\Collections\ArrayCollection<int, Organization>
+     * @var Common\Collections\Collection<int, Organization>
      */
     private $organizations;
 


### PR DESCRIPTION
This pull request

- [x] uses the `Collection` interface instead of the `ArrayCollection` implementation in DocBlocks