### PR TITLE
Fix: Rename `ResolutionStrategy` to `CountResolutionStrategy`

### DIFF
--- a/src/FieldResolution/CountResolutionStrategy.php
+++ b/src/FieldResolution/CountResolutionStrategy.php
@@ -19,7 +19,7 @@ use Faker\Generator;
 /**
  * @internal
  */
-interface ResolutionStrategy
+interface CountResolutionStrategy
 {
     public function resolveCount(
         Generator $faker,

--- a/src/FieldResolution/DefaultStrategy.php
+++ b/src/FieldResolution/DefaultStrategy.php
@@ -21,7 +21,7 @@ use Faker\Generator;
 /**
  * @internal
  */
-final class DefaultStrategy implements FieldValueResolutionStrategy, ResolutionStrategy
+final class DefaultStrategy implements CountResolutionStrategy, FieldValueResolutionStrategy
 {
     public function resolveFieldValue(
         Generator $faker,

--- a/src/FieldResolution/WithOptionalStrategy.php
+++ b/src/FieldResolution/WithOptionalStrategy.php
@@ -21,7 +21,7 @@ use Faker\Generator;
 /**
  * @internal
  */
-final class WithOptionalStrategy implements FieldValueResolutionStrategy, ResolutionStrategy
+final class WithOptionalStrategy implements CountResolutionStrategy, FieldValueResolutionStrategy
 {
     public function resolveFieldValue(
         Generator $faker,

--- a/src/FieldResolution/WithoutOptionalStrategy.php
+++ b/src/FieldResolution/WithoutOptionalStrategy.php
@@ -21,7 +21,7 @@ use Faker\Generator;
 /**
  * @internal
  */
-final class WithoutOptionalStrategy implements FieldValueResolutionStrategy, ResolutionStrategy
+final class WithoutOptionalStrategy implements CountResolutionStrategy, FieldValueResolutionStrategy
 {
     public function resolveFieldValue(
         Generator $faker,

--- a/src/FixtureFactory.php
+++ b/src/FixtureFactory.php
@@ -21,7 +21,7 @@ use Faker\Generator;
 final class FixtureFactory
 {
     private FieldResolution\FieldValueResolutionStrategy $fieldValueResolutionStrategy;
-    private FieldResolution\ResolutionStrategy $resolutionStrategy;
+    private FieldResolution\CountResolutionStrategy $countResolutionStrategy;
     private bool $persistAfterCreate = false;
 
     /**
@@ -34,7 +34,7 @@ final class FixtureFactory
         private Generator $faker,
     ) {
         $this->fieldValueResolutionStrategy = new FieldResolution\DefaultStrategy();
-        $this->resolutionStrategy = new FieldResolution\DefaultStrategy();
+        $this->countResolutionStrategy = new FieldResolution\DefaultStrategy();
     }
 
     /**
@@ -298,7 +298,7 @@ final class FixtureFactory
         Count $count,
         array $fieldDefinitionOverrides = [],
     ): array {
-        $resolved = $this->resolutionStrategy->resolveCount(
+        $resolved = $this->countResolutionStrategy->resolveCount(
             $this->faker,
             $count,
         );
@@ -328,7 +328,7 @@ final class FixtureFactory
         $instance = clone $this;
 
         $instance->fieldValueResolutionStrategy = new FieldResolution\WithOptionalStrategy();
-        $instance->resolutionStrategy = new FieldResolution\WithOptionalStrategy();
+        $instance->countResolutionStrategy = new FieldResolution\WithOptionalStrategy();
 
         return $instance;
     }
@@ -346,7 +346,7 @@ final class FixtureFactory
         $instance = clone $this;
 
         $instance->fieldValueResolutionStrategy = new FieldResolution\WithoutOptionalStrategy();
-        $instance->resolutionStrategy = new FieldResolution\WithoutOptionalStrategy();
+        $instance->countResolutionStrategy = new FieldResolution\WithoutOptionalStrategy();
 
         return $instance;
     }


### PR DESCRIPTION
This pull request

- [x] renames `ResolutionStrategy` to `CountResolutionStrategy`