### PR TITLE
Fix: Require `doctrine/persistence:^2.1.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     "doctrine/collections": "^1.6.5",
     "doctrine/dbal": "^2.12.0 || ^3.0.0",
     "doctrine/orm": "^2.8.0",
+    "doctrine/persistence": "^2.1.0",
     "ergebnis/classy": "^1.1.1",
     "fakerphp/faker": "^1.11.0"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1822b655d5aca59ea5efc529a9fc5ad4",
+    "content-hash": "0d4301222e14bffa48038734bc68562e",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -879,21 +879,21 @@
         },
         {
             "name": "doctrine/persistence",
-            "version": "2.1.0",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/persistence.git",
-                "reference": "9899c16934053880876b920a3b8b02ed2337ac1d"
+                "reference": "bac0f7fc16fc294e4c38b8763de21657dcf803f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/persistence/zipball/9899c16934053880876b920a3b8b02ed2337ac1d",
-                "reference": "9899c16934053880876b920a3b8b02ed2337ac1d",
+                "url": "https://api.github.com/repos/doctrine/persistence/zipball/bac0f7fc16fc294e4c38b8763de21657dcf803f0",
+                "reference": "bac0f7fc16fc294e4c38b8763de21657dcf803f0",
                 "shasum": ""
             },
             "require": {
                 "doctrine/annotations": "^1.0",
-                "doctrine/cache": "^1.0",
+                "doctrine/cache": "^1.0|^2.0",
                 "doctrine/collections": "^1.0",
                 "doctrine/event-manager": "^1.0",
                 "php": "^7.1 || ^8.0"
@@ -907,7 +907,8 @@
                 "doctrine/common": "^3.0",
                 "phpstan/phpstan": "^0.12",
                 "phpunit/phpunit": "^7.5.20 || ^8.0 || ^9.0",
-                "vimeo/psalm": "^3.11"
+                "symfony/cache": "^4.4",
+                "vimeo/psalm": "^4.3.1"
             },
             "type": "library",
             "autoload": {
@@ -957,9 +958,9 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/persistence/issues",
-                "source": "https://github.com/doctrine/persistence/tree/2.1.0"
+                "source": "https://github.com/doctrine/persistence/tree/2.1.1"
             },
-            "time": "2020-10-24T22:13:54+00:00"
+            "time": "2021-04-30T12:44:08+00:00"
         },
         {
             "name": "ergebnis/classy",
@@ -7824,5 +7825,5 @@
     "platform-overrides": {
         "php": "7.4.26"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
This pull request

- [x] requires `doctrine/persistence:^2.1.0`

Blocks #697.

Related to https://github.com/doctrine/persistence/pull/122.