### PR TITLE
Fix: Do not let dependabot update `doctrine/persistence`

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -12,6 +12,7 @@ updates:
       - dependency-name: "doctrine/collections"
       - dependency-name: "doctrine/dbal"
       - dependency-name: "doctrine/orm"
+      - dependency-name: "doctrine/persistence"
       - dependency-name: "fakerphp/faker"
     labels:
       - "dependency"


### PR DESCRIPTION
This pull request

- [x] configures dependabot to stop updating `doctrine/persistence`