### PR TITLE
Fix: Use methods instead of deprecated magic properties

### DIFF
--- a/example/test/Fixture/Entity/CodeOfConductDefinitionProvider.php
+++ b/example/test/Fixture/Entity/CodeOfConductDefinitionProvider.php
@@ -26,13 +26,13 @@ final class CodeOfConductDefinitionProvider implements FactoryBot\EntityDefiniti
                 return $faker->realText();
             }),
             'key' => FactoryBot\FieldDefinition::closure(static function (Generator $faker): string {
-                return $faker->word;
+                return $faker->word();
             }),
             'name' => FactoryBot\FieldDefinition::closure(static function (Generator $faker): string {
-                return $faker->sentence;
+                return $faker->sentence();
             }),
             'url' => FactoryBot\FieldDefinition::closure(static function (Generator $faker): string {
-                return $faker->url;
+                return $faker->url();
             }),
         ]);
     }

--- a/example/test/Fixture/Entity/OrganizationDefinitionProvider.php
+++ b/example/test/Fixture/Entity/OrganizationDefinitionProvider.php
@@ -23,20 +23,20 @@ final class OrganizationDefinitionProvider implements FactoryBot\EntityDefinitio
     {
         $fixtureFactory->define(Entity\Organization::class, [
             'id' => FactoryBot\FieldDefinition::closure(static function (Generator $faker): string {
-                return $faker->uuid;
+                return $faker->uuid();
             }),
             'isVerified' => FactoryBot\FieldDefinition::closure(static function (Generator $faker): bool {
-                return $faker->boolean;
+                return $faker->boolean();
             }),
             'members' => FactoryBot\FieldDefinition::references(
                 Entity\User::class,
                 FactoryBot\Count::between(1, 10),
             ),
             'name' => FactoryBot\FieldDefinition::closure(static function (Generator $faker): string {
-                return $faker->word;
+                return $faker->word();
             }),
             'url' => FactoryBot\FieldDefinition::optionalClosure(static function (Generator $faker): string {
-                return $faker->url;
+                return $faker->url();
             }),
         ]);
     }

--- a/example/test/Fixture/Entity/ProjectDefinitionProvider.php
+++ b/example/test/Fixture/Entity/ProjectDefinitionProvider.php
@@ -23,10 +23,10 @@ final class ProjectDefinitionProvider implements FactoryBot\EntityDefinitionProv
     {
         $fixtureFactory->define(Entity\Project::class, [
             'id' => FactoryBot\FieldDefinition::closure(static function (Generator $faker): string {
-                return $faker->uuid;
+                return $faker->uuid();
             }),
             'name' => FactoryBot\FieldDefinition::closure(static function (Generator $faker): string {
-                return $faker->word;
+                return $faker->word();
             }),
             'repository' => FactoryBot\FieldDefinition::reference(Entity\Repository::class),
         ]);

--- a/example/test/Fixture/Entity/RepositoryDefinitionProvider.php
+++ b/example/test/Fixture/Entity/RepositoryDefinitionProvider.php
@@ -24,10 +24,10 @@ final class RepositoryDefinitionProvider implements FactoryBot\EntityDefinitionP
         $fixtureFactory->define(Entity\Repository::class, [
             'codeOfConduct' => FactoryBot\FieldDefinition::optionalReference(Entity\CodeOfConduct::class),
             'id' => FactoryBot\FieldDefinition::closure(static function (Generator $faker): string {
-                return $faker->uuid;
+                return $faker->uuid();
             }),
             'name' => FactoryBot\FieldDefinition::closure(static function (Generator $faker): string {
-                return $faker->word;
+                return $faker->word();
             }),
             'organization' => FactoryBot\FieldDefinition::reference(Entity\Organization::class),
             'template' => FactoryBot\FieldDefinition::optionalReference(Entity\Repository::class),

--- a/example/test/Fixture/Entity/UserDefinitionProvider.php
+++ b/example/test/Fixture/Entity/UserDefinitionProvider.php
@@ -24,13 +24,13 @@ final class UserDefinitionProvider implements FactoryBot\EntityDefinitionProvide
         $fixtureFactory->define(Entity\User::class, [
             'avatar' => FactoryBot\FieldDefinition::reference(Entity\Avatar::class),
             'id' => FactoryBot\FieldDefinition::closure(static function (Generator $faker): string {
-                return $faker->uuid;
+                return $faker->uuid();
             }),
             'location' => FactoryBot\FieldDefinition::optionalClosure(static function (Generator $faker): string {
-                return $faker->city;
+                return $faker->city();
             }),
             'login' => FactoryBot\FieldDefinition::closure(static function (Generator $faker): string {
-                return $faker->userName;
+                return $faker->userName();
             }),
         ]);
     }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -108,6 +108,12 @@
     <InternalMethod occurrences="1">
       <code>addToAssertionCount</code>
     </InternalMethod>
+    <MixedInferredReturnType occurrences="1">
+      <code>string</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$faker-&gt;unique()-&gt;uuid()</code>
+    </MixedReturnStatement>
   </file>
   <file src="test/Unit/EntityDefinitionTest.php">
     <MissingClosureParamType occurrences="2">
@@ -257,6 +263,10 @@
       <code>$fieldValues['name']</code>
       <code>$name</code>
     </MixedArgument>
+    <MixedAssignment occurrences="2">
+      <code>$name</code>
+      <code>$name</code>
+    </MixedAssignment>
     <RedundantCondition occurrences="2">
       <code>assertNotNull</code>
       <code>assertNotNull</code>

--- a/test/DataProvider/ValueProvider.php
+++ b/test/DataProvider/ValueProvider.php
@@ -27,14 +27,14 @@ final class ValueProvider
         $faker = self::faker();
 
         $values = [
-            'array' => $faker->words,
+            'array' => $faker->words(),
             'bool-false' => false,
             'bool-true' => true,
             'float' => $faker->randomFloat(),
             'int' => $faker->numberBetween(),
             'object' => new \stdClass(),
             'resource' => \fopen(__FILE__, 'rb'),
-            'string' => $faker->sentence,
+            'string' => $faker->sentence(),
         ];
 
         foreach ($values as $key => $value) {

--- a/test/Integration/FixtureFactoryTest.php
+++ b/test/Integration/FixtureFactoryTest.php
@@ -45,7 +45,7 @@ final class FixtureFactoryTest extends AbstractTestCase
             $faker,
         );
 
-        $name = $faker->word;
+        $name = $faker->word();
 
         $fixtureFactory->define(Entity\Organization::class, [
             'name' => $name,
@@ -73,11 +73,11 @@ final class FixtureFactoryTest extends AbstractTestCase
             $faker,
         );
 
-        $name = $faker->word;
+        $name = $faker->word();
 
         $fixtureFactory->define(Entity\Organization::class, [
             'id' => FieldDefinition::closure(static function (Generator $faker): string {
-                return $faker->uuid;
+                return $faker->uuid();
             }),
             'name' => $name,
         ]);
@@ -115,9 +115,9 @@ final class FixtureFactoryTest extends AbstractTestCase
         $fixtureFactory->define(Entity\User::class, [
             'avatar' => FieldDefinition::reference(Entity\Avatar::class),
             'id' => FieldDefinition::closure(static function (Generator $faker): string {
-                return $faker->uuid;
+                return $faker->uuid();
             }),
-            'login' => $faker->userName,
+            'login' => $faker->userName(),
         ]);
 
         $persistingFixtureFactory = $fixtureFactory->persisting();
@@ -167,7 +167,7 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         $fixtureFactory->define(Entity\Organization::class, [
             'id' => FieldDefinition::closure(static function (Generator $faker): string {
-                return $faker->unique()->uuid;
+                return $faker->unique()->uuid();
             }),
             'name' => FieldDefinition::sequence('name-%d'),
         ]);

--- a/test/Unit/Exception/InvalidFieldNamesTest.php
+++ b/test/Unit/Exception/InvalidFieldNamesTest.php
@@ -30,8 +30,8 @@ final class InvalidFieldNamesTest extends Framework\TestCase
     {
         $faker = self::faker();
 
-        $className = $faker->word;
-        $fieldName = $faker->word;
+        $className = $faker->word();
+        $fieldName = $faker->word();
 
         $exception = Exception\InvalidFieldNames::notFoundIn(
             $className,
@@ -55,7 +55,7 @@ final class InvalidFieldNamesTest extends Framework\TestCase
     {
         $faker = self::faker();
 
-        $className = $faker->word;
+        $className = $faker->word();
 
         /** @var string[] $fieldNames */
         $fieldNames = $faker->words(10);

--- a/test/Unit/FieldDefinition/SequenceTest.php
+++ b/test/Unit/FieldDefinition/SequenceTest.php
@@ -32,7 +32,7 @@ final class SequenceTest extends Test\Unit\AbstractTestCase
     {
         $faker = self::faker();
 
-        $value = $faker->sentence;
+        $value = $faker->sentence();
         $initialNumber = $faker->randomNumber();
 
         $this->expectException(Exception\InvalidSequence::class);

--- a/test/Unit/FieldDefinitionTest.php
+++ b/test/Unit/FieldDefinitionTest.php
@@ -119,7 +119,7 @@ final class FieldDefinitionTest extends AbstractTestCase
     {
         $faker = self::faker();
 
-        $value = $faker->sentence;
+        $value = $faker->sentence();
         $initialNumber = $faker->randomNumber();
 
         $this->expectException(Exception\InvalidSequence::class);
@@ -172,7 +172,7 @@ final class FieldDefinitionTest extends AbstractTestCase
     {
         $faker = self::faker();
 
-        $value = $faker->sentence;
+        $value = $faker->sentence();
         $initialNumber = $faker->randomNumber();
 
         $this->expectException(Exception\InvalidSequence::class);

--- a/test/Unit/FixtureFactoryTest.php
+++ b/test/Unit/FixtureFactoryTest.php
@@ -102,8 +102,8 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         $fixtureFactory->define(Entity\User::class, [
             'avatar' => new Entity\Avatar(),
-            'email' => $faker->email,
-            'phone' => $faker->phoneNumber,
+            'email' => $faker->email(),
+            'phone' => $faker->phoneNumber(),
         ]);
     }
 
@@ -243,7 +243,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         );
 
         $fixtureFactory->define(Entity\Organization::class, [
-            'name' => $faker->word,
+            'name' => $faker->word(),
         ]);
 
         $this->expectException(Exception\InvalidFieldNames::class);
@@ -294,7 +294,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         $this->expectException(Exception\InvalidFieldNames::class);
 
         $fixtureFactory->define(Entity\User::class, [
-            'login' => $faker->userName,
+            'login' => $faker->userName(),
             'avatar.url' => $faker->imageUrl(),
             'avatar.width' => $faker->numberBetween(100, 250),
             'avatar.height' => $faker->numberBetween(100, 250),
@@ -315,7 +315,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         $this->expectException(Exception\InvalidFieldNames::class);
 
         $fixtureFactory->createOne(Entity\User::class, [
-            'login' => $faker->userName,
+            'login' => $faker->userName(),
             'avatar.url' => $faker->imageUrl(),
             'avatar.width' => $faker->numberBetween(100, 250),
             'avatar.height' => $faker->numberBetween(100, 250),
@@ -326,7 +326,7 @@ final class FixtureFactoryTest extends AbstractTestCase
     {
         $faker = self::faker();
 
-        $name = $faker->word;
+        $name = $faker->word();
 
         $fixtureFactory = new FixtureFactory(
             self::entityManager(),
@@ -428,7 +428,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         );
 
         $fixtureFactory->define(Entity\Organization::class, [
-            'name' => $faker->word,
+            'name' => $faker->word(),
         ]);
 
         /** @var Entity\Organization $organization */
@@ -460,7 +460,7 @@ final class FixtureFactoryTest extends AbstractTestCase
 
         /** @var Entity\Organization $organization */
         $organization = $fixtureFactory->createOne(Entity\Organization::class, [
-            'name' => $faker->word,
+            'name' => $faker->word(),
             'repositories' => [
                 $repositoryOne,
                 $repositoryTwo,
@@ -530,10 +530,10 @@ final class FixtureFactoryTest extends AbstractTestCase
         );
 
         $fixtureFactory->define(Entity\Organization::class, [
-            'name' => $faker->unique()->word,
+            'name' => $faker->unique()->word(),
         ]);
 
-        $name = $faker->unique()->word;
+        $name = $faker->unique()->word();
 
         /** @var Entity\Organization $organization */
         $organization = $fixtureFactory->createOne(Entity\Organization::class, [
@@ -553,10 +553,10 @@ final class FixtureFactoryTest extends AbstractTestCase
         );
 
         $fixtureFactory->define(Entity\Organization::class, [
-            'name' => $faker->unique()->word,
+            'name' => $faker->unique()->word(),
         ]);
 
-        $name = $faker->unique()->word;
+        $name = $faker->unique()->word();
 
         /** @var Entity\Organization $organization */
         $organization = $fixtureFactory->createOne(Entity\Organization::class, [
@@ -630,7 +630,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         ]);
 
         $fixtureFactory->define(Entity\Repository::class, [
-            'name' => $faker->word,
+            'name' => $faker->word(),
         ]);
 
         /** @var Entity\Organization $organization */
@@ -667,7 +667,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         ]);
 
         $fixtureFactory->define(Entity\Repository::class, [
-            'name' => $faker->word,
+            'name' => $faker->word(),
         ]);
 
         /** @var Entity\Organization $organization */
@@ -688,7 +688,7 @@ final class FixtureFactoryTest extends AbstractTestCase
     {
         $faker = self::faker();
 
-        $name = $faker->word;
+        $name = $faker->word();
 
         $fixtureFactory = new FixtureFactory(
             self::entityManager(),
@@ -738,7 +738,7 @@ final class FixtureFactoryTest extends AbstractTestCase
         $fixtureFactory->define(Entity\Organization::class);
 
         $fixtureFactory->define(Entity\Repository::class, [
-            'name' => $faker->word,
+            'name' => $faker->word(),
             'organization' => FieldDefinition::reference(Entity\Organization::class),
         ]);
 


### PR DESCRIPTION
This pull request

- [x] uses methods instead of deprecated magic properties