### PR TITLE
Enhancement: Require and use `ergebnis/data-provider`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
   "require-dev": {
     "ext-pdo_sqlite": "*",
     "ergebnis/composer-normalize": "^2.42.0",
+    "ergebnis/data-provider": "^3.2.0",
     "ergebnis/license": "^2.4.0",
     "ergebnis/php-cs-fixer-config": "^6.26.0",
     "ergebnis/phpstan-rules": "^2.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "411955d38d5fc27b4a5a10c799ff1e5a",
+    "content-hash": "f3835fd25269acf98af49d60b3447c9f",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -3255,6 +3255,69 @@
                 "source": "https://github.com/ergebnis/composer-normalize"
             },
             "time": "2024-01-30T11:54:02+00:00"
+        },
+        {
+            "name": "ergebnis/data-provider",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/data-provider.git",
+                "reference": "e2b0b79b833f5a5799f2ee52ebc8e08e8d52f9eb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/data-provider/zipball/e2b0b79b833f5a5799f2ee52ebc8e08e8d52f9eb",
+                "reference": "e2b0b79b833f5a5799f2ee52ebc8e08e8d52f9eb",
+                "shasum": ""
+            },
+            "require": {
+                "fakerphp/faker": "^1.21.0",
+                "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.28.3",
+                "ergebnis/license": "^2.4.0",
+                "ergebnis/php-cs-fixer-config": "^6.13.0",
+                "infection/infection": "~0.26.6",
+                "phpunit/phpunit": "^9.6.13",
+                "psalm/plugin-phpunit": "~0.18.4",
+                "rector/rector": "~0.18.11",
+                "vimeo/psalm": "^5.16.0"
+            },
+            "type": "library",
+            "extra": {
+                "composer-normalize": {
+                    "indent-size": 2,
+                    "indent-style": "space"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\DataProvider\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com",
+                    "homepage": "https://localheinz.com"
+                }
+            ],
+            "description": "Provides generic data providers for use with phpunit/phpunit.",
+            "homepage": "https://github.com/ergebnis/data-provider",
+            "keywords": [
+                "data-provider",
+                "phpunit"
+            ],
+            "support": {
+                "issues": "https://github.com/ergebnis/data-provider/issues",
+                "source": "https://github.com/ergebnis/data-provider"
+            },
+            "time": "2023-11-30T17:30:28+00:00"
         },
         {
             "name": "ergebnis/json",


### PR DESCRIPTION
This pull request

- [x] requires `ergebnis/data-provider`
- [ ] uses data providers provided by `ergebnis/data-provider`