### PR TITLE
Fix: Move zizmor artipacked ignore for `renew.yaml` into configuration

### DIFF
--- a/.github/workflows/renew.yaml
+++ b/.github/workflows/renew.yaml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10" # v6.0.2 # zizmor: ignore[artipacked]
+        uses: "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10" # v6.0.2
         with:
           token: "${{ secrets.ERGEBNIS_BOT_TOKEN }}"
 

--- a/.github/zizmor.yaml
+++ b/.github/zizmor.yaml
@@ -1,0 +1,4 @@
+rules:
+  artipacked:
+    ignore:
+      - "renew.yaml"


### PR DESCRIPTION
This pull request

- [x] moves zizmor `artipacked` ignore for `renew.yaml` into configuration

Follows ergebnis/php-package-template#1841.