### PR TITLE
Fix: Do not use deprecated `Doctrine\ORM\Tools\Setup`

### DIFF
--- a/example/test/Unit/AbstractTestCase.php
+++ b/example/test/Unit/AbstractTestCase.php
@@ -23,7 +23,7 @@ abstract class AbstractTestCase extends Framework\TestCase
 {
     final protected static function entityManager(): ORM\EntityManagerInterface
     {
-        $configuration = ORM\Tools\Setup::createConfiguration(true);
+        $configuration = ORM\ORMSetup::createConfiguration(true);
 
         $configuration->setMetadataDriverImpl(new ORM\Mapping\Driver\AttributeDriver([
             __DIR__ . '/../../src/Entity',

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -137,14 +137,6 @@ parameters:
 			path: example/test/Unit/AbstractTestCase.php
 
 		-
-			message: """
-				#^Call to method createConfiguration\\(\\) of deprecated class Doctrine\\\\ORM\\\\Tools\\\\Setup\\:
-				Use \\{@see ORMSetup\\} instead\\.$#
-			"""
-			count: 1
-			path: example/test/Unit/AbstractTestCase.php
-
-		-
 			message: "#^Instanceof between Ergebnis\\\\FactoryBot\\\\FieldDefinition\\\\Resolvable and Ergebnis\\\\FactoryBot\\\\FieldDefinition\\\\Resolvable will always evaluate to true\\.$#"
 			count: 1
 			path: src/EntityDefinition.php
@@ -563,14 +555,6 @@ parameters:
 			message: """
 				#^Call to deprecated method create\\(\\) of class Doctrine\\\\ORM\\\\EntityManager\\:
 				Use \\{@see DriverManager\\:\\:getConnection\\(\\)\\} to bootstrap the connection and call the constructor\\.$#
-			"""
-			count: 1
-			path: test/Util/Doctrine/ORM/EntityManagerFactory.php
-
-		-
-			message: """
-				#^Call to method createConfiguration\\(\\) of deprecated class Doctrine\\\\ORM\\\\Tools\\\\Setup\\:
-				Use \\{@see ORMSetup\\} instead\\.$#
 			"""
 			count: 1
 			path: test/Util/Doctrine/ORM/EntityManagerFactory.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -76,9 +76,6 @@
     </UnusedClass>
   </file>
   <file src="example/test/Unit/AbstractTestCase.php">
-    <DeprecatedClass>
-      <code>ORM\Tools\Setup::createConfiguration(true)</code>
-    </DeprecatedClass>
     <DeprecatedMethod>
       <code><![CDATA[ORM\EntityManager::create(
             [
@@ -448,9 +445,6 @@
     </MixedAssignment>
   </file>
   <file src="test/Util/Doctrine/ORM/EntityManagerFactory.php">
-    <DeprecatedClass>
-      <code>ORM\Tools\Setup::createConfiguration(true)</code>
-    </DeprecatedClass>
     <DeprecatedMethod>
       <code><![CDATA[ORM\EntityManager::create(
             [

--- a/test/Util/Doctrine/ORM/EntityManagerFactory.php
+++ b/test/Util/Doctrine/ORM/EntityManagerFactory.php
@@ -19,7 +19,7 @@ final class EntityManagerFactory
 {
     public static function create(): ORM\EntityManagerInterface
     {
-        $configuration = ORM\Tools\Setup::createConfiguration(true);
+        $configuration = ORM\ORMSetup::createConfiguration(true);
 
         $configuration->setMetadataDriverImpl(new ORM\Mapping\Driver\AttributeDriver([
             __DIR__ . '/../../../../example/src/Entity',


### PR DESCRIPTION
This pull request

- [x] stops using the deprecated `Doctrine\ORM\Tools\Setup`

Blocks #1293.