### PR TITLE
Fix: Remove `doctrine/annotations`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ For a full diff see [`1.5.0...main`][1.5.0...main].
 
 - Required `doctrine/orm:^2.9.0` ([#1234]), by [@localheinz]
 
+### Removed
+
+- Removed dependency on `doctrine/annotations` ([#1233]), by [@localheinz]
+
 ## [`1.5.0`][1.5.0]
 
 For a full diff see [`1.4.0...1.5.0`][1.4.0...1.5.0].
@@ -343,6 +347,7 @@ For a full diff see [`fa9c564...0.1.0`][fa9c564...0.1.0].
 [#1000]: https://github.com/ergebnis/factory-bot/pull/1000
 [#1109]: https://github.com/ergebnis/factory-bot/pull/1109
 [#1213]: https://github.com/ergebnis/factory-bot/pull/1213
+[#1233]: https://github.com/ergebnis/factory-bot/pull/1233
 [#1234]: https://github.com/ergebnis/factory-bot/pull/1234
 
 [@abenerd]: https://github.com/abenerd

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
   },
   "require": {
     "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-    "doctrine/annotations": "^1.10.3 || ^2.0.0",
     "doctrine/collections": "^1.6.5 || ^2.0.0",
     "doctrine/dbal": "^2.12.0 || ^3.0.0",
     "doctrine/orm": "^2.9.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,84 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "38dfcdc71179d1e3ece8a5f0ba75177c",
+    "content-hash": "df09ed86893fb7d5fbc0a25f8ece387a",
     "packages": [
-        {
-            "name": "doctrine/annotations",
-            "version": "2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/annotations.git",
-                "reference": "e157ef3f3124bbf6fe7ce0ffd109e8a8ef284e7f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/e157ef3f3124bbf6fe7ce0ffd109e8a8ef284e7f",
-                "reference": "e157ef3f3124bbf6fe7ce0ffd109e8a8ef284e7f",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/lexer": "^2 || ^3",
-                "ext-tokenizer": "*",
-                "php": "^7.2 || ^8.0",
-                "psr/cache": "^1 || ^2 || ^3"
-            },
-            "require-dev": {
-                "doctrine/cache": "^2.0",
-                "doctrine/coding-standard": "^10",
-                "phpstan/phpstan": "^1.8.0",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "symfony/cache": "^5.4 || ^6",
-                "vimeo/psalm": "^4.10"
-            },
-            "suggest": {
-                "php": "PHP 8.0 or higher comes with attributes, a native replacement for annotations"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
-                },
-                {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
-                    "name": "Benjamin Eberlei",
-                    "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Jonathan Wage",
-                    "email": "jonwage@gmail.com"
-                },
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                }
-            ],
-            "description": "Docblock Annotations Parser",
-            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
-            "keywords": [
-                "annotations",
-                "docblock",
-                "parser"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/annotations/issues",
-                "source": "https://github.com/doctrine/annotations/tree/2.0.1"
-            },
-            "time": "2023-02-02T22:02:53+00:00"
-        },
         {
             "name": "doctrine/cache",
             "version": "2.2.0",


### PR DESCRIPTION
This pull request

- [x] removes `doctrine/annotations`