### PR TITLE
Fix: Require `doctrine/orm:^2.14.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ For a full diff see [`1.6.0...main`][1.6.0...main].
 
 ### Changed
 
-- Required `doctrine/orm:^2.12.0` ([#1296]), by [@localheinz]
+- Required `doctrine/orm:^2.14.0` ([#1298]), by [@localheinz]
 
 ## [`1.6.0`][1.6.0]
 
@@ -359,7 +359,7 @@ For a full diff see [`fa9c564...0.1.0`][fa9c564...0.1.0].
 [#1213]: https://github.com/ergebnis/factory-bot/pull/1213
 [#1233]: https://github.com/ergebnis/factory-bot/pull/1233
 [#1234]: https://github.com/ergebnis/factory-bot/pull/1234
-[#1296]: https://github.com/ergebnis/factory-bot/pull/1296
+[#1298]: https://github.com/ergebnis/factory-bot/pull/1298
 
 [@abenerd]: https://github.com/abenerd
 [@localheinz]: https://github.com/localheinz

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
     "doctrine/collections": "^1.6.5 || ^2.0.0",
     "doctrine/dbal": "^2.12.0 || ^3.0.0",
-    "doctrine/orm": "^2.12.0",
+    "doctrine/orm": "^2.14.0",
     "doctrine/persistence": "^2.1.0 || ^3.0.0",
     "ergebnis/classy": "^1.6.0",
     "fakerphp/faker": "^1.20.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9cd2604b0ac69aec9d1c617acb07f4ca",
+    "content-hash": "1d005d9482abe8ef9293f9686bd2cb49",
     "packages": [
         {
             "name": "doctrine/cache",


### PR DESCRIPTION
This pull request

- [x] requires `doctrine/orm:^2.14.0`

Blocks #1295.
Related to #1297.