### PR TITLE
Fix: Do not use deprecated `Doctrine\ORM\EntityManager::create()`

### DIFF
--- a/example/test/Unit/AbstractTestCase.php
+++ b/example/test/Unit/AbstractTestCase.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Example\Test\Unit;
 
+use Doctrine\DBAL;
 use Doctrine\ORM;
 use Ergebnis\FactoryBot;
 use Faker\Factory;
@@ -23,17 +24,19 @@ abstract class AbstractTestCase extends Framework\TestCase
 {
     final protected static function entityManager(): ORM\EntityManagerInterface
     {
+        $connection = DBAL\DriverManager::getConnection([
+            'driver' => 'pdo_sqlite',
+            'path' => ':memory:',
+        ]);
+
         $configuration = ORM\ORMSetup::createConfiguration(true);
 
         $configuration->setMetadataDriverImpl(new ORM\Mapping\Driver\AttributeDriver([
             __DIR__ . '/../../src/Entity',
         ]));
 
-        $entityManager = ORM\EntityManager::create(
-            [
-                'driver' => 'pdo_sqlite',
-                'path' => ':memory:',
-            ],
+        $entityManager = new ORM\EntityManager(
+            $connection,
             $configuration,
         );
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -129,14 +129,6 @@ parameters:
 			path: example/test/AutoReview/FixtureTest.php
 
 		-
-			message: """
-				#^Call to deprecated method create\\(\\) of class Doctrine\\\\ORM\\\\EntityManager\\:
-				Use \\{@see DriverManager\\:\\:getConnection\\(\\)\\} to bootstrap the connection and call the constructor\\.$#
-			"""
-			count: 1
-			path: example/test/Unit/AbstractTestCase.php
-
-		-
 			message: "#^Instanceof between Ergebnis\\\\FactoryBot\\\\FieldDefinition\\\\Resolvable and Ergebnis\\\\FactoryBot\\\\FieldDefinition\\\\Resolvable will always evaluate to true\\.$#"
 			count: 1
 			path: src/EntityDefinition.php
@@ -550,12 +542,4 @@ parameters:
 			message: "#^Parameter \\#1 \\$className of method Ergebnis\\\\FactoryBot\\\\FixtureFactory\\:\\:define\\(\\) expects class\\-string\\<NotAClass\\>, string given\\.$#"
 			count: 1
 			path: test/Unit/FixtureFactoryTest.php
-
-		-
-			message: """
-				#^Call to deprecated method create\\(\\) of class Doctrine\\\\ORM\\\\EntityManager\\:
-				Use \\{@see DriverManager\\:\\:getConnection\\(\\)\\} to bootstrap the connection and call the constructor\\.$#
-			"""
-			count: 1
-			path: test/Util/Doctrine/ORM/EntityManagerFactory.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -75,17 +75,6 @@
       <code>ProjectDefinitionProvider</code>
     </UnusedClass>
   </file>
-  <file src="example/test/Unit/AbstractTestCase.php">
-    <DeprecatedMethod>
-      <code><![CDATA[ORM\EntityManager::create(
-            [
-                'driver' => 'pdo_sqlite',
-                'path' => ':memory:',
-            ],
-            $configuration,
-        )]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="example/test/Unit/Entity/UserTest.php">
     <UnnecessaryVarAnnotation>
       <code>Entity\User</code>
@@ -443,16 +432,5 @@
       <code>$resolved</code>
       <code>$resolved</code>
     </MixedAssignment>
-  </file>
-  <file src="test/Util/Doctrine/ORM/EntityManagerFactory.php">
-    <DeprecatedMethod>
-      <code><![CDATA[ORM\EntityManager::create(
-            [
-                'driver' => 'pdo_sqlite',
-                'path' => ':memory:',
-            ],
-            $configuration,
-        )]]></code>
-    </DeprecatedMethod>
   </file>
 </files>

--- a/test/Util/Doctrine/ORM/EntityManagerFactory.php
+++ b/test/Util/Doctrine/ORM/EntityManagerFactory.php
@@ -13,23 +13,26 @@ declare(strict_types=1);
 
 namespace Ergebnis\FactoryBot\Test\Util\Doctrine\ORM;
 
+use Doctrine\DBAL;
 use Doctrine\ORM;
 
 final class EntityManagerFactory
 {
     public static function create(): ORM\EntityManagerInterface
     {
+        $connection = DBAL\DriverManager::getConnection([
+            'driver' => 'pdo_sqlite',
+            'path' => ':memory:',
+        ]);
+
         $configuration = ORM\ORMSetup::createConfiguration(true);
 
         $configuration->setMetadataDriverImpl(new ORM\Mapping\Driver\AttributeDriver([
             __DIR__ . '/../../../../example/src/Entity',
         ]));
 
-        return ORM\EntityManager::create(
-            [
-                'driver' => 'pdo_sqlite',
-                'path' => ':memory:',
-            ],
+        return new ORM\EntityManager(
+            $connection,
             $configuration,
         );
     }


### PR DESCRIPTION
This pull request

- [x] stops using the deprecated `Doctrine\ORM\EntityManager::create()`

Blocks #1293.